### PR TITLE
addpatch: obs-studio, ver=30.2.1-1

### DIFF
--- a/obs-studio/loong.patch
+++ b/obs-studio/loong.patch
@@ -1,0 +1,12 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index bbe5b78..f092485 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -41,6 +41,7 @@ build() {
+     -DENABLE_AJA=OFF \
+     -DENABLE_JACK=ON \
+     -DENABLE_LIBFDK=ON \
++    -DENABLE_QSV11=OFF \
+     -DENABLE_WEBRTC=ON \
+     -DOBS_VERSION_OVERRIDE="$pkgver-$pkgrel" \
+     -DCALM_DEPRECATION=ON \


### PR DESCRIPTION
* Disable `QSV11` in loong that it doesn't support loong and will fail in header missing