### PR TITLE
addpatch: notcurses, ver=3.0.9-5

### DIFF
--- a/notcurses/loong.patch
+++ b/notcurses/loong.patch
@@ -1,0 +1,51 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index fcc29d7..7bac11a 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -22,13 +22,13 @@ makedepends=(
+   'libunistring'
+   'ncurses'
+   'ninja'
+-  'pandoc'
+-  'python-build'
+-  'python-cffi'
+-  'python-installer'
+-  'python-pypandoc'
+-  'python-setuptools'
+-  'python-wheel'
++#   'pandoc'
++#   'python-build'
++#   'python-cffi'
++#   'python-installer'
++#   'python-pypandoc'
++#   'python-setuptools'
++#   'python-wheel'
+   'readline'
+   'zlib'
+ )
+@@ -56,6 +56,7 @@ build() {
+     -DCMAKE_BUILD_TYPE=None
+     -DUSE_GPM=on
+     -DUSE_QRCODEGEN=off
++    -DUSE_PANDOC=OFF
+     -GNinja
+     -S $pkgname-$pkgver
+     -Wno-dev
+@@ -63,8 +64,8 @@ build() {
+ 
+   cmake "${cmake_options[@]}"
+   cmake --build build
+-  cd $pkgname-$pkgver/cffi
+-  CFLAGS+=" -I$srcdir/$pkgname-$pkgver/include -L$srcdir/build" python -m build --wheel --no-isolation
++#   cd $pkgname-$pkgver/cffi
++#   CFLAGS+=" -I$srcdir/$pkgname-$pkgver/include -L$srcdir/build" python -m build --wheel --no-isolation
+ }
+ 
+ check() {
+@@ -83,5 +84,5 @@ package() {
+   )
+ 
+   DESTDIR="$pkgdir" cmake --install build
+-  python -m installer --destdir="$pkgdir" $pkgname-$pkgver/cffi/dist/*.whl
++#   python -m installer --destdir="$pkgdir" $pkgname-$pkgver/cffi/dist/*.whl
+ }


### PR DESCRIPTION
* Temporarily disable pandoc since it has not been ported to loong
* Also, temporarily disable python binding that requires pandoc