### PR TITLE
addpatch: firefox, ver=129.0.2-1

### DIFF
--- a/firefox/0010-Fix-libyuv-build-with-LSX-LASX.patch
+++ b/firefox/0010-Fix-libyuv-build-with-LSX-LASX.patch
@@ -1,0 +1,400 @@
+From 9e991746b5dc9310be05996dd73455c5debc9fce Mon Sep 17 00:00:00 2001
+From: WANG Xuerui <xen0n@gentoo.org>
+Date: Sun, 31 Dec 2023 13:16:33 +0800
+Subject: [PATCH 04/12] Fix libyuv build with LSX & LASX
+
+This is not of upstream quality, and will not be upstreamed as-is.
+This is only meant as a quick-and-dirty build fix for LoongArch early
+adopters.
+
+Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
+---
+ media/libyuv/libyuv/BUILD.gn           | 37 +++++++++++++++++++++
+ media/libyuv/libyuv/libyuv.gni         |  2 ++
+ media/libyuv/libyuv/libyuv.gypi        |  5 +++
+ media/libyuv/libyuv/source/row_lasx.cc | 46 ++++++++++++++++----------
+ media/libyuv/libyuv/source/row_lsx.cc  | 30 +++++++++++------
+ 5 files changed, 92 insertions(+), 28 deletions(-)
+
+diff --git a/media/libyuv/libyuv/BUILD.gn b/media/libyuv/libyuv/BUILD.gn
+index a72ff06558..7d70848be9 100644
+--- a/media/libyuv/libyuv/BUILD.gn
++++ b/media/libyuv/libyuv/BUILD.gn
+@@ -69,6 +69,14 @@ group("libyuv") {
+     deps += [ ":libyuv_msa" ]
+   }
+ 
++  if (libyuv_use_lsx) {
++    deps += [ ":libyuv_lsx" ]
++  }
++
++  if (libyuv_use_lasx) {
++    deps += [ ":libyuv_lasx" ]
++  }
++
+   if (!is_ios && !libyuv_disable_jpeg) {
+     # Make sure that clients of libyuv link with libjpeg. This can't go in
+     # libyuv_internal because in Windows x64 builds that will generate a clang
+@@ -90,6 +98,7 @@ static_library("libyuv_internal") {
+     "include/libyuv/convert_from.h",
+     "include/libyuv/convert_from_argb.h",
+     "include/libyuv/cpu_id.h",
++    "include/libyuv/loongson_intrinsics.h",
+     "include/libyuv/mjpeg_decoder.h",
+     "include/libyuv/planar_functions.h",
+     "include/libyuv/rotate.h",
+@@ -229,6 +238,34 @@ if (libyuv_use_msa) {
+   }
+ }
+ 
++if (libyuv_use_lsx) {
++  static_library("libyuv_lsx") {
++    sources = [
++      # LSX Source Files
++      "source/rotate_lsx.cc",
++      "source/row_lsx.cc",
++      "source/scale_lsx.cc",
++    ]
++
++    deps = [ ":libyuv_internal" ]
++
++    public_configs = [ ":libyuv_config" ]
++  }
++}
++
++if (libyuv_use_lasx) {
++  static_library("libyuv_lasx") {
++    sources = [
++      # LASX Source Files
++      "source/row_lasx.cc",
++    ]
++
++    deps = [ ":libyuv_internal" ]
++
++    public_configs = [ ":libyuv_config" ]
++  }
++}
++
+ if (libyuv_include_tests) {
+   config("libyuv_unittest_warnings_config") {
+     if (!is_win) {
+diff --git a/media/libyuv/libyuv/libyuv.gni b/media/libyuv/libyuv/libyuv.gni
+index 852f08ca9d..8e5bd40e4e 100644
+--- a/media/libyuv/libyuv/libyuv.gni
++++ b/media/libyuv/libyuv/libyuv.gni
+@@ -20,4 +20,6 @@ declare_args() {
+       (current_cpu == "mips64el" || current_cpu == "mipsel") && mips_use_msa
+   libyuv_use_mmi =
+       (current_cpu == "mips64el" || current_cpu == "mipsel") && mips_use_mmi
++  libyuv_use_lsx = current_cpu == "loong64"
++  libyuv_use_lasx = current_cpu == "loong64"
+ }
+diff --git a/media/libyuv/libyuv/libyuv.gypi b/media/libyuv/libyuv/libyuv.gypi
+index 48936aa7b0..9c19abf9c3 100644
+--- a/media/libyuv/libyuv/libyuv.gypi
++++ b/media/libyuv/libyuv/libyuv.gypi
+@@ -18,6 +18,7 @@
+       'include/libyuv/convert_from.h',
+       'include/libyuv/convert_from_argb.h',
+       'include/libyuv/cpu_id.h',
++      'include/libyuv/loongson_intrinsics.h',
+       'include/libyuv/macros_msa.h',
+       'include/libyuv/mjpeg_decoder.h',
+       'include/libyuv/planar_functions.h',
+@@ -57,6 +58,7 @@
+       'source/rotate_argb.cc',
+       'source/rotate_common.cc',
+       'source/rotate_gcc.cc',
++      'source/rotate_lsx.cc',
+       'source/rotate_msa.cc',
+       'source/rotate_neon.cc',
+       'source/rotate_neon64.cc',
+@@ -64,6 +66,8 @@
+       'source/row_any.cc',
+       'source/row_common.cc',
+       'source/row_gcc.cc',
++      'source/row_lasx.cc',
++      'source/row_lsx.cc',
+       'source/row_msa.cc',
+       'source/row_neon.cc',
+       'source/row_neon64.cc',
+@@ -73,6 +77,7 @@
+       'source/scale_argb.cc',
+       'source/scale_common.cc',
+       'source/scale_gcc.cc',
++      'source/scale_lsx.cc',
+       'source/scale_msa.cc',
+       'source/scale_neon.cc',
+       'source/scale_neon64.cc',
+diff --git a/media/libyuv/libyuv/source/row_lasx.cc b/media/libyuv/libyuv/source/row_lasx.cc
+index 29ac9254d9..8c325483b1 100644
+--- a/media/libyuv/libyuv/source/row_lasx.cc
++++ b/media/libyuv/libyuv/source/row_lasx.cc
+@@ -543,8 +543,8 @@ void I422ToARGB4444Row_LASX(const uint8_t* src_y,
+   __m256i vec_yb, vec_yg, vec_ub, vec_vr, vec_ug, vec_vg;
+   __m256i vec_ubvr, vec_ugvg;
+   __m256i const_0x80 = __lasx_xvldi(0x80);
+-  __m256i alpha = {0xF000F000F000F000, 0xF000F000F000F000, 0xF000F000F000F000,
+-                   0xF000F000F000F000};
++  __m256i alpha = {static_cast<long long>(0xF000F000F000F000), static_cast<long long>(0xF000F000F000F000), static_cast<long long>(0xF000F000F000F000),
++                   static_cast<long long>(0xF000F000F000F000)};
+   __m256i mask = {0x00F000F000F000F0, 0x00F000F000F000F0, 0x00F000F000F000F0,
+                   0x00F000F000F000F0};
+ 
+@@ -595,8 +595,8 @@ void I422ToARGB1555Row_LASX(const uint8_t* src_y,
+   __m256i vec_yb, vec_yg, vec_ub, vec_vr, vec_ug, vec_vg;
+   __m256i vec_ubvr, vec_ugvg;
+   __m256i const_0x80 = __lasx_xvldi(0x80);
+-  __m256i alpha = {0x8000800080008000, 0x8000800080008000, 0x8000800080008000,
+-                   0x8000800080008000};
++  __m256i alpha = {static_cast<long long>(0x8000800080008000), static_cast<long long>(0x8000800080008000), static_cast<long long>(0x8000800080008000),
++                   static_cast<long long>(0x8000800080008000)};
+ 
+   YUVTORGB_SETUP(yuvconstants, vec_ub, vec_vr, vec_ug, vec_vg, vec_yg, vec_yb);
+   vec_ubvr = __lasx_xvilvl_h(vec_ub, vec_vr);
+@@ -799,8 +799,8 @@ void ARGBToUVRow_LASX(const uint8_t* src_argb0,
+                         0x0009000900090009, 0x0009000900090009};
+   __m256i control = {0x0000000400000000, 0x0000000500000001, 0x0000000600000002,
+                      0x0000000700000003};
+-  __m256i const_0x8080 = {0x8080808080808080, 0x8080808080808080,
+-                          0x8080808080808080, 0x8080808080808080};
++  __m256i const_0x8080 = {static_cast<long long>(0x8080808080808080), static_cast<long long>(0x8080808080808080),
++                          static_cast<long long>(0x8080808080808080), static_cast<long long>(0x8080808080808080)};
+ 
+   for (x = 0; x < len; x++) {
+     DUP4_ARG2(__lasx_xvld, src_argb0, 0, src_argb0, 32, src_argb0, 64,
+@@ -1037,8 +1037,8 @@ void ARGBToUV444Row_LASX(const uint8_t* src_argb,
+   __m256i const_38 = __lasx_xvldi(38);
+   __m256i const_94 = __lasx_xvldi(94);
+   __m256i const_18 = __lasx_xvldi(18);
+-  __m256i const_0x8080 = {0x8080808080808080, 0x8080808080808080,
+-                          0x8080808080808080, 0x8080808080808080};
++  __m256i const_0x8080 = {static_cast<long long>(0x8080808080808080), static_cast<long long>(0x8080808080808080),
++                          static_cast<long long>(0x8080808080808080), static_cast<long long>(0x8080808080808080)};
+   __m256i control = {0x0000000400000000, 0x0000000500000001, 0x0000000600000002,
+                      0x0000000700000003};
+   for (x = 0; x < len; x++) {
+@@ -1609,8 +1609,8 @@ void ARGB1555ToUVRow_LASX(const uint8_t* src_argb1555,
+   __m256i const_38 = __lasx_xvldi(0x413);
+   __m256i const_94 = __lasx_xvldi(0x42F);
+   __m256i const_18 = __lasx_xvldi(0x409);
+-  __m256i const_8080 = {0x8080808080808080, 0x8080808080808080,
+-                        0x8080808080808080, 0x8080808080808080};
++  __m256i const_8080 = {static_cast<long long>(0x8080808080808080), static_cast<long long>(0x8080808080808080),
++                        static_cast<long long>(0x8080808080808080), static_cast<long long>(0x8080808080808080)};
+ 
+   for (x = 0; x < len; x++) {
+     DUP4_ARG2(__lasx_xvld, src_argb1555, 0, src_argb1555, 32, next_argb1555, 0,
+@@ -1726,8 +1726,8 @@ void RGB565ToUVRow_LASX(const uint8_t* src_rgb565,
+   __m256i const_38 = __lasx_xvldi(0x413);
+   __m256i const_94 = __lasx_xvldi(0x42F);
+   __m256i const_18 = __lasx_xvldi(0x409);
+-  __m256i const_8080 = {0x8080808080808080, 0x8080808080808080,
+-                        0x8080808080808080, 0x8080808080808080};
++  __m256i const_8080 = {static_cast<long long>(0x8080808080808080), static_cast<long long>(0x8080808080808080),
++                        static_cast<long long>(0x8080808080808080), static_cast<long long>(0x8080808080808080)};
+ 
+   for (x = 0; x < len; x++) {
+     DUP4_ARG2(__lasx_xvld, src_rgb565, 0, src_rgb565, 32, next_rgb565, 0,
+@@ -1793,8 +1793,8 @@ void RGB24ToUVRow_LASX(const uint8_t* src_rgb24,
+   __m256i const_38 = __lasx_xvldi(0x413);
+   __m256i const_94 = __lasx_xvldi(0x42F);
+   __m256i const_18 = __lasx_xvldi(0x409);
+-  __m256i const_8080 = {0x8080808080808080, 0x8080808080808080,
+-                        0x8080808080808080, 0x8080808080808080};
++  __m256i const_8080 = {static_cast<long long>(0x8080808080808080), static_cast<long long>(0x8080808080808080),
++                        static_cast<long long>(0x8080808080808080), static_cast<long long>(0x8080808080808080)};
+   __m256i shuff0_b = {0x15120F0C09060300, 0x00000000001E1B18,
+                       0x15120F0C09060300, 0x00000000001E1B18};
+   __m256i shuff1_b = {0x0706050403020100, 0x1D1A1714110A0908,
+@@ -1856,8 +1856,8 @@ void RAWToUVRow_LASX(const uint8_t* src_raw,
+   __m256i const_38 = __lasx_xvldi(0x413);
+   __m256i const_94 = __lasx_xvldi(0x42F);
+   __m256i const_18 = __lasx_xvldi(0x409);
+-  __m256i const_8080 = {0x8080808080808080, 0x8080808080808080,
+-                        0x8080808080808080, 0x8080808080808080};
++  __m256i const_8080 = {static_cast<long long>(0x8080808080808080), static_cast<long long>(0x8080808080808080),
++                        static_cast<long long>(0x8080808080808080), static_cast<long long>(0x8080808080808080)};
+   __m256i shuff0_r = {0x15120F0C09060300, 0x00000000001E1B18,
+                       0x15120F0C09060300, 0x00000000001E1B18};
+   __m256i shuff1_r = {0x0706050403020100, 0x1D1A1714110A0908,
+@@ -2000,11 +2000,13 @@ void NV21ToARGBRow_LASX(const uint8_t* src_y,
+   }
+ }
+ 
++#ifndef RgbConstants
+ struct RgbConstants {
+   uint8_t kRGBToY[4];
+   uint16_t kAddY;
+   uint16_t pad;
+ };
++#define RgbConstants RgbConstants
+ 
+ // RGB to JPeg coefficients
+ // B * 0.1140 coefficient = 29
+@@ -2030,6 +2032,7 @@ static const struct RgbConstants kRgb24I601Constants = {{25, 129, 66, 0},
+ static const struct RgbConstants kRawI601Constants = {{66, 129, 25, 0},
+                                                       0x1080,
+                                                       0};
++#endif  // RgbConstaints
+ 
+ // ARGB expects first 3 values to contain RGB and 4th value is ignored.
+ static void ARGBToYMatrixRow_LASX(const uint8_t* src_argb,
+@@ -2242,8 +2245,8 @@ void ARGBToUVJRow_LASX(const uint8_t* src_argb,
+   __m256i const_21 = __lasx_xvldi(0x415);
+   __m256i const_53 = __lasx_xvldi(0x435);
+   __m256i const_10 = __lasx_xvldi(0x40A);
+-  __m256i const_8080 = {0x8080808080808080, 0x8080808080808080,
+-                        0x8080808080808080, 0x8080808080808080};
++  __m256i const_8080 = {static_cast<long long>(0x8080808080808080), static_cast<long long>(0x8080808080808080),
++                        static_cast<long long>(0x8080808080808080), static_cast<long long>(0x8080808080808080)};
+   __m256i shuff = {0x1614060412100200, 0x1E1C0E0C1A180A08, 0x1715070513110301,
+                    0x1F1D0F0D1B190B09};
+ 
+@@ -2296,6 +2299,13 @@ void ARGBToUVJRow_LASX(const uint8_t* src_argb,
+   }
+ }
+ 
++// undef for unified sources build
++#undef YUVTORGB_SETUP
++#undef YUVTORGB
++#undef I444TORGB
++#undef STOREARGB
++#undef RGBTOUV
++
+ #ifdef __cplusplus
+ }  // extern "C"
+ }  // namespace libyuv
+diff --git a/media/libyuv/libyuv/source/row_lsx.cc b/media/libyuv/libyuv/source/row_lsx.cc
+index 9c1e16f22e..91221ff03c 100644
+--- a/media/libyuv/libyuv/source/row_lsx.cc
++++ b/media/libyuv/libyuv/source/row_lsx.cc
+@@ -407,7 +407,7 @@ void ARGB1555ToUVRow_LSX(const uint8_t* src_argb1555,
+   __m128i const_38 = __lsx_vldi(0x413);
+   __m128i const_94 = __lsx_vldi(0x42F);
+   __m128i const_18 = __lsx_vldi(0x409);
+-  __m128i const_8080 = {0x8080808080808080, 0x8080808080808080};
++  __m128i const_8080 = {static_cast<long long>(0x8080808080808080), static_cast<long long>(0x8080808080808080)};
+ 
+   for (x = 0; x < len; x++) {
+     DUP4_ARG2(__lsx_vld, src_argb1555, 0, src_argb1555, 16, next_argb1555, 0,
+@@ -516,7 +516,7 @@ void RGB565ToUVRow_LSX(const uint8_t* src_rgb565,
+   __m128i const_38 = __lsx_vldi(0x413);
+   __m128i const_94 = __lsx_vldi(0x42F);
+   __m128i const_18 = __lsx_vldi(0x409);
+-  __m128i const_8080 = {0x8080808080808080, 0x8080808080808080};
++  __m128i const_8080 = {static_cast<long long>(0x8080808080808080), static_cast<long long>(0x8080808080808080)};
+ 
+   for (x = 0; x < len; x++) {
+     DUP4_ARG2(__lsx_vld, src_rgb565, 0, src_rgb565, 16, next_rgb565, 0,
+@@ -577,7 +577,7 @@ void RGB24ToUVRow_LSX(const uint8_t* src_rgb24,
+   __m128i const_38 = __lsx_vldi(0x413);
+   __m128i const_94 = __lsx_vldi(0x42F);
+   __m128i const_18 = __lsx_vldi(0x409);
+-  __m128i const_8080 = {0x8080808080808080, 0x8080808080808080};
++  __m128i const_8080 = {static_cast<long long>(0x8080808080808080), static_cast<long long>(0x8080808080808080)};
+   __m128i shuff0_b = {0x15120F0C09060300, 0x00000000001E1B18};
+   __m128i shuff1_b = {0x0706050403020100, 0x1D1A1714110A0908};
+   __m128i shuff0_g = {0x1613100D0A070401, 0x00000000001F1C19};
+@@ -630,7 +630,7 @@ void RAWToUVRow_LSX(const uint8_t* src_raw,
+   __m128i const_38 = __lsx_vldi(0x413);
+   __m128i const_94 = __lsx_vldi(0x42F);
+   __m128i const_18 = __lsx_vldi(0x409);
+-  __m128i const_8080 = {0x8080808080808080, 0x8080808080808080};
++  __m128i const_8080 = {static_cast<long long>(0x8080808080808080), static_cast<long long>(0x8080808080808080)};
+   __m128i shuff0_r = {0x15120F0C09060300, 0x00000000001E1B18};
+   __m128i shuff1_r = {0x0706050403020100, 0x1D1A1714110A0908};
+   __m128i shuff0_g = {0x1613100D0A070401, 0x00000000001F1C19};
+@@ -865,7 +865,7 @@ void BGRAToUVRow_LSX(const uint8_t* src_bgra,
+   __m128i const_38 = __lsx_vldi(0x413);
+   __m128i const_94 = __lsx_vldi(0x42F);
+   __m128i const_18 = __lsx_vldi(0x409);
+-  __m128i const_8080 = {0x8080808080808080, 0x8080808080808080};
++  __m128i const_8080 = {static_cast<long long>(0x8080808080808080), static_cast<long long>(0x8080808080808080)};
+ 
+   for (x = 0; x < len; x++) {
+     DUP4_ARG2(__lsx_vld, src_bgra, 0, src_bgra, 16, src_bgra, 32, src_bgra, 48,
+@@ -913,7 +913,7 @@ void ABGRToUVRow_LSX(const uint8_t* src_abgr,
+   __m128i const_38 = __lsx_vldi(0x413);
+   __m128i const_94 = __lsx_vldi(0x42F);
+   __m128i const_18 = __lsx_vldi(0x409);
+-  __m128i const_8080 = {0x8080808080808080, 0x8080808080808080};
++  __m128i const_8080 = {static_cast<long long>(0x8080808080808080), static_cast<long long>(0x8080808080808080)};
+ 
+   for (x = 0; x < len; x++) {
+     DUP4_ARG2(__lsx_vld, src_abgr, 0, src_abgr, 16, src_abgr, 32, src_abgr, 48,
+@@ -961,7 +961,7 @@ void RGBAToUVRow_LSX(const uint8_t* src_rgba,
+   __m128i const_38 = __lsx_vldi(0x413);
+   __m128i const_94 = __lsx_vldi(0x42F);
+   __m128i const_18 = __lsx_vldi(0x409);
+-  __m128i const_8080 = {0x8080808080808080, 0x8080808080808080};
++  __m128i const_8080 = {static_cast<long long>(0x8080808080808080), static_cast<long long>(0x8080808080808080)};
+ 
+   for (x = 0; x < len; x++) {
+     DUP4_ARG2(__lsx_vld, src_rgba, 0, src_rgba, 16, src_rgba, 32, src_rgba, 48,
+@@ -1010,7 +1010,7 @@ void ARGBToUVJRow_LSX(const uint8_t* src_argb,
+   __m128i const_21 = __lsx_vldi(0x415);
+   __m128i const_53 = __lsx_vldi(0x435);
+   __m128i const_10 = __lsx_vldi(0x40A);
+-  __m128i const_8080 = {0x8080808080808080, 0x8080808080808080};
++  __m128i const_8080 = {static_cast<long long>(0x8080808080808080), static_cast<long long>(0x8080808080808080)};
+ 
+   for (x = 0; x < len; x++) {
+     DUP4_ARG2(__lsx_vld, src_argb, 0, src_argb, 16, src_argb, 32, src_argb, 48,
+@@ -1388,7 +1388,7 @@ void ARGBBlendRow_LSX(const uint8_t* src_argb,
+   __m128i const_256 = __lsx_vldi(0x500);
+   __m128i zero = __lsx_vldi(0);
+   __m128i alpha = __lsx_vldi(0xFF);
+-  __m128i control = {0xFF000000FF000000, 0xFF000000FF000000};
++  __m128i control = {static_cast<long long>(0xFF000000FF000000), static_cast<long long>(0xFF000000FF000000)};
+ 
+   for (x = 0; x < len; x++) {
+     DUP4_ARG2(__lsx_vld, src_argb, 0, src_argb, 16, src_argb1, 0, src_argb1, 16,
+@@ -1434,7 +1434,7 @@ void ARGBQuantizeRow_LSX(uint8_t* dst_argb,
+   __m128i vec_offset = __lsx_vreplgr2vr_b(interval_offset);
+   __m128i vec_scale = __lsx_vreplgr2vr_w(scale);
+   __m128i zero = __lsx_vldi(0);
+-  __m128i control = {0xFF000000FF000000, 0xFF000000FF000000};
++  __m128i control = {static_cast<long long>(0xFF000000FF000000), static_cast<long long>(0xFF000000FF000000)};
+ 
+   for (x = 0; x < len; x++) {
+     DUP4_ARG2(__lsx_vld, dst_argb, 0, dst_argb, 16, dst_argb, 32, dst_argb, 48,
+@@ -1643,11 +1643,13 @@ void HalfFloatRow_LSX(const uint16_t* src,
+   }
+ }
+ 
++#ifndef RgbConstants
+ struct RgbConstants {
+   uint8_t kRGBToY[4];
+   uint16_t kAddY;
+   uint16_t pad;
+ };
++#define RgbConstants RgbConstants
+ 
+ // RGB to JPeg coefficients
+ // B * 0.1140 coefficient = 29
+@@ -1673,6 +1675,7 @@ static const struct RgbConstants kRgb24I601Constants = {{25, 129, 66, 0},
+ static const struct RgbConstants kRawI601Constants = {{66, 129, 25, 0},
+                                                       0x1080,
+                                                       0};
++#endif  // RgbConstaints
+ 
+ // ARGB expects first 3 values to contain RGB and 4th value is ignored.
+ static void ARGBToYMatrixRow_LSX(const uint8_t* src_argb,
+@@ -1853,6 +1856,13 @@ void RAWToYRow_LSX(const uint8_t* src_raw, uint8_t* dst_y, int width) {
+   RGBToYMatrixRow_LSX(src_raw, dst_y, width, &kRawI601Constants);
+ }
+ 
++// undef for unified sources build
++#undef YUVTORGB_SETUP
++#undef YUVTORGB
++#undef I444TORGB
++#undef STOREARGB
++#undef RGBTOUV
++
+ #ifdef __cplusplus
+ }  // extern "C"
+ }  // namespace libyuv
+-- 
+2.46.0
+

--- a/firefox/0011-Add-missing-loongarch-lsx-code-for-libpng.patch
+++ b/firefox/0011-Add-missing-loongarch-lsx-code-for-libpng.patch
@@ -1,0 +1,554 @@
+From 52c3816b97e244ee2b4008b68bdb03bbb1e7685a Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Tue, 14 May 2024 16:36:09 -0700
+Subject: [PATCH 09/12] Add missing loongarch lsx code for libpng
+
+---
+ .../libpng/loongarch/filter_lsx_intrinsics.c  | 412 ++++++++++++++++++
+ media/libpng/loongarch/loongarch_lsx_init.c   |  65 +++
+ media/libpng/moz.build                        |   7 +
+ media/libpng/moz.yaml                         |   1 +
+ media/libpng/pnglibconf.h                     |   6 +
+ 5 files changed, 491 insertions(+)
+ create mode 100644 media/libpng/loongarch/filter_lsx_intrinsics.c
+ create mode 100644 media/libpng/loongarch/loongarch_lsx_init.c
+
+diff --git a/media/libpng/loongarch/filter_lsx_intrinsics.c b/media/libpng/loongarch/filter_lsx_intrinsics.c
+new file mode 100644
+index 0000000000..af6cc763a0
+--- /dev/null
++++ b/media/libpng/loongarch/filter_lsx_intrinsics.c
+@@ -0,0 +1,412 @@
++/* filter_lsx_intrinsics.c - LSX optimized filter functions
++ *
++ * Copyright (c) 2021 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Copyright (c) 2018 Cosmin Truta
++ * Copyright (c) 2016 Glenn Randers-Pehrson
++ * Contributed by Jin Bo (jinbo@loongson.cn)
++ *
++ * This code is released under the libpng license.
++ * For conditions of distribution and use, see the disclaimer
++ * and license in png.h
++ */
++
++#include "../pngpriv.h"
++
++#ifdef PNG_READ_SUPPORTED
++
++#if PNG_LOONGARCH_LSX_IMPLEMENTATION == 1 /* intrinsics code from pngpriv.h */
++
++#include <lsxintrin.h>
++
++#define LSX_LD(psrc) __lsx_vld((psrc), 0)
++
++#define LSX_LD_2(psrc, stride, out0, out1) \
++{                                          \
++   out0 = LSX_LD(psrc);                    \
++   out1 = LSX_LD(psrc + stride);           \
++}
++
++#define LSX_LD_4(psrc, stride, out0, out1, out2, out3) \
++{                                                      \
++   LSX_LD_2(psrc, stride, out0, out1);                 \
++   LSX_LD_2(psrc + stride * 2, stride, out2, out3);    \
++}
++
++#define LSX_ST(in, pdst) __lsx_vst(in, (pdst), 0)
++
++#define LSX_ST_2(in0, in1, pdst, stride) \
++{                                        \
++   LSX_ST(in0, pdst);                    \
++   LSX_ST(in1, pdst + stride);           \
++}
++
++#define LSX_ST_4(in0, in1, in2, in3, pdst, stride) \
++{                                                  \
++   LSX_ST_2(in0, in1, pdst, stride);               \
++   LSX_ST_2(in2, in3, pdst + stride * 2, stride);  \
++}
++
++#define LSX_ADD_B(in0, in1, out0) \
++{                                 \
++   out0 = __lsx_vadd_b(in0, in1); \
++}
++
++#define LSX_ADD_B_2(in0, in1, in2, in3, out0, out1) \
++{                                                   \
++   LSX_ADD_B(in0, in1, out0);                       \
++   LSX_ADD_B(in2, in3, out1);                       \
++}
++
++#define LSX_ADD_B_4(in0, in1, in2, in3, in4, in5,     \
++                    in6, in7, out0, out1, out2, out3) \
++{                                                     \
++   LSX_ADD_B_2(in0, in1, in2, in3, out0, out1);       \
++   LSX_ADD_B_2(in4, in5, in6, in7, out2, out3);       \
++}
++
++#define LSX_ABS_B_3(in0, in1, in2, out0, out1, out2) \
++{                                                    \
++   out0 = __lsx_vadda_h(in0, zero);                  \
++   out1 = __lsx_vadda_h(in1, zero);                  \
++   out2 = __lsx_vadda_h(in2, zero);                  \
++}
++
++#define LSX_ILVL_B(in_h, in_l, out0)  \
++{                                     \
++   out0 = __lsx_vilvl_b(in_h, in_l);  \
++}
++
++#define LSX_ILVL_B_2(in0_h, in0_l, in1_h, in1_l, out0, out1) \
++{                                                            \
++   LSX_ILVL_B(in0_h, in0_l, out0);                           \
++   LSX_ILVL_B(in1_h, in1_l, out1);                           \
++}
++
++#define LSX_HSUB_HU_BU_2(in0, in1, out0, out1) \
++{                                              \
++   out0 = __lsx_vhsubw_hu_bu(in0, in0);        \
++   out1 = __lsx_vhsubw_hu_bu(in1, in1);        \
++}
++
++#define LSX_CMP_PICK_SMALLER(in0, in1, in2, in3, in4, in5, out0) \
++{                                                                \
++   __m128i _cmph, _cmpb, _in0, _in3;                             \
++   _cmph = __lsx_vslt_h(in1, in0);                               \
++   _cmpb = __lsx_vpickev_b(_cmph, _cmph);                        \
++   _in0  = __lsx_vmin_bu(in0,in1);                               \
++   _in3  = __lsx_vbitsel_v(in3, in4, _cmpb);                     \
++   _cmph = __lsx_vslt_h(in2, _in0);                              \
++   _cmpb = __lsx_vpickev_b(_cmph, _cmph);                        \
++   _in3  = __lsx_vbitsel_v(_in3, in5, _cmpb);                    \
++   out0  = __lsx_vadd_b(out0, _in3);                             \
++}
++
++void png_read_filter_row_up_lsx(png_row_infop row_info, png_bytep row,
++                                png_const_bytep prev_row)
++{
++   size_t n = row_info->rowbytes;
++   png_bytep rp = row;
++   png_const_bytep pp = prev_row;
++   __m128i vec_0, vec_1, vec_2, vec_3;
++   __m128i vec_4, vec_5, vec_6, vec_7;
++
++   while (n >= 64)
++   {
++      LSX_LD_4(rp, 16, vec_0, vec_1, vec_2, vec_3);
++      LSX_LD_4(pp, 16, vec_4, vec_5, vec_6, vec_7);
++      pp += 64;
++      LSX_ADD_B_4(vec_0 ,vec_4, vec_1, vec_5, vec_2, vec_6,
++                  vec_3, vec_7, vec_0, vec_1, vec_2, vec_3);
++      LSX_ST_4(vec_0, vec_1, vec_2, vec_3, rp, 16);
++      rp += 64;
++      n -= 64;
++   }
++   if (n & 63)
++   {
++      if (n >= 32)
++      {
++         LSX_LD_2(rp, 16, vec_0, vec_1);
++         LSX_LD_2(pp, 16, vec_2, vec_3);
++         pp += 32;
++         LSX_ADD_B_2(vec_0, vec_2, vec_1, vec_3, vec_0, vec_1);
++         LSX_ST_2(vec_0, vec_1, rp, 16);
++         rp += 32;
++         n -= 32;
++      }
++      if (n & 31)
++      {
++         if (n >= 16)
++         {
++            vec_0 = LSX_LD(rp);
++            vec_1 = LSX_LD(pp);
++            pp += 16;
++            LSX_ADD_B(vec_0, vec_1, vec_0);
++            LSX_ST(vec_0, rp);
++            rp += 16;
++            n -= 16;
++         }
++         if (n >= 8)
++         {
++            vec_0 = __lsx_vldrepl_d(rp, 0);
++            vec_1 = __lsx_vldrepl_d(pp, 0);
++            vec_0 = __lsx_vadd_b(vec_0, vec_1);
++            __lsx_vstelm_d(vec_0, rp, 0, 0);
++            rp += 8;
++            pp += 8;
++            n -= 8;
++         }
++         while (n--)
++         {
++            *rp = *rp + *pp++;
++            rp++;
++         }
++      }
++   }
++}
++
++void png_read_filter_row_sub3_lsx(png_row_infop row_info, png_bytep row,
++                                  png_const_bytep prev_row)
++{
++   size_t n = row_info->rowbytes;
++   png_uint_32 tmp;
++   png_bytep nxt = row;
++   __m128i vec_0, vec_1;
++
++   PNG_UNUSED(prev_row);
++
++   vec_0 = __lsx_vldrepl_w(nxt, 0);
++   nxt += 3;
++   n -= 3;
++
++   while (n >= 3)
++   {
++      vec_1 = __lsx_vldrepl_w(nxt, 0);
++      vec_1 = __lsx_vadd_b(vec_1, vec_0);
++      __lsx_vstelm_h(vec_1, nxt, 0, 0);
++      vec_0 = vec_1;
++      nxt += 2;
++      __lsx_vstelm_b(vec_1, nxt, 0, 2);
++      nxt += 1;
++      n -= 3;
++   }
++
++   row = nxt - 3;
++   while (n--)
++   {
++      *nxt = *nxt + *row++;
++      nxt++;
++   }
++}
++
++void png_read_filter_row_sub4_lsx(png_row_infop row_info, png_bytep row,
++                                  png_const_bytep prev_row)
++{
++   size_t n = row_info->rowbytes;
++   __m128i vec_0, vec_1;
++
++   PNG_UNUSED(prev_row);
++
++   vec_0 = __lsx_vldrepl_w(row, 0);
++   row += 4;
++   n -= 4;
++
++   while (n >= 4)
++   {
++      vec_1 = __lsx_vldrepl_w(row, 0);
++      vec_1 = __lsx_vadd_b(vec_1, vec_0);
++      __lsx_vstelm_w(vec_1, row, 0, 0);
++      vec_0 = vec_1;
++      row += 4;
++      n -= 4;
++   }
++}
++
++void png_read_filter_row_avg3_lsx(png_row_infop row_info, png_bytep row,
++                                  png_const_bytep prev_row)
++{
++   size_t n = row_info->rowbytes;
++   png_bytep nxt = row;
++   png_const_bytep prev_nxt = prev_row;
++   __m128i vec_0, vec_1, vec_2;
++
++   vec_0 = __lsx_vldrepl_w(nxt, 0);
++   vec_1 = __lsx_vldrepl_w(prev_nxt, 0);
++   prev_nxt += 3;
++   vec_1 = __lsx_vsrli_b(vec_1, 1);
++   vec_1 = __lsx_vadd_b(vec_1, vec_0);
++   __lsx_vstelm_h(vec_1, nxt, 0, 0);
++   nxt += 2;
++   __lsx_vstelm_b(vec_1, nxt, 0, 2);
++   nxt += 1;
++   n -= 3;
++
++   while (n >= 3)
++   {
++      vec_2 = vec_1;
++      vec_0 = __lsx_vldrepl_w(nxt, 0);
++      vec_1 = __lsx_vldrepl_w(prev_nxt, 0);
++      prev_nxt += 3;
++
++      vec_1 = __lsx_vavg_bu(vec_1, vec_2);
++      vec_1 = __lsx_vadd_b(vec_1, vec_0);
++
++      __lsx_vstelm_h(vec_1, nxt, 0, 0);
++      nxt += 2;
++      __lsx_vstelm_b(vec_1, nxt, 0, 2);
++      nxt += 1;
++      n -= 3;
++   }
++
++   row = nxt - 3;
++   while (n--)
++   {
++      vec_2 = __lsx_vldrepl_b(row, 0);
++      row++;
++      vec_0 = __lsx_vldrepl_b(nxt, 0);
++      vec_1 = __lsx_vldrepl_b(prev_nxt, 0);
++      prev_nxt++;
++
++      vec_1 = __lsx_vavg_bu(vec_1, vec_2);
++      vec_1 = __lsx_vadd_b(vec_1, vec_0);
++
++      __lsx_vstelm_b(vec_1, nxt, 0, 0);
++      nxt++;
++   }
++}
++
++void png_read_filter_row_avg4_lsx(png_row_infop row_info, png_bytep row,
++                                  png_const_bytep prev_row)
++{
++   size_t n = row_info->rowbytes;
++   __m128i vec_0, vec_1, vec_2;
++
++   vec_0 = __lsx_vldrepl_w(row, 0);
++   vec_1 = __lsx_vldrepl_w(prev_row, 0);
++   prev_row += 4;
++   vec_1 = __lsx_vsrli_b(vec_1, 1);
++   vec_1 = __lsx_vadd_b(vec_1, vec_0);
++   __lsx_vstelm_w(vec_1, row, 0, 0);
++   row += 4;
++   n -= 4;
++
++   while (n >= 4)
++   {
++      vec_2 = vec_1;
++      vec_0 = __lsx_vldrepl_w(row, 0);
++      vec_1 = __lsx_vldrepl_w(prev_row, 0);
++      prev_row += 4;
++
++      vec_1 = __lsx_vavg_bu(vec_1, vec_2);
++      vec_1 = __lsx_vadd_b(vec_1, vec_0);
++
++      __lsx_vstelm_w(vec_1, row, 0, 0);
++      row += 4;
++      n -= 4;
++   }
++}
++
++void png_read_filter_row_paeth3_lsx(png_row_infop row_info,
++                                    png_bytep row,
++                                    png_const_bytep prev_row)
++{
++   size_t n = row_info->rowbytes;
++   png_bytep nxt = row;
++   png_const_bytep prev_nxt = prev_row;
++   __m128i vec_a, vec_b, vec_c, vec_d;
++   __m128i vec_pa, vec_pb, vec_pc;
++   __m128i zero = {0};
++
++   vec_a = __lsx_vldrepl_w(nxt, 0);
++   vec_b = __lsx_vldrepl_w(prev_nxt, 0);
++   prev_nxt += 3;
++   vec_d = __lsx_vadd_b(vec_a, vec_b);
++   __lsx_vstelm_h(vec_d, nxt, 0, 0);
++   nxt += 2;
++   __lsx_vstelm_b(vec_d, nxt, 0, 2);
++   nxt += 1;
++   n -= 3;
++
++   while (n >= 3)
++   {
++      vec_a = vec_d;
++      vec_c = vec_b;
++      vec_b = __lsx_vldrepl_w(prev_nxt, 0);
++      prev_nxt += 3;
++      vec_d = __lsx_vldrepl_w(nxt, 0);
++
++      LSX_ILVL_B_2(vec_b, vec_c, vec_a, vec_c, vec_pa, vec_pb);
++      LSX_HSUB_HU_BU_2(vec_pa, vec_pb, vec_pa, vec_pb);
++      vec_pc = __lsx_vadd_h(vec_pa, vec_pb);
++      LSX_ABS_B_3(vec_pa, vec_pb, vec_pc, vec_pa, vec_pb, vec_pc);
++      LSX_CMP_PICK_SMALLER(vec_pa, vec_pb, vec_pc, vec_a, vec_b, vec_c, vec_d);
++
++      __lsx_vstelm_h(vec_d, nxt, 0, 0);
++      nxt += 2;
++      __lsx_vstelm_b(vec_d, nxt, 0, 2);
++      nxt += 1;
++      n -= 3;
++   }
++
++   prev_row = prev_nxt - 3;
++   row = nxt - 3;
++   while (n--)
++   {
++      vec_a = __lsx_vldrepl_b(row, 0);
++      row++;
++      vec_b = __lsx_vldrepl_b(prev_nxt, 0);
++      prev_nxt++;
++      vec_c = __lsx_vldrepl_b(prev_row, 0);
++      prev_row++;
++      vec_d = __lsx_vldrepl_b(nxt, 0);
++
++      LSX_ILVL_B_2(vec_b, vec_c, vec_a, vec_c, vec_pa, vec_pb);
++      LSX_HSUB_HU_BU_2(vec_pa, vec_pb, vec_pa, vec_pb);
++      vec_pc = __lsx_vadd_h(vec_pa, vec_pb);
++      LSX_ABS_B_3(vec_pa, vec_pb, vec_pc, vec_pa, vec_pb, vec_pc);
++      LSX_CMP_PICK_SMALLER(vec_pa, vec_pb, vec_pc, vec_a, vec_b, vec_c, vec_d);
++
++      __lsx_vstelm_b(vec_d, nxt, 0, 0);
++      nxt++;
++   }
++}
++
++void png_read_filter_row_paeth4_lsx(png_row_infop row_info,
++                                    png_bytep row,
++                                    png_const_bytep prev_row)
++{
++   size_t n = row_info->rowbytes;
++   __m128i vec_a, vec_b, vec_c, vec_d;
++   __m128i vec_pa, vec_pb, vec_pc;
++   __m128i zero = {0};
++
++   vec_a = __lsx_vldrepl_w(row, 0);
++   vec_b = __lsx_vldrepl_w(prev_row, 0);
++   prev_row += 4;
++   vec_d = __lsx_vadd_b(vec_a, vec_b);
++   __lsx_vstelm_w(vec_d, row, 0, 0);
++   row += 4;
++   n -= 4;
++
++   while (n >= 4)
++   {
++      vec_a = vec_d;
++      vec_c = vec_b;
++      vec_b = __lsx_vldrepl_w(prev_row, 0);
++      prev_row += 4;
++      vec_d = __lsx_vldrepl_w(row, 0);
++
++      LSX_ILVL_B_2(vec_b, vec_c, vec_a, vec_c, vec_pa, vec_pb);
++      LSX_HSUB_HU_BU_2(vec_pa, vec_pb, vec_pa, vec_pb);
++      vec_pc = __lsx_vadd_h(vec_pa, vec_pb);
++      LSX_ABS_B_3(vec_pa, vec_pb, vec_pc, vec_pa, vec_pb, vec_pc);
++      LSX_CMP_PICK_SMALLER(vec_pa, vec_pb, vec_pc, vec_a, vec_b, vec_c, vec_d);
++
++      __lsx_vstelm_w(vec_d, row, 0, 0);
++      row += 4;
++      n -= 4;
++   }
++}
++
++#endif /* PNG_LOONGARCH_LSX_IMPLEMENTATION == 1 (intrinsics) */
++#endif /* PNG_READ_SUPPORTED */
+diff --git a/media/libpng/loongarch/loongarch_lsx_init.c b/media/libpng/loongarch/loongarch_lsx_init.c
+new file mode 100644
+index 0000000000..2c80fe81b6
+--- /dev/null
++++ b/media/libpng/loongarch/loongarch_lsx_init.c
+@@ -0,0 +1,65 @@
++/* loongarch_lsx_init.c - LSX optimized filter functions
++ *
++ * Copyright (c) 2021 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Jin Bo <jinbo@loongson.cn>
++ *
++ * This code is released under the libpng license.
++ * For conditions of distribution and use, see the disclaimer
++ * and license in png.h
++ */
++
++#include "../pngpriv.h"
++
++#ifdef PNG_READ_SUPPORTED
++#if PNG_LOONGARCH_LSX_IMPLEMENTATION == 1
++
++#include <sys/auxv.h>
++
++#define LA_HWCAP_LSX    (1<<4)
++static int png_has_lsx(void)
++{
++    int flags = 0;
++    int flag  = (int)getauxval(AT_HWCAP);
++
++    if (flag & LA_HWCAP_LSX)
++        return 1;
++
++    return 0;
++}
++
++void
++png_init_filter_functions_lsx(png_structp pp, unsigned int bpp)
++{
++   /* IMPORTANT: any new external functions used here must be declared using
++    * PNG_INTERNAL_FUNCTION in ../pngpriv.h.  This is required so that the
++    * 'prefix' option to configure works:
++    *
++    *    ./configure --with-libpng-prefix=foobar_
++    *
++    * Verify you have got this right by running the above command, doing a build
++    * and examining pngprefix.h; it must contain a #define for every external
++    * function you add.  (Notice that this happens automatically for the
++    * initialization function.)
++    */
++
++   if (png_has_lsx())
++   {
++      pp->read_filter[PNG_FILTER_VALUE_UP-1] = png_read_filter_row_up_lsx;
++      if (bpp == 3)
++      {
++         pp->read_filter[PNG_FILTER_VALUE_SUB-1] = png_read_filter_row_sub3_lsx;
++         pp->read_filter[PNG_FILTER_VALUE_AVG-1] = png_read_filter_row_avg3_lsx;
++         pp->read_filter[PNG_FILTER_VALUE_PAETH-1] = png_read_filter_row_paeth3_lsx;
++      }
++      else if (bpp == 4)
++      {
++         pp->read_filter[PNG_FILTER_VALUE_SUB-1] = png_read_filter_row_sub4_lsx;
++         pp->read_filter[PNG_FILTER_VALUE_AVG-1] = png_read_filter_row_avg4_lsx;
++         pp->read_filter[PNG_FILTER_VALUE_PAETH-1] = png_read_filter_row_paeth4_lsx;
++      }
++   }
++}
++
++#endif /* PNG_LOONGARCH_LSX_IMPLEMENTATION == 1 */
++#endif /* PNG_READ_SUPPORTED */
+diff --git a/media/libpng/moz.build b/media/libpng/moz.build
+index 663eb929fe..fc2218e100 100644
+--- a/media/libpng/moz.build
++++ b/media/libpng/moz.build
+@@ -65,6 +65,13 @@ if CONFIG['HAVE_ALTIVEC']:
+         'powerpc/powerpc_init.c'
+     ]
+ 
++if CONFIG['TARGET_CPU'] == 'loongarch64':
++    DEFINES['MOZ_PNG_USE_LOONGARCH_LSX'] = True
++    UNIFIED_SOURCES += [
++        'loongarch/filter_lsx_intrinsics.c',
++        'loongarch/loongarch_lsx_init.c'
++    ]
++
+ if CONFIG['MOZ_TREE_FREETYPE']:
+     DEFINES['FT_CONFIG_OPTION_USE_PNG'] = True
+ 
+diff --git a/media/libpng/moz.yaml b/media/libpng/moz.yaml
+index 4d193089ac..e3c63908cc 100644
+--- a/media/libpng/moz.yaml
++++ b/media/libpng/moz.yaml
+@@ -37,6 +37,7 @@ vendoring:
+     - arm
+     - contrib/arm-neon/linux.c
+     - intel
++    - loongarch
+     - mips
+     - powerpc
+     - ANNOUNCE
+diff --git a/media/libpng/pnglibconf.h b/media/libpng/pnglibconf.h
+index 1cbb828436..7d50038c28 100644
+--- a/media/libpng/pnglibconf.h
++++ b/media/libpng/pnglibconf.h
+@@ -75,6 +75,12 @@
+ #  define PNG_POWERPC_VSX_OPT 0 /* Do not use VSX optimization */
+ #endif
+ 
++#ifdef MOZ_PNG_USE_LOONGARCH_LSX
++#  undef PNG_LOONGARCH_LSX_OPT /* Let libpng decide */
++#else
++#  define PNG_LOONGARCH_LSX_OPT 0 /* Do not use LSX optimization */
++#endif
++
+ #define PNG_READ_SUPPORTED
+ #define PNG_PROGRESSIVE_READ_SUPPORTED
+ #define PNG_READ_APNG_SUPPORTED
+-- 
+2.46.0
+

--- a/firefox/0012-Add-support-for-LoongArch64.patch
+++ b/firefox/0012-Add-support-for-LoongArch64.patch
@@ -1,0 +1,45 @@
+From f3a27a4821bc2dffd9f65a668821eb5e99df9608 Mon Sep 17 00:00:00 2001
+From: Jiangjin Wang <kaymw@aosc.io>
+Date: Sun, 22 Oct 2023 22:13:17 -0700
+Subject: [PATCH 01/12] Add support for LoongArch64
+
+Adapted from LoongArchLinux. Rebased to Firefox 122.0.0.
+
+Co-Authored-By: loongson <loongson@loongson.cn>
+Co-Authored-By: WANG Xuerui <xen0n@gentoo.org>
+Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
+---
+ third_party/libwebrtc/build/build_config.h             | 4 ++++
+ toolkit/components/telemetry/pingsender/pingsender.cpp | 1 +
+ 2 files changed, 5 insertions(+)
+
+diff --git a/third_party/libwebrtc/build/build_config.h b/third_party/libwebrtc/build/build_config.h
+index c39ae9da50..28191de026 100644
+--- a/third_party/libwebrtc/build/build_config.h
++++ b/third_party/libwebrtc/build/build_config.h
+@@ -210,6 +210,10 @@
+ #define ARCH_CPU_SPARC 1
+ #define ARCH_CPU_32_BITS 1
+ #define ARCH_CPU_BIG_ENDIAN 1
++#elif defined(__loongarch_lp64)
++#define ARCH_CPU_LOONGARCH64 1
++#define ARCH_CPU_64_BITS 1
++#define ARCH_CPU_LITTLE_ENDIAN 1
+ #else
+ #error Please add support for your architecture in build/build_config.h
+ #endif
+diff --git a/toolkit/components/telemetry/pingsender/pingsender.cpp b/toolkit/components/telemetry/pingsender/pingsender.cpp
+index 30f2907c72..e6645227a2 100644
+--- a/toolkit/components/telemetry/pingsender/pingsender.cpp
++++ b/toolkit/components/telemetry/pingsender/pingsender.cpp
+@@ -10,6 +10,7 @@
+ #include <fstream>
+ #include <iomanip>
+ #include <string>
++#include <cstdint>
+ #include <vector>
+ 
+ #include <zlib.h>
+-- 
+2.46.0
+

--- a/firefox/0013-Enable-WebRTC-for-LoongArch.patch
+++ b/firefox/0013-Enable-WebRTC-for-LoongArch.patch
@@ -1,0 +1,157 @@
+From 21271679b418bc4a824f00a9ebd0cf9d32f3751e Mon Sep 17 00:00:00 2001
+From: Jiangjin Wang <kaymw@aosc.io>
+Date: Tue, 21 Nov 2023 17:17:16 -0800
+Subject: [PATCH 03/12] Enable WebRTC for LoongArch
+
+Co-Authored-By: WANG Xuerui <xen0n@gentoo.org>
+Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
+---
+ .../common_audio/common_audio_c_gn/moz.build  |  8 ++++++
+ .../spl_sqrt_floor_gn/moz.build               |  6 ++++
+ .../aecm/aecm_core_gn/moz.build               |  6 ++++
+ .../desktop_capture_gn/moz.build              | 28 +++++++++++++++++++
+ .../desktop_capture/primitives_gn/moz.build   |  4 +++
+ third_party/libwebrtc/moz.build               |  7 +++++
+ toolkit/moz.configure                         |  1 +
+ 7 files changed, 60 insertions(+)
+
+diff --git a/third_party/libwebrtc/common_audio/common_audio_c_gn/moz.build b/third_party/libwebrtc/common_audio/common_audio_c_gn/moz.build
+index 99cceabf29..ffc3677b05 100644
+--- a/third_party/libwebrtc/common_audio/common_audio_c_gn/moz.build
++++ b/third_party/libwebrtc/common_audio/common_audio_c_gn/moz.build
+@@ -250,6 +250,14 @@ if CONFIG["TARGET_CPU"] == "ppc64":
+         "/third_party/libwebrtc/common_audio/signal_processing/filter_ar_fast_q12.c"
+     ]
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    UNIFIED_SOURCES += [
++        "/third_party/libwebrtc/common_audio/signal_processing/complex_bit_reverse.c",
++        "/third_party/libwebrtc/common_audio/signal_processing/complex_fft.c",
++        "/third_party/libwebrtc/common_audio/signal_processing/filter_ar_fast_q12.c"
++    ]
++
+ if CONFIG["TARGET_CPU"] == "x86":
+ 
+     DEFINES["WEBRTC_ENABLE_AVX2"] = True
+diff --git a/third_party/libwebrtc/common_audio/third_party/spl_sqrt_floor/spl_sqrt_floor_gn/moz.build b/third_party/libwebrtc/common_audio/third_party/spl_sqrt_floor/spl_sqrt_floor_gn/moz.build
+index ec09e725ff..2f743d1d8e 100644
+--- a/third_party/libwebrtc/common_audio/third_party/spl_sqrt_floor/spl_sqrt_floor_gn/moz.build
++++ b/third_party/libwebrtc/common_audio/third_party/spl_sqrt_floor/spl_sqrt_floor_gn/moz.build
+@@ -171,6 +171,12 @@ if CONFIG["TARGET_CPU"] == "ppc64":
+         "/third_party/libwebrtc/common_audio/third_party/spl_sqrt_floor/spl_sqrt_floor.c"
+     ]
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    UNIFIED_SOURCES += [
++        "/third_party/libwebrtc/common_audio/third_party/spl_sqrt_floor/spl_sqrt_floor.c"
++    ]
++
+ if CONFIG["TARGET_CPU"] == "x86":
+ 
+     DEFINES["WEBRTC_ENABLE_AVX2"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/aecm/aecm_core_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aecm/aecm_core_gn/moz.build
+index fc1a743ada..79a4af0e4b 100644
+--- a/third_party/libwebrtc/modules/audio_processing/aecm/aecm_core_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/aecm/aecm_core_gn/moz.build
+@@ -203,6 +203,12 @@ if CONFIG["TARGET_CPU"] == "ppc64":
+         "/third_party/libwebrtc/modules/audio_processing/aecm/aecm_core_c.cc"
+     ]
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    SOURCES += [
++        "/third_party/libwebrtc/modules/audio_processing/aecm/aecm_core_c.cc"
++    ]
++
+ if CONFIG["TARGET_CPU"] == "x86":
+ 
+     DEFINES["WEBRTC_ENABLE_AVX2"] = True
+diff --git a/third_party/libwebrtc/modules/desktop_capture/desktop_capture_gn/moz.build b/third_party/libwebrtc/modules/desktop_capture/desktop_capture_gn/moz.build
+index a4fb8b3162..e8078699da 100644
+--- a/third_party/libwebrtc/modules/desktop_capture/desktop_capture_gn/moz.build
++++ b/third_party/libwebrtc/modules/desktop_capture/desktop_capture_gn/moz.build
+@@ -564,6 +564,34 @@ if CONFIG["MOZ_X11"] == "1" and CONFIG["OS_TARGET"] == "Linux" and CONFIG["TARGE
+         "/third_party/libwebrtc/modules/desktop_capture/linux/x11/x_window_property.cc"
+     ]
+ 
++if CONFIG["MOZ_X11"] == "1" and CONFIG["OS_TARGET"] == "Linux" and CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_USE_X11"] = True
++
++    OS_LIBS += [
++        "X11",
++        "Xcomposite",
++        "Xdamage",
++        "Xext",
++        "Xfixes",
++        "Xrandr",
++        "Xrender"
++    ]
++
++    UNIFIED_SOURCES += [
++        "/third_party/libwebrtc/modules/desktop_capture/linux/x11/mouse_cursor_monitor_x11.cc",
++        "/third_party/libwebrtc/modules/desktop_capture/linux/x11/screen_capturer_x11.cc",
++        "/third_party/libwebrtc/modules/desktop_capture/linux/x11/shared_x_display.cc",
++        "/third_party/libwebrtc/modules/desktop_capture/linux/x11/window_capturer_x11.cc",
++        "/third_party/libwebrtc/modules/desktop_capture/linux/x11/window_finder_x11.cc",
++        "/third_party/libwebrtc/modules/desktop_capture/linux/x11/window_list_utils.cc",
++        "/third_party/libwebrtc/modules/desktop_capture/linux/x11/x_atom_cache.cc",
++        "/third_party/libwebrtc/modules/desktop_capture/linux/x11/x_error_trap.cc",
++        "/third_party/libwebrtc/modules/desktop_capture/linux/x11/x_server_pixel_buffer.cc",
++        "/third_party/libwebrtc/modules/desktop_capture/linux/x11/x_window_property.cc"
++    ]
++
+ if CONFIG["MOZ_X11"] == "1" and CONFIG["OS_TARGET"] == "Linux" and CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["USE_X11"] = "1"
+diff --git a/third_party/libwebrtc/modules/desktop_capture/primitives_gn/moz.build b/third_party/libwebrtc/modules/desktop_capture/primitives_gn/moz.build
+index 927926f3e9..1b058ce83c 100644
+--- a/third_party/libwebrtc/modules/desktop_capture/primitives_gn/moz.build
++++ b/third_party/libwebrtc/modules/desktop_capture/primitives_gn/moz.build
+@@ -198,6 +198,10 @@ if CONFIG["MOZ_X11"] == "1" and CONFIG["OS_TARGET"] == "Linux" and CONFIG["TARGE
+ 
+     DEFINES["USE_X11"] = "1"
+ 
++if CONFIG["MOZ_X11"] == "1" and CONFIG["OS_TARGET"] == "Linux" and CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["USE_X11"] = "1"
++
+ if CONFIG["MOZ_X11"] == "1" and CONFIG["OS_TARGET"] == "Linux" and CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["USE_X11"] = "1"
+diff --git a/third_party/libwebrtc/moz.build b/third_party/libwebrtc/moz.build
+index 3aa8fb0867..8c9a6b3312 100644
+--- a/third_party/libwebrtc/moz.build
++++ b/third_party/libwebrtc/moz.build
+@@ -692,6 +692,13 @@ if CONFIG["OS_TARGET"] == "WINNT" and CONFIG["TARGET_CPU"] == "x86_64":
+         "/third_party/libwebrtc/modules/desktop_capture/desktop_capture_differ_sse2_gn"
+     ]
+ 
++if CONFIG["MOZ_X11"] == "1" and CONFIG["OS_TARGET"] == "Linux" and CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DIRS += [
++        "/third_party/libwebrtc/modules/desktop_capture/desktop_capture_gn",
++        "/third_party/libwebrtc/modules/desktop_capture/primitives_gn"
++    ]
++
+ if CONFIG["MOZ_X11"] == "1" and CONFIG["OS_TARGET"] == "Linux" and CONFIG["TARGET_CPU"] == "ppc64":
+ 
+     DIRS += [
+diff --git a/toolkit/moz.configure b/toolkit/moz.configure
+index a424446c7d..b68315241f 100644
+--- a/toolkit/moz.configure
++++ b/toolkit/moz.configure
+@@ -1399,6 +1399,7 @@ def webrtc_default(target):
+         "aarch64",
+         "x86",
+         "ia64",
++        "loongarch64",
+         "mips32",
+         "mips64",
+         "ppc",
+-- 
+2.46.0
+

--- a/firefox/loong.patch
+++ b/firefox/loong.patch
@@ -1,0 +1,97 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 63813f5..7a7b924 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -129,6 +129,14 @@ prepare() {
+   # Fix build with cinbdgen 0.27.0
+   # https://bugzilla.mozilla.org/show_bug.cgi?id=1912663
+   patch -Np1 -i ../0004-Bug-1912663-Fix-some-build-issues-with-cbindgen-0.27.patch
++  
++  # Fix `ld.lld: error: undefined hidden symbol` in libyuv
++  patch -Np1 -i ../0010-Fix-libyuv-build-with-LSX-LASX.patch
++  # Fix `ld.lld: error: undefined hidden symbol: png_init_filter_functions_lsx`
++  patch -Np1 -i ../0011-Add-missing-loongarch-lsx-code-for-libpng.patch
++  # WebRTC support for loong64
++  patch -Np1 -i ../0012-Add-support-for-LoongArch64.patch
++  patch -Np1 -i ../0013-Enable-WebRTC-for-LoongArch.patch
+ 
+   echo -n "$_google_api_key" >google-api-key
+ 
+@@ -143,7 +151,6 @@ ac_add_options --enable-optimize
+ ac_add_options --enable-rust-simd
+ ac_add_options --enable-linker=lld
+ ac_add_options --disable-install-strip
+-ac_add_options --disable-elf-hack
+ ac_add_options --disable-bootstrap
+ ac_add_options --with-wasi-sysroot=/usr/share/wasi-sysroot
+ 
+@@ -167,7 +174,7 @@ ac_add_options --with-system-nss
+ # Features
+ ac_add_options --enable-alsa
+ ac_add_options --enable-jack
+-ac_add_options --enable-crashreporter
++ac_add_options --disable-crashreporter
+ ac_add_options --disable-updater
+ ac_add_options --disable-tests
+ END
+@@ -194,41 +201,7 @@ build() {
+ 
+   # Do 3-tier PGO
+   echo "Building instrumented browser..."
+-  cat >.mozconfig ../mozconfig - <<END
+-ac_add_options --enable-profile-generate=cross
+-END
+-  ./mach build --priority normal
+-
+-  echo "Profiling instrumented browser..."
+-  ./mach package
+-  LLVM_PROFDATA=llvm-profdata JARLOG_FILE="$PWD/jarlog" \
+-    MOZ_DISABLE_CONTENT_SANDBOX=1 \
+-    MOZ_DISABLE_GMP_SANDBOX=1 \
+-    MOZ_DISABLE_GPU_SANDBOX=1 \
+-    MOZ_DISABLE_RDD_SANDBOX=1 \
+-    MOZ_DISABLE_SOCKET_PROCESS_SANDBOX=1 \
+-    MOZ_DISABLE_UTILITY_SANDBOX=1 \
+-    MOZ_DISABLE_VR_SANDBOX=1 \
+-    GTK_A11Y=none NO_AT_BRIDGE=1 dbus-run-session \
+-    xvfb-run -s "-screen 0 1920x1080x24 -nolisten local" \
+-    ./mach python build/pgo/profileserver.py
+-
+-  stat -c "Profile data found (%s bytes)" merged.profdata
+-  test -s merged.profdata
+-
+-  stat -c "Jar log found (%s bytes)" jarlog
+-  test -s jarlog
+-
+-  echo "Removing instrumented browser..."
+-  ./mach clobber objdir
+-
+-  echo "Building optimized browser..."
+-  cat >.mozconfig ../mozconfig - <<END
+-ac_add_options --enable-lto=cross,full
+-ac_add_options --enable-profile-use=cross
+-ac_add_options --with-pgo-profile-path=${PWD@Q}/merged.profdata
+-ac_add_options --with-pgo-jarlog=${PWD@Q}/jarlog
+-END
++  cat >.mozconfig ../mozconfig
+   ./mach build --priority normal
+ }
+ 
+@@ -313,4 +286,17 @@ Version=2
+ END
+ }
+ 
++source+=('0010-Fix-libyuv-build-with-LSX-LASX.patch'
++         '0011-Add-missing-loongarch-lsx-code-for-libpng.patch'
++         '0012-Add-support-for-LoongArch64.patch'
++         '0013-Enable-WebRTC-for-LoongArch.patch')
++sha256sums+=('b2d1b209b1d1e484bfa5861728fefc6918d903994d2d42a710f70b213447745b'
++             'da6733b8ca23d9de4f4c2ee1ff2bdc111128da4ec403e385bb576f2e229d1f6e'
++             '20263ae1fb3f0a424af71fb867ea7a46646a95b2f86dae229fd78a277595113e'
++             'c37b4c91e80ffb64b261e968dde3513a36ba77cd414689c7106e4d2cdbeb76a2')
++b2sums+=('b23dd10c654e8a3c0f1fbf8101d5bcffb58fcda9dbc8df5188ac8bbbb6a00539f5639e3f2c2d33399b0708c848f0da48a3cae80bef060758ec0c3ea9f5ee72df'
++         '4b0f39835f67b6b1ab120f4cb038e1afd169b84b4f8bf18b669468b6ac3543de3e131947aca616ca5db6f9cb0f97c58dd6115af9c0138a41f5f990a5b6e304c7'
++         '7f09ea931476ba0f8e4b8e3088e9fc9b8bd4cdf266b7dd90634acb73037f529904936736fc2746f2bae5c2aa9f1c19036f1fb247c9642240e4ff1cdf7a427d9b'
++         '884139f25013c18fd6dd82153bc713ac98dd50bd647ae570ca52dfda1dfec7d8c5b2a4b22ffd4afc00202249b847e4816a5c3e21852e2ef7cf33ed463e2facac')
++
+ # vim:set sw=2 sts=-1 et:


### PR DESCRIPTION
* remove `--disable-elf-hack` (not applicable to loong)
* Disable crashreporter (not applicable to loong)
* Disable PGO to avoid lld error:
  * `relocation R_LARCH_B26 out of range: 171621280 is not in [-134217728, 134217727]`
* 0010-Fix-libyuv-build-with-LSX-LASX.patch to support lsx in libyuv
* 0011-Add-missing-loongarch-lsx-code-for-libpng.patch to support lsx in libpng
* 0012-Add-support-for-LoongArch64.patch and 0013-Enable-WebRTC-for-LoongArch.patch for WebRTC support for loong