### PR TITLE
addpatch: protobuf, ver=27.3-2

### DIFF
--- a/protobuf/loong.patch
+++ b/protobuf/loong.patch
@@ -1,0 +1,42 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index ea554b3..4455d0f 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -22,7 +22,6 @@ depends=(
+   'abseil-cpp'
+ )
+ makedepends=(
+-  'bazel'
+   'cmake'
+   'gtest'
+   'python-build'
+@@ -68,10 +67,10 @@ build() {
+   cmake "${cmake_options[@]}"
+   cmake --build build --verbose
+ 
+-  cd "$pkgbase-$pkgver"
+-  bazel build //python/dist:binary_wheel
++  cd "$pkgbase-5.$pkgver"
++  python -m build --wheel --no-isolation
+ 
+-  cd ruby
++  cd ../"$pkgbase-$pkgver"/ruby
+   local _gemdir="$(gem env gemdir)"
+   local _gemver=4.$pkgver
+ 
+@@ -142,7 +141,7 @@ package_python-protobuf() {
+     'python'
+   )
+ 
+-  python -m installer --destdir="$pkgdir" "$pkgbase-$pkgver"/bazel-bin/python/dist/*.whl
++  python -m installer --destdir="$pkgdir" "$pkgbase-5.$pkgver"/dist/*.whl
+   install -vDm 644 $pkgbase-$pkgver/LICENSE -t "$pkgdir/usr/share/licenses/$pkgname/"
+ }
+ 
+@@ -157,3 +156,6 @@ package_ruby-google-protobuf() {
+   install -vDm 644 $pkgbase-$pkgver/LICENSE -t "$pkgdir/usr/share/licenses/$pkgname/"
+   install -Dm 0644 $pkgbase-$pkgver/ruby/*.md -t "$pkgdir/usr/share/doc/${pkgname}"
+ }
++
++source+=("$pkgbase-$pkgver-python.tar.gz::https://files.pythonhosted.org/packages/source/${pkgbase::1}/${pkgbase//-/_}/${pkgbase//-/_}-5.$pkgver.tar.gz")
++sha512sums+=('3462518edf957582cbbd8caaa7507970339788ecde8b934b0466976cbe8bfb4aecc8690b9f6d900ea84d3084bce52ec0fd5764de862dc4839d461ef7bde63741')


### PR DESCRIPTION
* Temporarily use PyPI's source package to build python-protobuf instead of using bazel
* since bazel is missing and need openjdk21