### PR TITLE
addpatch: gn, ver=0.2174.b3a0bff4-1

### DIFF
--- a/gn/loong.patch
+++ b/gn/loong.patch
@@ -1,0 +1,14 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 77077a7..adf19d1 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -20,6 +20,9 @@ pkgver() {
+ 
+ build() {
+   cd $pkgname
++  # clang does not support it
++  CXXFLAGS="${CXXFLAGS//-fstack-clash-protection/}"
++  CFLAGS="${CFLAGS//-fstack-clash-protection/}"
+   ./build/gen.py
+   ninja -C out
+ }


### PR DESCRIPTION
* Clang does not support `-fstack-clash-protection` and will fail by `-Werror`