### PR TITLE
addpatch: cargo-tauri, ver=1.5.11-2

### DIFF
--- a/cargo-tauri/loong.patch
+++ b/cargo-tauri/loong.patch
@@ -1,0 +1,12 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index a54fd99..d16dc5a 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -16,6 +16,7 @@ options=('!lto')
+ prepare() {
+   mv "$_pkgname-tauri-cli-v$pkgver" "$pkgname-$pkgver"
+   cd "$pkgname-$pkgver/tooling/cli"
++  cargo update -p time
+   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+   mkdir -p completions
+ }


### PR DESCRIPTION
* Fix inference error on crate `time` caused by an API change in Rust 1.80.0