### PR TITLE
addpatch: gst-plugins-rs, ver=0.13.1-2

### DIFF
--- a/gst-plugins-rs/loong.patch
+++ b/gst-plugins-rs/loong.patch
@@ -1,0 +1,33 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index cc436e9..e95b4d0 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -8,7 +8,7 @@ pkgname=(
+   gst-plugin-claxon
+   gst-plugin-dav1d
+   gst-plugin-fallbackswitch
+-  gst-plugin-ffv1
++  #gst-plugin-ffv1 # Disabled for it needs nix 0.23 that doesn't support loong
+   gst-plugin-fmp4
+   gst-plugin-gif
+   gst-plugin-gopbuffer
+@@ -40,7 +40,7 @@ pkgname=(
+   gst-plugin-rswebp
+   gst-plugin-rswebrtc
+   gst-plugin-sodium
+-  gst-plugin-spotify
++  #gst-plugin-spotify # Disabled for it needs nix 0.23 that doesn't support loong
+   gst-plugin-textahead
+   gst-plugin-textwrap
+   gst-plugin-threadshare
+@@ -93,6 +93,10 @@ _cargo_c_options=(
+   --exclude gst-plugin-csound
+   --exclude gst-plugin-ndi
+   --exclude gst-plugin-uriplaylistbin
++  # Following are temporarily disabled because they need nix 0.23
++  # that doesn't support loong
++  --exclude gst-plugin-ffv1
++  --exclude gst-plugin-spotify
+ )
+ 
+ # Link with libsodium from system


### PR DESCRIPTION
* Temporarily disable plugins that need nix 0.23, which doesn't support loong64