### PR TITLE
addpatch: distrho-ports, ver=2021.03.15-4

### DIFF
--- a/distrho-ports/loong.patch
+++ b/distrho-ports/loong.patch
@@ -1,0 +1,22 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 4e9a995..9ad3340 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -40,6 +40,9 @@ _pick() {
+ }
+ 
+ build() {
++  patch -Np1 -d $pkgname -i ../use-simde.patch
++  export CXXFLAGS="${CXXFLAGS} -fpermissive -DSIMDE_NO_NATIVE"
++
+   arch-meson build $pkgname
+   ninja -C build
+ }
+@@ -222,3 +225,7 @@ package_distrho-ports-vst3() {
+ 
+   mv -v $pkgname/* "$pkgdir"
+ }
++
++makedepends+=(simde)
++source+=("use-simde.patch")
++b2sums+=('11bbfa467a0453e831eee1ecfe2b4e0f5a430db0059dd9ebcdc4863627807ad52275c3ba3437964956e7b372cef53e0332152ff27fdbe4e186c954f9314a7453')

--- a/distrho-ports/use-simde.patch
+++ b/distrho-ports/use-simde.patch
@@ -1,0 +1,42 @@
+diff --git a/ports-legacy/pitchedDelay/source/dsp/BandLimit.cpp b/ports-legacy/pitchedDelay/source/dsp/BandLimit.cpp
+index 7d8759be..663799f0 100644
+--- a/ports-legacy/pitchedDelay/source/dsp/BandLimit.cpp
++++ b/ports-legacy/pitchedDelay/source/dsp/BandLimit.cpp
+@@ -2,7 +2,7 @@
+ #if defined(__x86_64__) || defined(__i386__)
+ #include <emmintrin.h>
+ #include <mmintrin.h>
+-#else
++#elif defined(__aarch64__) || defined(__arm__)
+ #include <arm_neon.h>
+ typedef float32x4_t __m128;
+ #define _mm_load_ps  vld1q_f32
+@@ -10,6 +10,9 @@ typedef float32x4_t __m128;
+ #define _mm_add_ps vaddq_f32
+ #define _mm_sub_ps vsubq_f32
+ #define _mm_mul_ps vmulq_f32
++#else
++#define SIMDE_ENABLE_NATIVE_ALIASES 1
++#include <simde/x86/sse2.h>
+ #endif
+ 
+ CAllPassFilterPair::CAllPassFilterPair(double coeff_A, double coeff_B)
+diff --git a/ports/vitalium/source/synthesis/framework/poly_values.h b/ports/vitalium/source/synthesis/framework/poly_values.h
+index fd90a8f9..4581e220 100644
+--- a/ports/vitalium/source/synthesis/framework/poly_values.h
++++ b/ports/vitalium/source/synthesis/framework/poly_values.h
+@@ -31,10 +31,12 @@
+     #define NEON_ARM32 1
+   #endif
+ #else
+-  static_assert(false, "No SIMD Intrinsics found which are necessary for compilation");
++  #define VITAL_SSE2 1
++  #define SIMDE_ENABLE_NATIVE_ALIASES 1
++  #include <simde/x86/sse2.h>
+ #endif
+ 
+-#if VITAL_SSE2
++#if VITAL_SSE2 && __SSE2__
+   #include <immintrin.h>
+ #elif VITAL_NEON
+   #include <arm_neon.h>


### PR DESCRIPTION
* Fix build with gcc14
* Use simde
  * Bug: `error: conflicting declaration ‘typedef simde__m128i __m128i’`
  * Temporarily switch to `SIMDE_NO_NATIVE`
  * This actually disables SIMD and need to be restored after simde's update