### PR TITLE
updpatch: linux-firmware, ver=20240928.c979a065-1

### DIFF
--- a/linux-firmware/loong.patch
+++ b/linux-firmware/loong.patch
@@ -1,6 +1,17 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 9531646..16d1b5c 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -62,6 +62,11 @@ build() {
+@@ -2,7 +2,7 @@
+ # Contributor: Thomas Bächler <thomas@archlinux.org>
+ 
+ pkgbase=linux-firmware
+-pkgname=(linux-firmware-whence linux-firmware amd-ucode
++pkgname=(linux-firmware-whence linux-firmware
+          linux-firmware-{nfp,mellanox,marvell,qcom,liquidio,qlogic,bnx2x}
+ )
+ _tag=20240909
+@@ -63,6 +63,11 @@ build() {
    echo kernel/x86/microcode/AuthenticAMD.bin |
      bsdtar --uid 0 --gid 0 -cnf - -T - |
      bsdtar --null -cf - --format=newc @- > amd-ucode.img
@@ -12,7 +23,7 @@
  }
  
  _pick() {
-@@ -177,4 +182,8 @@ package_linux-firmware-bnx2x() {
+@@ -178,4 +183,8 @@ package_linux-firmware-bnx2x() {
    mv -v linux-firmware-bnx2x/* "${pkgdir}"
  }
  


### PR DESCRIPTION
* Disable to package `amd-ucode` since it's invalid in loong64