### PR TITLE
addpatch: libvpx, ver=1.14.1-1

### DIFF
--- a/libvpx/loong.patch
+++ b/libvpx/loong.patch
@@ -1,0 +1,13 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 50af858..ed86326 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -34,6 +34,8 @@ build() {
+     --prefix=/usr \
+     --disable-install-docs \
+     --disable-install-srcs \
++    --disable-lsx \
++    --disable-lasx \
+     --disable-unit-tests \
+     --enable-pic \
+     --enable-postproc \


### PR DESCRIPTION
* Disable lsx and lasx since functions like `vpx_quantize_b_lsx` are not implmented yet