### PR TITLE
addpatch: john, ver=1.9.0.jumbo1-11

### DIFF
--- a/john/loong.patch
+++ b/john/loong.patch
@@ -1,0 +1,14 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 6ca3519..2ba3ec9 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -93,6 +93,9 @@ build() {
+     mv ../run/john{,-non-xop}
+     ./configure "${options[@]}" CFLAGS="${CFLAGS} -mxop"
+     make clean; make
++  elif [[ "${CARCH}" == "loong64" ]]; then
++    ./configure "${options[@]}" CFLAGS="${CFLAGS/-DCPU_FALLBACK}"
++    make clean; make
+   else
+     ./configure "${options[@]}" CFLAGS="${CFLAGS}"
+     make clean; make


### PR DESCRIPTION
Apply patch from https://github.com/felixonmars/archriscv-packages/blob/master/john/riscv64.patch 
Fix CPU_FALLBACK_BINARY error in listconf.c