### PR TITLE
addpatch: trurl, ver=0.16-1

### DIFF
--- a/trurl/loong.patch
+++ b/trurl/loong.patch
@@ -1,0 +1,12 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 520c457..6666f59 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -24,7 +24,6 @@ build() {
+ check() {
+ 	cd "$pkgname-$pkgver"
+ 	make test
+-	make test-memory
+ }
+ 
+ package() {


### PR DESCRIPTION
* Disable `test-memory`, which is not for loong64