### PR TITLE
updpatch: codeblocks, ver=20.03-5.1

### DIFF
--- a/codeblocks/add-loong64-support.patch
+++ b/codeblocks/add-loong64-support.patch
@@ -1,5 +1,3 @@
-diff --git a/src/include/mozilla_chardet/nsprpub/pr/include/prcpucfg_linux.h b/src/include/mozilla_chardet/nsprpub/pr/include/prcpucfg_linux.h
-index 2fdbf63..c3e9879 100644
 --- a/src/include/mozilla_chardet/nsprpub/pr/include/prcpucfg_linux.h
 +++ b/src/include/mozilla_chardet/nsprpub/pr/include/prcpucfg_linux.h
 @@ -914,6 +914,52 @@
@@ -55,20 +53,27 @@ index 2fdbf63..c3e9879 100644
  #else
  
  #error "Unknown CPU architecture"
-diff --git a/src/plugins/contrib/dragscroll/dragscrollcfg.h b/src/plugins/contrib/dragscroll/dragscrollcfg.h
-index 7fc28be..06d7197 100644
 --- a/src/plugins/contrib/dragscroll/dragscrollcfg.h
 +++ b/src/plugins/contrib/dragscroll/dragscrollcfg.h
-@@ -35,7 +35,13 @@ class cbDragScrollCfg: public cbConfigurationPanel
+@@ -1,6 +1,8 @@
+ #ifndef DragScrollCfg_H
+ #define DragScrollCfg_H
+ 
++#include <csignal>
++
+ #ifdef __BORLANDC__
+     #pragma hdrstop
+ #endif
+@@ -35,7 +37,13 @@
          wxString GetBitmapBaseName() const;
          void OnApply();
          void OnCancel(){}
 -        virtual void InitDialog(){ asm("int3");} /*trap*/
 +        virtual void InitDialog(){ /*trap*/
-+#if defined(__loongarch_lp64)
-+            asm(".4byte 0x00100073");
-+#else
++#if defined(__i386__) || defined(__x86_64__)
 +            asm("int3");
++#else
++            std::raise(SIGTRAP);
 +#endif
 +        }
  

--- a/codeblocks/loong.patch
+++ b/codeblocks/loong.patch
@@ -1,5 +1,5 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 22a0af3..b9f9672 100644
+index 22a0af3..98e9559 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
 @@ -69,11 +69,14 @@ prepare() {
@@ -24,4 +24,4 @@ index 22a0af3..b9f9672 100644
  }
 +
 +source+=("add-loong64-support.patch")
-+sha256sums+=('8115d8b4f4618f17efdc727b1bf06020a688f7f8cdaef8ec7f48d95cae97ca90')
++sha256sums+=('4691ea04a7bb73c6e6634124419c27b7882a1633f01ed1728085515f7abbfbdf')


### PR DESCRIPTION
* Fix the error of calling trap as risc-v instruction
* Use architecture-independent `std::raise(SIGTRAP)`