### PR TITLE
addpatch: john, ver=1.9.0.jumbo1-11

### DIFF
--- a/john/loong.patch
+++ b/john/loong.patch
@@ -1,0 +1,14 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 6ca3519..2ba3ec9 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -93,6 +93,9 @@ build() {
+     mv ../run/john{,-non-xop}
+     ./configure "${options[@]}" CFLAGS="${CFLAGS} -mxop"
+     make clean; make
++  elif [[ "${CARCH}" == "loong64" ]]; then
++    ./configure "${options[@]}" CFLAGS="${CFLAGS/-DCPU_FALLBACK}"
++    make clean; make
+   else
+     ./configure "${options[@]}" CFLAGS="${CFLAGS}"
+     make clean; make

--- a/jujutsu/loong.patch
+++ b/jujutsu/loong.patch
@@ -1,0 +1,12 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 3ed3fc6..d2fc983 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -49,6 +49,7 @@ check() {
+ 		test_diff_command # relies on config of external command
+ 		test_acls::test_diff # relies on assumptions about tty
+ 		test_show_command::test_show_basic # https://github.com/martinvonz/jj/issues/4394
++		test_describe_command::test_describe
+ 	)
+ 	cargo test --frozen --all-features --package jj-cli -- \
+ 		${skipped[@]/#/--skip }


### PR DESCRIPTION
Apply patch from https://github.com/felixonmars/archriscv-packages/blob/master/john/riscv64.patch
Fix CPU_FALLBACK_BINARY error in listconf.c