### PR TITLE
addpatch: libblockdev, ver=3.1.1-2

### DIFF
--- a/libblockdev/loong.patch
+++ b/libblockdev/loong.patch
@@ -1,0 +1,14 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 6c3b9df..01fe0d1 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -62,6 +62,9 @@ build() {
+     --sysconfdir=/etc
+   )
+ 
++  CFLAGS+=" -Wno-error=unused-parameter"
++  CXXFLAGS+=" -Wno-error=unused-parameter"
++
+   cd $pkgname-$pkgver
+   ./configure "${configure_options[@]}"
+   # prevent libtool from overlinking everything


### PR DESCRIPTION
* Add `-Wno-error=unused-parameter` to `CFLAGS` to prevent from reporting an error