### PR TITLE
addpatch: telegram-desktop, ver=5.6.0-1.1

### DIFF
--- a/telegram-desktop/loong.patch
+++ b/telegram-desktop/loong.patch
@@ -1,0 +1,14 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 7dfaa75..697ddf9 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -38,3 +38,9 @@ build() {
+ package() {
+     DESTDIR="$pkgdir" cmake --install build
+ }
++
++prepare() {
++    export LDFLAGS="${LDFLAGS} -fuse-ld=mold"
++}
++
++makedepends+=(mold)


### PR DESCRIPTION
* Use `mold` to replace `ld.bfd` as the linker to temporarily avoid the bug of
`binutils`
  * `fatal error: ld terminated with signal 11 [Segmentation fault], core
dumped`