### PR TITLE
addpatch: budgie-desktop-view, ver=1.3-2

### DIFF
--- a/budgie-desktop-view/loong.patch
+++ b/budgie-desktop-view/loong.patch
@@ -1,0 +1,15 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 7623862..211ac8c 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -25,3 +25,10 @@ build() {
+ package() {
+     meson install -C build --destdir "$pkgdir"
+ }
++
++prepare() {
++    patch -d "$pkgname-$pkgver" -p1 -i "$srcdir/fix-compilation-under-newer-meson-and-gcc.patch"
++}
++
++source+=("fix-compilation-under-newer-meson-and-gcc.patch::https://github.com/BuddiesOfBudgie/budgie-desktop-view/commit/05a9822a465a023968efb28c620e9448c82634db.patch")
++b2sums+=('8fd7114539f67b8eaaa63f4b6c1d8ce9844ae4948845153703245f5f6d6cc37dfc8f52c52413d8c45459ef4bd7917110d70d2971b25112736e379c3a5b661c24')


### PR DESCRIPTION
* Cherry-pick upstreamed fix for new meson and gcc