### PR TITLE
addpatch: termusic, ver=0.9.1-1

### DIFF
--- a/termusic/loong.patch
+++ b/termusic/loong.patch
@@ -1,0 +1,13 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index d14c363..eb65758 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -8,7 +8,7 @@ pkgdesc="Music Player TUI written in Rust"
+ arch=('x86_64')
+ url="https://github.com/tramhao/termusic"
+ license=('MIT' 'GPL3')
+-depends=('gstreamer' 'gst-plugins-base' 'gst-plugins-good' 'gst-plugins-bad' 'gst-plugins-ugly' 'gst-libav' 'dbus' 'ueberzug' 'protobuf')
++depends=('gstreamer' 'gst-plugins-base' 'gst-plugins-good' 'gst-plugins-bad' 'gst-plugins-ugly' 'gst-libav' 'dbus' 'ueberzug' 'protobuf' 'libsixel')
+ optdepends=('yt-dlp: download mp3'
+   'ffmpeg: download mp3'
+   'emoji-font: for displaying emojis')


### PR DESCRIPTION
* `libsixel` is needed to build in loong64