### PR TITLE
addpatch: kernel-header-musl, ver=6.0-1

### DIFF
--- a/kernel-headers-musl/loong.patch
+++ b/kernel-headers-musl/loong.patch
@@ -1,0 +1,39 @@
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -3,25 +3,27 @@
+ # Contributor: Jens Staal <staal1978@gmail.com>
+ 
+ pkgname=kernel-headers-musl
+-pkgver=4.19.88
+-pkgrel=2
++pkgver=6.0
++_rdate=20221017
++pkgrel=1
+ pkgdesc="Linux kernel headers sanitized for use with musl libc"
+ arch=('x86_64')
+ url="https://github.com/sabotage-linux/kernel-headers"
+ license=('LGPL')
++makedepends=(rsync)
+ depends=('musl')
+-source=("$pkgname-$pkgver.tar.gz::https://github.com/sabotage-linux/kernel-headers/archive/v${pkgver/_/-}.tar.gz")
+-sha512sums=('db0239c40399c89cc250b9f1f53b7ec4eb119fde6b25c503aef7e88b80694df3a5e89196a22e66376731764bac83d9120794ee6c601a95b824f1ab770cb45a61')
++source=(https://github.com/yetist/linux/releases/download/v${_rdate}/linux-${pkgver}-${_rdate}.tar.xz)
++sha256sums=('ac4822f7dad35e42b1d0b02190eb876d80f3beefe9576ae8b45aeb5c5bc79eb1')
+ 
+ _CARCH=$CARCH
+-[[ $CARCH = i?86 ]] && _CARCH=x86
++[[ $CARCH = loong64 ]] && _CARCH=loongarch
+ 
+ build() {
+-  cd "$srcdir"/kernel-headers-${pkgver/_/-}
+-  make ARCH=${_CARCH} prefix=/usr/lib/musl
++  cd "$srcdir"/linux-${pkgver/_/-}
++  make ARCH=${_CARCH} mrproper
+ }
+ 
+ package() {
+-  cd "$srcdir"/kernel-headers-${pkgver/_/-}
+-  make ARCH=${_CARCH} prefix=/usr/lib/musl DESTDIR="$pkgdir" install
++  cd "$srcdir"/linux-${pkgver/_/-}
++  make ARCH=${_CARCH} INSTALL_HDR_PATH="$pkgdir/usr/lib/musl" headers_install
+ }


### PR DESCRIPTION
The upstream uses kernel version 4.19.88-2, which does not support loongarch64. This patch is adapte from yetist, and use his repo as the source of this package.