### PR TITLE
addpatch: librustls, ver=0.14.0

### DIFF
--- a/librustls/loong.patch
+++ b/librustls/loong.patch
@@ -1,0 +1,13 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 5769a94..7a8f164 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -15,6 +15,8 @@ makedepends=(
+   cargo-c
+   nasm
+   rust
++  cmake
++  clang
+ )
+ provides=('librustls.so')
+ options=(!lto)


### PR DESCRIPTION
Note: x86 archlinux DO NOT need this patch to build successfully. Reason is unclear.