### PR TITLE
updpatch: rust, ver=1:1.81.0-1

### DIFF
--- a/rust/0010-medium-code-model-on-LoongArch.patch
+++ b/rust/0010-medium-code-model-on-LoongArch.patch
@@ -1,0 +1,82 @@
+From 35dad14dfb63d77cf4a2077f1e8e9cff5a02a92b Mon Sep 17 00:00:00 2001
+From: WANG Xuerui <xen0n@gentoo.org>
+Date: Mon, 5 Feb 2024 13:18:32 +0800
+Subject: [PATCH] target: default to the medium code model on LoongArch targets
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The Rust LoongArch targets have been using the default LLVM code model
+so far, which is "small" in LLVM-speak and "normal" in LoongArch-speak.
+As described in the "Code Model" section of LoongArch ELF psABI spec
+v20231219 [1], one can only make function calls as far as ±128MiB with
+the "normal" code model; this is insufficient for very large software
+containing Rust components that needs to be linked into the big text
+section, such as Chromium.
+
+Because:
+
+* we do not want to ask users to recompile std if they are to build
+  such software,
+* objects compiled with larger code models can be linked with those
+  with smaller code models without problems, and
+* the "medium" code model is comparable to the "small"/"normal" one
+  performance-wise (same data access pattern; each function call
+  becomes 2-insn long and indirect, but this may be relaxed back into
+  the direct 1-insn form in a future LLVM version), but is able to
+  perform function calls within ±128GiB,
+
+it is better to just switch the targets to the "medium" code model,
+which is also "medium" in LLVM-speak.
+
+[1]: https://github.com/loongson/la-abi-specs/blob/v2.30/laelf.adoc#code-models
+---
+ .../src/spec/targets/loongarch64_unknown_linux_gnu.rs          | 3 ++-
+ .../rustc_target/src/spec/targets/loongarch64_unknown_none.rs  | 2 +-
+ .../src/spec/targets/loongarch64_unknown_none_softfloat.rs     | 2 +-
+ 3 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_gnu.rs b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_gnu.rs
+index 0f05e7c475a83..cb24e740c86f2 100644
+--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_gnu.rs
++++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_linux_gnu.rs
+@@ -1,4 +1,4 @@
+-use crate::spec::{base, Target, TargetOptions};
++use crate::spec::{base, CodeModel, Target, TargetOptions};
+ 
+ pub fn target() -> Target {
+     Target {
+@@ -7,6 +7,7 @@ pub fn target() -> Target {
+         data_layout: "e-m:e-p:64:64-i64:64-i128:128-n64-S128".into(),
+         arch: "loongarch64".into(),
+         options: TargetOptions {
++            code_model: Some(CodeModel::Medium),
+             cpu: "generic".into(),
+             features: "+f,+d".into(),
+             llvm_abiname: "lp64d".into(),
+diff --git a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_none.rs b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_none.rs
+index 3b1ea8e206f1c..f448017a2a58d 100644
+--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_none.rs
++++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_none.rs
+@@ -16,7 +16,7 @@ pub fn target() -> Target {
+             max_atomic_width: Some(64),
+             relocation_model: RelocModel::Static,
+             panic_strategy: PanicStrategy::Abort,
+-            code_model: Some(CodeModel::Small),
++            code_model: Some(CodeModel::Medium),
+             ..Default::default()
+         },
+     }
+diff --git a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_none_softfloat.rs b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_none_softfloat.rs
+index ab9300ef9c723..d636c9599a7be 100644
+--- a/compiler/rustc_target/src/spec/targets/loongarch64_unknown_none_softfloat.rs
++++ b/compiler/rustc_target/src/spec/targets/loongarch64_unknown_none_softfloat.rs
+@@ -17,7 +17,7 @@ pub fn target() -> Target {
+             max_atomic_width: Some(64),
+             relocation_model: RelocModel::Static,
+             panic_strategy: PanicStrategy::Abort,
+-            code_model: Some(CodeModel::Small),
++            code_model: Some(CodeModel::Medium),
+             ..Default::default()
+         },
+     }

--- a/rust/loong.patch
+++ b/rust/loong.patch
@@ -1,3 +1,5 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 0b08895..deb1612 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
 @@ -7,9 +7,6 @@
@@ -29,7 +31,18 @@
  )
  checkdepends=(
    gdb
-@@ -99,14 +91,7 @@ link-shared = true
+@@ -87,6 +79,10 @@ prepare() {
+   # Use our wasm-ld
+   patch -Np1 -i ../0004-compiler-Use-wasm-ld-for-wasm-targets.patch
+ 
++  # Patches for loong64
++  # Avoid `relocation R_LARCH_B26 out of range` when binary is huge
++  patch -Np1 -i ../0010-medium-code-model-on-LoongArch.patch
++
+   cat >config.toml <<END
+ # see src/bootstrap/defaults/
+ profile = "dist"
+@@ -99,14 +95,7 @@ link-shared = true
  
  [build]
  target = [
@@ -45,7 +58,7 @@
  ]
  cargo = "/usr/bin/cargo"
  rustc = "/usr/bin/rustc"
-@@ -148,46 +133,13 @@ jemalloc = true
+@@ -149,46 +138,13 @@ jemalloc = true
  [dist]
  compression-formats = ["gz"]
  
@@ -93,7 +106,7 @@
  END
  }
  
-@@ -229,13 +181,8 @@ build() {
+@@ -230,13 +186,8 @@ build() {
  
    # rustbuild always installs copies of the shared libraries to /usr/lib,
    # overwrite them with symlinks to the per-architecture versions
@@ -108,3 +121,10 @@
    _pick dest-src  usr/lib/rustlib/src
  }
  
+@@ -316,3 +267,6 @@ package_rust-src() {
+ }
+ 
+ # vim:set ts=2 sw=2 et:
++
++source+=("0010-medium-code-model-on-LoongArch.patch")
++b2sums+=('f72780cea412a3d1c1710ab55839e519324534a4f92e39b153bdfc27e2beb82297b17423d46756e15875c2864946efbbe0c2ea152c1497568a26b7df8fa3e9a2')


### PR DESCRIPTION
* Apply patch to avoid `relocation R_LARCH_B26 out of range` when binary is huge