### PR TITLE
addpatch: jdk21-openjdk

### DIFF
--- a/jdk21-openjdk/loong.patch
+++ b/jdk21-openjdk/loong.patch
@@ -1,0 +1,80 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 5dfd47b..5bde666 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -13,19 +13,18 @@ _securityver=4
+ _updatever=7
+ pkgver=${_majorver}.${_minorver}.${_securityver}.u${_updatever}
+ pkgrel=1
+- _git_tag=jdk-${_majorver}.${_minorver}.${_securityver}+${_updatever}
+ arch=('x86_64')
+ url='https://openjdk.java.net/'
+ license=('LicenseRef-Java')
+-makedepends=('java-environment=21' 'cpio' 'unzip' 'zip' 'libelf' 'libcups' 'libx11'
+-             'libxrender' 'libxtst' 'libxt' 'libxext' 'libxrandr' 'alsa-lib' 'pandoc'
++makedepends=('java-environment=20' 'cpio' 'unzip' 'zip' 'libelf' 'libcups' 'libx11'
++             'libxrender' 'libxtst' 'libxt' 'libxext' 'libxrandr' 'alsa-lib'
+              'graphviz' 'freetype2' 'libjpeg-turbo' 'giflib' 'libpng' 'lcms2'
+-             'libnet' 'bash' 'harfbuzz' 'gcc-libs' 'glibc')
+-source=(https://github.com/openjdk/jdk${_majorver}u/archive/${_git_tag}.tar.gz
++             'libnet' 'bash' 'harfbuzz' 'gcc-libs' 'glibc' 'git')
++source=(git+https://github.com/AOSC-Tracking/jdk21u#commit=f32be54
+         freedesktop-java.desktop
+         freedesktop-jconsole.desktop
+         freedesktop-jshell.desktop)
+-sha256sums=('b8b37fa6fcc284d91e7458c703ca4c893a1dd5a6e0f6b9e198e7d13cd8efd24d'
++sha256sums=('SKIP'
+             '72111743ab6ab36854b0c85a504172983715d0798fce10bc4e35689b7d15fd93'
+             '8ecdf5c1605bafa58b3f7da615e6d8d3d943e3a2d3831930d6efa7815aacce07'
+             '50fc0d677489b73d549df2f08d759d5f057f200adbbab83ea5e87456152ee03e')
+@@ -33,10 +32,10 @@ sha256sums=('b8b37fa6fcc284d91e7458c703ca4c893a1dd5a6e0f6b9e198e7d13cd8efd24d'
+ case "${CARCH}" in
+   x86_64) _JARCH='x86_64';;
+   i686)   _JARCH='x86';;
++  loong64) _JARCH='loongarch64';;
+ esac
+-
+ _jvmdir=/usr/lib/jvm/java-${_majorver}-openjdk
+-_jdkdir=jdk${_majorver}u-${_git_tag//+/-}
++_jdkdir=jdk${_majorver}u
+ _imgdir=${_jdkdir}/build/linux-${_JARCH}-server-release/images
+ 
+ _nonheadless=(lib/libawt_xawt.so
+@@ -87,13 +86,13 @@ build() {
+   unset CFLAGS
+   unset CXXFLAGS
+   unset LDFLAGS
+-
+   if check_option "lto" "y"; then
+-    jvm_features="zgc,shenandoahgc,link-time-opt"
+-  else
+-    jvm_features="zgc,shenandoahgc"
++    jvm_features="link-time-opt"
+   fi
+-
++  case "$CARCH" in
++    x86_64|i686) jvm_features+=(zgc shenandoahgc);;
++    loong64);; 
++  esac
+ 
+   bash configure \
+     --with-version-build="${_updatever}" \
+@@ -117,7 +116,7 @@ build() {
+     ${NUM_PROC_OPT}
+     #--disable-javac-server
+ 
+-  make images legacy-jre-image docs
++  make images legacy-jre-image # docs #FIXME: add doc support
+ 
+   # https://bugs.openjdk.java.net/browse/JDK-8173610
+   find "${srcdir}/${_imgdir}" -iname '*.so' -exec chmod +x {} \;
+@@ -348,7 +347,8 @@ package_openjdk21-doc() {
+   provides=("openjdk${_majorver}-doc=${pkgver}-${pkgrel}")
+ 
+   install -dm 755 "${pkgdir}/usr/share/doc"
+-  cp -r ${_imgdir}/docs "${pkgdir}/usr/share/doc/${pkgbase}"
++  # FIXME: add doc support
++  # cp -r ${_imgdir}/docs "${pkgdir}/usr/share/doc/${pkgbase}"
+ 
+   install -dm 755 "${pkgdir}/usr/share/licenses"
+   ln -s ${pkgbase} "${pkgdir}/usr/share/licenses/${pkgname}"


### PR DESCRIPTION
Change upstream to AOSC as loongarch is not officially supported by openjdk upstream.