### PR TITLE
addpatch: firefox-developer-edition, ver=132.0b8-1

### DIFF
--- a/firefox-developer-edition/0001-Add-support-for-LoongArch64.patch
+++ b/firefox-developer-edition/0001-Add-support-for-LoongArch64.patch
@@ -1,0 +1,45 @@
+From 19140a75d513f3f3d5c12d42a65d2c892e934e3f Mon Sep 17 00:00:00 2001
+From: Jiangjin Wang <kaymw@aosc.io>
+Date: Sun, 22 Oct 2023 22:13:17 -0700
+Subject: [PATCH 1/6] Add support for LoongArch64
+
+Adapted from LoongArchLinux. Rebased to Firefox 130.0.0.
+
+Co-Authored-By: loongson <loongson@loongson.cn>
+Co-Authored-By: WANG Xuerui <xen0n@gentoo.org>
+Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
+---
+ third_party/libwebrtc/build/build_config.h             | 4 ++++
+ toolkit/components/telemetry/pingsender/pingsender.cpp | 1 +
+ 2 files changed, 5 insertions(+)
+
+diff --git a/third_party/libwebrtc/build/build_config.h b/third_party/libwebrtc/build/build_config.h
+index c39ae9da50f99..28191de02654b 100644
+--- a/third_party/libwebrtc/build/build_config.h
++++ b/third_party/libwebrtc/build/build_config.h
+@@ -210,6 +210,10 @@
+ #define ARCH_CPU_SPARC 1
+ #define ARCH_CPU_32_BITS 1
+ #define ARCH_CPU_BIG_ENDIAN 1
++#elif defined(__loongarch_lp64)
++#define ARCH_CPU_LOONGARCH64 1
++#define ARCH_CPU_64_BITS 1
++#define ARCH_CPU_LITTLE_ENDIAN 1
+ #else
+ #error Please add support for your architecture in build/build_config.h
+ #endif
+diff --git a/toolkit/components/telemetry/pingsender/pingsender.cpp b/toolkit/components/telemetry/pingsender/pingsender.cpp
+index 30f2907c720e1..e6645227a2949 100644
+--- a/toolkit/components/telemetry/pingsender/pingsender.cpp
++++ b/toolkit/components/telemetry/pingsender/pingsender.cpp
+@@ -10,6 +10,7 @@
+ #include <fstream>
+ #include <iomanip>
+ #include <string>
++#include <cstdint>
+ #include <vector>
+ 
+ #include <zlib.h>
+-- 
+2.45.2
+

--- a/firefox-developer-edition/0003-update-gn_processor.py-to-support-linux-on-loong64.patch
+++ b/firefox-developer-edition/0003-update-gn_processor.py-to-support-linux-on-loong64.patch
@@ -1,0 +1,34 @@
+From cf96c8fb08a17fafc72ca7c43b9c2fd77557e899 Mon Sep 17 00:00:00 2001
+From: WANG Xuerui <xen0n@gentoo.org>
+Date: Tue, 3 Sep 2024 15:38:04 +0800
+Subject: [PATCH 3/6] update gn_processor.py to support linux on loong64
+
+Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
+---
+ python/mozbuild/mozbuild/gn_processor.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/python/mozbuild/mozbuild/gn_processor.py b/python/mozbuild/mozbuild/gn_processor.py
+index 3a9b9e7f3baeb..fc771a4e63fd0 100644
+--- a/python/mozbuild/mozbuild/gn_processor.py
++++ b/python/mozbuild/mozbuild/gn_processor.py
+@@ -182,6 +182,7 @@ def filter_gn_config(path, gn_result, sandbox_vars, input_vars, gn_target):
+         "x64": "x86_64",
+         "mipsel": "mips32",
+         "mips64el": "mips64",
++        "loong64": "loongarch64",
+     }
+     oses = {
+         "android": "Android",
+@@ -753,7 +754,7 @@ def main():
+             if target_os in ("linux", "openbsd"):
+                 target_cpus.append("riscv64")
+             if target_os == "linux":
+-                target_cpus.extend(["ppc64", "mipsel", "mips64el"])
++                target_cpus.extend(["loong64", "ppc64", "mipsel", "mips64el"])
+             for target_cpu in target_cpus:
+                 vars = {
+                     "host_cpu": "x64",
+-- 
+2.45.2
+

--- a/firefox-developer-edition/0004-Re-generate-libwebrtc-moz.build-files.patch
+++ b/firefox-developer-edition/0004-Re-generate-libwebrtc-moz.build-files.patch
@@ -1,0 +1,7022 @@
+diff --git a/third_party/libwebrtc/api/adaptation/resource_adaptation_api_gn/moz.build b/third_party/libwebrtc/api/adaptation/resource_adaptation_api_gn/moz.build
+index 2dbd5881583e3..b63b665289b5a 100644
+--- a/third_party/libwebrtc/api/adaptation/resource_adaptation_api_gn/moz.build
++++ b/third_party/libwebrtc/api/adaptation/resource_adaptation_api_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/array_view_gn/moz.build b/third_party/libwebrtc/api/array_view_gn/moz.build
+index df2c86715cacd..0a60fd48bb19b 100644
+--- a/third_party/libwebrtc/api/array_view_gn/moz.build
++++ b/third_party/libwebrtc/api/array_view_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/async_dns_resolver_gn/moz.build b/third_party/libwebrtc/api/async_dns_resolver_gn/moz.build
+index 4d678a1de7c96..90dd37068d148 100644
+--- a/third_party/libwebrtc/api/async_dns_resolver_gn/moz.build
++++ b/third_party/libwebrtc/api/async_dns_resolver_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio/aec3_config_gn/moz.build b/third_party/libwebrtc/api/audio/aec3_config_gn/moz.build
+index cbd6f2e6f0d53..785f61c7f9c33 100644
+--- a/third_party/libwebrtc/api/audio/aec3_config_gn/moz.build
++++ b/third_party/libwebrtc/api/audio/aec3_config_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio/aec3_factory_gn/moz.build b/third_party/libwebrtc/api/audio/aec3_factory_gn/moz.build
+index 746585483f964..b702e63d8d1c1 100644
+--- a/third_party/libwebrtc/api/audio/aec3_factory_gn/moz.build
++++ b/third_party/libwebrtc/api/audio/aec3_factory_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio/audio_device_gn/moz.build b/third_party/libwebrtc/api/audio/audio_device_gn/moz.build
+index 9609692094c15..4b1e3244c5b73 100644
+--- a/third_party/libwebrtc/api/audio/audio_device_gn/moz.build
++++ b/third_party/libwebrtc/api/audio/audio_device_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio/audio_frame_api_gn/moz.build b/third_party/libwebrtc/api/audio/audio_frame_api_gn/moz.build
+index e2561db08f06e..5da158eb823a1 100644
+--- a/third_party/libwebrtc/api/audio/audio_frame_api_gn/moz.build
++++ b/third_party/libwebrtc/api/audio/audio_frame_api_gn/moz.build
+@@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio/audio_frame_processor_gn/moz.build b/third_party/libwebrtc/api/audio/audio_frame_processor_gn/moz.build
+index 7dd1c4b91100e..d33585f69fe68 100644
+--- a/third_party/libwebrtc/api/audio/audio_frame_processor_gn/moz.build
++++ b/third_party/libwebrtc/api/audio/audio_frame_processor_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio/audio_mixer_api_gn/moz.build b/third_party/libwebrtc/api/audio/audio_mixer_api_gn/moz.build
+index 36d43783a3e7d..f8d9e41c9a370 100644
+--- a/third_party/libwebrtc/api/audio/audio_mixer_api_gn/moz.build
++++ b/third_party/libwebrtc/api/audio/audio_mixer_api_gn/moz.build
+@@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio/audio_processing_gn/moz.build b/third_party/libwebrtc/api/audio/audio_processing_gn/moz.build
+index 7226d2a92a40a..a3ed2ed8a94dd 100644
+--- a/third_party/libwebrtc/api/audio/audio_processing_gn/moz.build
++++ b/third_party/libwebrtc/api/audio/audio_processing_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio/audio_processing_statistics_gn/moz.build b/third_party/libwebrtc/api/audio/audio_processing_statistics_gn/moz.build
+index d7629659d6bac..ede61bc1f955a 100644
+--- a/third_party/libwebrtc/api/audio/audio_processing_statistics_gn/moz.build
++++ b/third_party/libwebrtc/api/audio/audio_processing_statistics_gn/moz.build
+@@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio/echo_control_gn/moz.build b/third_party/libwebrtc/api/audio/echo_control_gn/moz.build
+index 06f43e765114c..cc5e401aa4f8a 100644
+--- a/third_party/libwebrtc/api/audio/echo_control_gn/moz.build
++++ b/third_party/libwebrtc/api/audio/echo_control_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio_codecs/L16/audio_decoder_L16_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/L16/audio_decoder_L16_gn/moz.build
+index 5811f4d9321bc..f530738ade2e5 100644
+--- a/third_party/libwebrtc/api/audio_codecs/L16/audio_decoder_L16_gn/moz.build
++++ b/third_party/libwebrtc/api/audio_codecs/L16/audio_decoder_L16_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio_codecs/L16/audio_encoder_L16_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/L16/audio_encoder_L16_gn/moz.build
+index f4fb06ef3f093..452bc02291fba 100644
+--- a/third_party/libwebrtc/api/audio_codecs/L16/audio_encoder_L16_gn/moz.build
++++ b/third_party/libwebrtc/api/audio_codecs/L16/audio_encoder_L16_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio_codecs/audio_codecs_api_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/audio_codecs_api_gn/moz.build
+index faed7e9b0f615..c0e23d412af50 100644
+--- a/third_party/libwebrtc/api/audio_codecs/audio_codecs_api_gn/moz.build
++++ b/third_party/libwebrtc/api/audio_codecs/audio_codecs_api_gn/moz.build
+@@ -153,6 +153,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio_codecs/builtin_audio_decoder_factory_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/builtin_audio_decoder_factory_gn/moz.build
+index 5de9c2960769a..d04a8351a0f6e 100644
+--- a/third_party/libwebrtc/api/audio_codecs/builtin_audio_decoder_factory_gn/moz.build
++++ b/third_party/libwebrtc/api/audio_codecs/builtin_audio_decoder_factory_gn/moz.build
+@@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio_codecs/builtin_audio_encoder_factory_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/builtin_audio_encoder_factory_gn/moz.build
+index 5ff7dfd0ffd44..dd8118bf090a4 100644
+--- a/third_party/libwebrtc/api/audio_codecs/builtin_audio_encoder_factory_gn/moz.build
++++ b/third_party/libwebrtc/api/audio_codecs/builtin_audio_encoder_factory_gn/moz.build
+@@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio_codecs/g711/audio_decoder_g711_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/g711/audio_decoder_g711_gn/moz.build
+index e1c8fa6a08bcd..132315de16c5c 100644
+--- a/third_party/libwebrtc/api/audio_codecs/g711/audio_decoder_g711_gn/moz.build
++++ b/third_party/libwebrtc/api/audio_codecs/g711/audio_decoder_g711_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio_codecs/g711/audio_encoder_g711_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/g711/audio_encoder_g711_gn/moz.build
+index 39513d15b310e..12e706e63a9a2 100644
+--- a/third_party/libwebrtc/api/audio_codecs/g711/audio_encoder_g711_gn/moz.build
++++ b/third_party/libwebrtc/api/audio_codecs/g711/audio_encoder_g711_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio_codecs/g722/audio_decoder_g722_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/g722/audio_decoder_g722_gn/moz.build
+index cf9228dcab3c2..4b5fab47cbeeb 100644
+--- a/third_party/libwebrtc/api/audio_codecs/g722/audio_decoder_g722_gn/moz.build
++++ b/third_party/libwebrtc/api/audio_codecs/g722/audio_decoder_g722_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_config_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_config_gn/moz.build
+index 3b1a814ac7b2f..aab75ab622b29 100644
+--- a/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_config_gn/moz.build
++++ b/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_config_gn/moz.build
+@@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_gn/moz.build
+index 57bdfeaf74c0e..bf6097f6d1371 100644
+--- a/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_gn/moz.build
++++ b/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio_codecs/ilbc/audio_decoder_ilbc_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/ilbc/audio_decoder_ilbc_gn/moz.build
+index ae2d4f5dc9b45..e89cb12925c3a 100644
+--- a/third_party/libwebrtc/api/audio_codecs/ilbc/audio_decoder_ilbc_gn/moz.build
++++ b/third_party/libwebrtc/api/audio_codecs/ilbc/audio_decoder_ilbc_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_config_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_config_gn/moz.build
+index 2ec1c97ea2406..f97c0e70bb9f3 100644
+--- a/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_config_gn/moz.build
++++ b/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_config_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_gn/moz.build
+index ff9d947abb855..f153ba6833814 100644
+--- a/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_gn/moz.build
++++ b/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_multiopus_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_multiopus_gn/moz.build
+index 06926f2550c69..66ab66c8f34b3 100644
+--- a/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_multiopus_gn/moz.build
++++ b/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_multiopus_gn/moz.build
+@@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_config_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_config_gn/moz.build
+index a40417692306e..c25005f9737ad 100644
+--- a/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_config_gn/moz.build
++++ b/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_config_gn/moz.build
+@@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_gn/moz.build
+index a52b290d08bcd..d131b519ffd26 100644
+--- a/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_gn/moz.build
++++ b/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_multiopus_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_multiopus_gn/moz.build
+index 1847aa9f23348..9952f0f04c168 100644
+--- a/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_multiopus_gn/moz.build
++++ b/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_multiopus_gn/moz.build
+@@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_config_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_config_gn/moz.build
+index b4ed20ad85894..895171c2d11a9 100644
+--- a/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_config_gn/moz.build
++++ b/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_config_gn/moz.build
+@@ -144,6 +144,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_gn/moz.build
+index dc73c7abc386d..8f4a2bf4f154a 100644
+--- a/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_gn/moz.build
++++ b/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/audio_options_api_gn/moz.build b/third_party/libwebrtc/api/audio_options_api_gn/moz.build
+index 974d1dbdf2c7a..0b52d3c7819f1 100644
+--- a/third_party/libwebrtc/api/audio_options_api_gn/moz.build
++++ b/third_party/libwebrtc/api/audio_options_api_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/bitrate_allocation_gn/moz.build b/third_party/libwebrtc/api/bitrate_allocation_gn/moz.build
+index 500eff54bbfd6..0daeeeffaceeb 100644
+--- a/third_party/libwebrtc/api/bitrate_allocation_gn/moz.build
++++ b/third_party/libwebrtc/api/bitrate_allocation_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/call_api_gn/moz.build b/third_party/libwebrtc/api/call_api_gn/moz.build
+index 372f0888fbba4..c694ed5d84f5a 100644
+--- a/third_party/libwebrtc/api/call_api_gn/moz.build
++++ b/third_party/libwebrtc/api/call_api_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/crypto/frame_decryptor_interface_gn/moz.build b/third_party/libwebrtc/api/crypto/frame_decryptor_interface_gn/moz.build
+index 2a9b6d96dd757..640dde634d168 100644
+--- a/third_party/libwebrtc/api/crypto/frame_decryptor_interface_gn/moz.build
++++ b/third_party/libwebrtc/api/crypto/frame_decryptor_interface_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/crypto/frame_encryptor_interface_gn/moz.build b/third_party/libwebrtc/api/crypto/frame_encryptor_interface_gn/moz.build
+index f1716e6b62674..a2119ffc20e1f 100644
+--- a/third_party/libwebrtc/api/crypto/frame_encryptor_interface_gn/moz.build
++++ b/third_party/libwebrtc/api/crypto/frame_encryptor_interface_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/crypto/options_gn/moz.build b/third_party/libwebrtc/api/crypto/options_gn/moz.build
+index fae93b139253d..eb25f7ce47a7d 100644
+--- a/third_party/libwebrtc/api/crypto/options_gn/moz.build
++++ b/third_party/libwebrtc/api/crypto/options_gn/moz.build
+@@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/environment/environment_factory_gn/moz.build b/third_party/libwebrtc/api/environment/environment_factory_gn/moz.build
+index 9388642ab5e6a..6f3bff64f1a64 100644
+--- a/third_party/libwebrtc/api/environment/environment_factory_gn/moz.build
++++ b/third_party/libwebrtc/api/environment/environment_factory_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/environment/environment_gn/moz.build b/third_party/libwebrtc/api/environment/environment_gn/moz.build
+index 5b7b361ac342f..59ebfd8ef91d1 100644
+--- a/third_party/libwebrtc/api/environment/environment_gn/moz.build
++++ b/third_party/libwebrtc/api/environment/environment_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/fec_controller_api_gn/moz.build b/third_party/libwebrtc/api/fec_controller_api_gn/moz.build
+index 653eae8f233f9..49f4eede6882d 100644
+--- a/third_party/libwebrtc/api/fec_controller_api_gn/moz.build
++++ b/third_party/libwebrtc/api/fec_controller_api_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/field_trials_registry_gn/moz.build b/third_party/libwebrtc/api/field_trials_registry_gn/moz.build
+index 76e121ec9f5ef..ea669bd624c78 100644
+--- a/third_party/libwebrtc/api/field_trials_registry_gn/moz.build
++++ b/third_party/libwebrtc/api/field_trials_registry_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/field_trials_view_gn/moz.build b/third_party/libwebrtc/api/field_trials_view_gn/moz.build
+index a6ac64bf50c65..2a3e4ded29f84 100644
+--- a/third_party/libwebrtc/api/field_trials_view_gn/moz.build
++++ b/third_party/libwebrtc/api/field_trials_view_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/frame_transformer_interface_gn/moz.build b/third_party/libwebrtc/api/frame_transformer_interface_gn/moz.build
+index 2ed19fd691d74..ad99d0d4c1649 100644
+--- a/third_party/libwebrtc/api/frame_transformer_interface_gn/moz.build
++++ b/third_party/libwebrtc/api/frame_transformer_interface_gn/moz.build
+@@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/function_view_gn/moz.build b/third_party/libwebrtc/api/function_view_gn/moz.build
+index feea8c2c0ba69..8b1ff5ec3a264 100644
+--- a/third_party/libwebrtc/api/function_view_gn/moz.build
++++ b/third_party/libwebrtc/api/function_view_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/libjingle_logging_api_gn/moz.build b/third_party/libwebrtc/api/libjingle_logging_api_gn/moz.build
+index 6729abedf9bdc..2e97c3bc61bc0 100644
+--- a/third_party/libwebrtc/api/libjingle_logging_api_gn/moz.build
++++ b/third_party/libwebrtc/api/libjingle_logging_api_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/libjingle_peerconnection_api_gn/moz.build b/third_party/libwebrtc/api/libjingle_peerconnection_api_gn/moz.build
+index f815d7da4e62c..084545fc52ea8 100644
+--- a/third_party/libwebrtc/api/libjingle_peerconnection_api_gn/moz.build
++++ b/third_party/libwebrtc/api/libjingle_peerconnection_api_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/location_gn/moz.build b/third_party/libwebrtc/api/location_gn/moz.build
+index 706b1d5026cc6..fe442cba8c1bb 100644
+--- a/third_party/libwebrtc/api/location_gn/moz.build
++++ b/third_party/libwebrtc/api/location_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/make_ref_counted_gn/moz.build b/third_party/libwebrtc/api/make_ref_counted_gn/moz.build
+index 6bedaf55cd032..0b1eb1b16cfff 100644
+--- a/third_party/libwebrtc/api/make_ref_counted_gn/moz.build
++++ b/third_party/libwebrtc/api/make_ref_counted_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/media_stream_interface_gn/moz.build b/third_party/libwebrtc/api/media_stream_interface_gn/moz.build
+index 8cc4995908e8f..75524f59d042e 100644
+--- a/third_party/libwebrtc/api/media_stream_interface_gn/moz.build
++++ b/third_party/libwebrtc/api/media_stream_interface_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/metronome/metronome_gn/moz.build b/third_party/libwebrtc/api/metronome/metronome_gn/moz.build
+index 5ffa4ac6c78f4..e26be50d5a96a 100644
+--- a/third_party/libwebrtc/api/metronome/metronome_gn/moz.build
++++ b/third_party/libwebrtc/api/metronome/metronome_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/neteq/default_neteq_controller_factory_gn/moz.build b/third_party/libwebrtc/api/neteq/default_neteq_controller_factory_gn/moz.build
+index 0486a791d10f2..ad94f63893193 100644
+--- a/third_party/libwebrtc/api/neteq/default_neteq_controller_factory_gn/moz.build
++++ b/third_party/libwebrtc/api/neteq/default_neteq_controller_factory_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/neteq/neteq_api_gn/moz.build b/third_party/libwebrtc/api/neteq/neteq_api_gn/moz.build
+index ec0207e6b81a6..ee453a5ba4923 100644
+--- a/third_party/libwebrtc/api/neteq/neteq_api_gn/moz.build
++++ b/third_party/libwebrtc/api/neteq/neteq_api_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/neteq/neteq_controller_api_gn/moz.build b/third_party/libwebrtc/api/neteq/neteq_controller_api_gn/moz.build
+index 830a41cbcb2fe..c896a2a54931b 100644
+--- a/third_party/libwebrtc/api/neteq/neteq_controller_api_gn/moz.build
++++ b/third_party/libwebrtc/api/neteq/neteq_controller_api_gn/moz.build
+@@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/neteq/tick_timer_gn/moz.build b/third_party/libwebrtc/api/neteq/tick_timer_gn/moz.build
+index 4f4101599f071..782b2f92bf77f 100644
+--- a/third_party/libwebrtc/api/neteq/tick_timer_gn/moz.build
++++ b/third_party/libwebrtc/api/neteq/tick_timer_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/network_state_predictor_api_gn/moz.build b/third_party/libwebrtc/api/network_state_predictor_api_gn/moz.build
+index 84ec637233068..00f9a3ed0f648 100644
+--- a/third_party/libwebrtc/api/network_state_predictor_api_gn/moz.build
++++ b/third_party/libwebrtc/api/network_state_predictor_api_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/priority_gn/moz.build b/third_party/libwebrtc/api/priority_gn/moz.build
+index e90b551e4d69f..15cd85663ab50 100644
+--- a/third_party/libwebrtc/api/priority_gn/moz.build
++++ b/third_party/libwebrtc/api/priority_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/ref_count_gn/moz.build b/third_party/libwebrtc/api/ref_count_gn/moz.build
+index b5ded03ae3a44..8ec15b650b3ca 100644
+--- a/third_party/libwebrtc/api/ref_count_gn/moz.build
++++ b/third_party/libwebrtc/api/ref_count_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/refcountedbase_gn/moz.build b/third_party/libwebrtc/api/refcountedbase_gn/moz.build
+index 42e693bf022a7..87e00c5de1d3e 100644
+--- a/third_party/libwebrtc/api/refcountedbase_gn/moz.build
++++ b/third_party/libwebrtc/api/refcountedbase_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/rtc_error_gn/moz.build b/third_party/libwebrtc/api/rtc_error_gn/moz.build
+index 1ff7960b4dd04..4bda31aba12f5 100644
+--- a/third_party/libwebrtc/api/rtc_error_gn/moz.build
++++ b/third_party/libwebrtc/api/rtc_error_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/rtc_event_log/rtc_event_log_gn/moz.build b/third_party/libwebrtc/api/rtc_event_log/rtc_event_log_gn/moz.build
+index e478cf3e4c3cc..e33d4042d5c35 100644
+--- a/third_party/libwebrtc/api/rtc_event_log/rtc_event_log_gn/moz.build
++++ b/third_party/libwebrtc/api/rtc_event_log/rtc_event_log_gn/moz.build
+@@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/rtp_headers_gn/moz.build b/third_party/libwebrtc/api/rtp_headers_gn/moz.build
+index 5b5cac9bf0461..5effef5b2c4e0 100644
+--- a/third_party/libwebrtc/api/rtp_headers_gn/moz.build
++++ b/third_party/libwebrtc/api/rtp_headers_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/rtp_packet_info_gn/moz.build b/third_party/libwebrtc/api/rtp_packet_info_gn/moz.build
+index 7bd7a37fb3611..0f24dd2a9bc4e 100644
+--- a/third_party/libwebrtc/api/rtp_packet_info_gn/moz.build
++++ b/third_party/libwebrtc/api/rtp_packet_info_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/rtp_parameters_gn/moz.build b/third_party/libwebrtc/api/rtp_parameters_gn/moz.build
+index ada3bfe3a22b4..2355c94b66390 100644
+--- a/third_party/libwebrtc/api/rtp_parameters_gn/moz.build
++++ b/third_party/libwebrtc/api/rtp_parameters_gn/moz.build
+@@ -144,6 +144,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/rtp_sender_interface_gn/moz.build b/third_party/libwebrtc/api/rtp_sender_interface_gn/moz.build
+index 5b41bb13cbbe3..9981f77bfc6ec 100644
+--- a/third_party/libwebrtc/api/rtp_sender_interface_gn/moz.build
++++ b/third_party/libwebrtc/api/rtp_sender_interface_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/rtp_sender_setparameters_callback_gn/moz.build b/third_party/libwebrtc/api/rtp_sender_setparameters_callback_gn/moz.build
+index 89f5c0fcc1184..46d09e7890da8 100644
+--- a/third_party/libwebrtc/api/rtp_sender_setparameters_callback_gn/moz.build
++++ b/third_party/libwebrtc/api/rtp_sender_setparameters_callback_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/rtp_transceiver_direction_gn/moz.build b/third_party/libwebrtc/api/rtp_transceiver_direction_gn/moz.build
+index c3b4e7f67e562..0c0233a8e64e4 100644
+--- a/third_party/libwebrtc/api/rtp_transceiver_direction_gn/moz.build
++++ b/third_party/libwebrtc/api/rtp_transceiver_direction_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/scoped_refptr_gn/moz.build b/third_party/libwebrtc/api/scoped_refptr_gn/moz.build
+index bd244c29b5cb2..10f1d42f76b2d 100644
+--- a/third_party/libwebrtc/api/scoped_refptr_gn/moz.build
++++ b/third_party/libwebrtc/api/scoped_refptr_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/sequence_checker_gn/moz.build b/third_party/libwebrtc/api/sequence_checker_gn/moz.build
+index e129bf8a010e9..11c8e5391fa57 100644
+--- a/third_party/libwebrtc/api/sequence_checker_gn/moz.build
++++ b/third_party/libwebrtc/api/sequence_checker_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/simulated_network_api_gn/moz.build b/third_party/libwebrtc/api/simulated_network_api_gn/moz.build
+index 222193edde3f0..e627311ebbf09 100644
+--- a/third_party/libwebrtc/api/simulated_network_api_gn/moz.build
++++ b/third_party/libwebrtc/api/simulated_network_api_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/task_queue/default_task_queue_factory_gn/moz.build b/third_party/libwebrtc/api/task_queue/default_task_queue_factory_gn/moz.build
+index 0d9947daa8ce4..77f07de263705 100644
+--- a/third_party/libwebrtc/api/task_queue/default_task_queue_factory_gn/moz.build
++++ b/third_party/libwebrtc/api/task_queue/default_task_queue_factory_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/task_queue/pending_task_safety_flag_gn/moz.build b/third_party/libwebrtc/api/task_queue/pending_task_safety_flag_gn/moz.build
+index e0e0b4688e62e..db1d874780dee 100644
+--- a/third_party/libwebrtc/api/task_queue/pending_task_safety_flag_gn/moz.build
++++ b/third_party/libwebrtc/api/task_queue/pending_task_safety_flag_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/task_queue/task_queue_gn/moz.build b/third_party/libwebrtc/api/task_queue/task_queue_gn/moz.build
+index b3eb74837f201..80617f24dd39e 100644
+--- a/third_party/libwebrtc/api/task_queue/task_queue_gn/moz.build
++++ b/third_party/libwebrtc/api/task_queue/task_queue_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/transport/bandwidth_estimation_settings_gn/moz.build b/third_party/libwebrtc/api/transport/bandwidth_estimation_settings_gn/moz.build
+index 0885f16a06553..5dd6c3a3c16e4 100644
+--- a/third_party/libwebrtc/api/transport/bandwidth_estimation_settings_gn/moz.build
++++ b/third_party/libwebrtc/api/transport/bandwidth_estimation_settings_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/transport/bitrate_settings_gn/moz.build b/third_party/libwebrtc/api/transport/bitrate_settings_gn/moz.build
+index 42410686d0beb..5a3b31c1162c5 100644
+--- a/third_party/libwebrtc/api/transport/bitrate_settings_gn/moz.build
++++ b/third_party/libwebrtc/api/transport/bitrate_settings_gn/moz.build
+@@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/transport/datagram_transport_interface_gn/moz.build b/third_party/libwebrtc/api/transport/datagram_transport_interface_gn/moz.build
+index e0f8f023787b7..a4a27afce7db4 100644
+--- a/third_party/libwebrtc/api/transport/datagram_transport_interface_gn/moz.build
++++ b/third_party/libwebrtc/api/transport/datagram_transport_interface_gn/moz.build
+@@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/transport/field_trial_based_config_gn/moz.build b/third_party/libwebrtc/api/transport/field_trial_based_config_gn/moz.build
+index 0b2e41f78c7bf..c89e0728c542a 100644
+--- a/third_party/libwebrtc/api/transport/field_trial_based_config_gn/moz.build
++++ b/third_party/libwebrtc/api/transport/field_trial_based_config_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/transport/goog_cc_gn/moz.build b/third_party/libwebrtc/api/transport/goog_cc_gn/moz.build
+index 70efa923b78f8..5d52ad1d36760 100644
+--- a/third_party/libwebrtc/api/transport/goog_cc_gn/moz.build
++++ b/third_party/libwebrtc/api/transport/goog_cc_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/transport/network_control_gn/moz.build b/third_party/libwebrtc/api/transport/network_control_gn/moz.build
+index abbedfaee9af4..7dc37c636547f 100644
+--- a/third_party/libwebrtc/api/transport/network_control_gn/moz.build
++++ b/third_party/libwebrtc/api/transport/network_control_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/transport/rtp/dependency_descriptor_gn/moz.build b/third_party/libwebrtc/api/transport/rtp/dependency_descriptor_gn/moz.build
+index 16ec75fa0170d..777afccd30656 100644
+--- a/third_party/libwebrtc/api/transport/rtp/dependency_descriptor_gn/moz.build
++++ b/third_party/libwebrtc/api/transport/rtp/dependency_descriptor_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/transport/rtp/rtp_source_gn/moz.build b/third_party/libwebrtc/api/transport/rtp/rtp_source_gn/moz.build
+index 83c88e8037fe7..c171d5eaae727 100644
+--- a/third_party/libwebrtc/api/transport/rtp/rtp_source_gn/moz.build
++++ b/third_party/libwebrtc/api/transport/rtp/rtp_source_gn/moz.build
+@@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/transport/stun_types_gn/moz.build b/third_party/libwebrtc/api/transport/stun_types_gn/moz.build
+index 51a16e295eef0..67f3481ac3f72 100644
+--- a/third_party/libwebrtc/api/transport/stun_types_gn/moz.build
++++ b/third_party/libwebrtc/api/transport/stun_types_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/transport_api_gn/moz.build b/third_party/libwebrtc/api/transport_api_gn/moz.build
+index a726caad2813e..1583c32e678d9 100644
+--- a/third_party/libwebrtc/api/transport_api_gn/moz.build
++++ b/third_party/libwebrtc/api/transport_api_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/units/data_rate_gn/moz.build b/third_party/libwebrtc/api/units/data_rate_gn/moz.build
+index 398b03d0a231e..6e9d5a3220072 100644
+--- a/third_party/libwebrtc/api/units/data_rate_gn/moz.build
++++ b/third_party/libwebrtc/api/units/data_rate_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/units/data_size_gn/moz.build b/third_party/libwebrtc/api/units/data_size_gn/moz.build
+index 8f61d01314631..4be1545e6b243 100644
+--- a/third_party/libwebrtc/api/units/data_size_gn/moz.build
++++ b/third_party/libwebrtc/api/units/data_size_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/units/frequency_gn/moz.build b/third_party/libwebrtc/api/units/frequency_gn/moz.build
+index 40a6bf2617104..30b302563cdef 100644
+--- a/third_party/libwebrtc/api/units/frequency_gn/moz.build
++++ b/third_party/libwebrtc/api/units/frequency_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/units/time_delta_gn/moz.build b/third_party/libwebrtc/api/units/time_delta_gn/moz.build
+index d9ede8c812f23..fbc69252d87c0 100644
+--- a/third_party/libwebrtc/api/units/time_delta_gn/moz.build
++++ b/third_party/libwebrtc/api/units/time_delta_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/units/timestamp_gn/moz.build b/third_party/libwebrtc/api/units/timestamp_gn/moz.build
+index 9e5ed8541e578..b1ac1b772c675 100644
+--- a/third_party/libwebrtc/api/units/timestamp_gn/moz.build
++++ b/third_party/libwebrtc/api/units/timestamp_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/video/builtin_video_bitrate_allocator_factory_gn/moz.build b/third_party/libwebrtc/api/video/builtin_video_bitrate_allocator_factory_gn/moz.build
+index cafafadf4452d..a085a657952c8 100644
+--- a/third_party/libwebrtc/api/video/builtin_video_bitrate_allocator_factory_gn/moz.build
++++ b/third_party/libwebrtc/api/video/builtin_video_bitrate_allocator_factory_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/video/encoded_frame_gn/moz.build b/third_party/libwebrtc/api/video/encoded_frame_gn/moz.build
+index d804e2fd36718..f21f8b55cf1c8 100644
+--- a/third_party/libwebrtc/api/video/encoded_frame_gn/moz.build
++++ b/third_party/libwebrtc/api/video/encoded_frame_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/video/encoded_image_gn/moz.build b/third_party/libwebrtc/api/video/encoded_image_gn/moz.build
+index a444a71189b96..a3ef10fcda796 100644
+--- a/third_party/libwebrtc/api/video/encoded_image_gn/moz.build
++++ b/third_party/libwebrtc/api/video/encoded_image_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/video/frame_buffer_gn/moz.build b/third_party/libwebrtc/api/video/frame_buffer_gn/moz.build
+index 01a33c4b813fc..8a7e83234f242 100644
+--- a/third_party/libwebrtc/api/video/frame_buffer_gn/moz.build
++++ b/third_party/libwebrtc/api/video/frame_buffer_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/video/recordable_encoded_frame_gn/moz.build b/third_party/libwebrtc/api/video/recordable_encoded_frame_gn/moz.build
+index 4d6199a71433e..b0203be91a91f 100644
+--- a/third_party/libwebrtc/api/video/recordable_encoded_frame_gn/moz.build
++++ b/third_party/libwebrtc/api/video/recordable_encoded_frame_gn/moz.build
+@@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/video/render_resolution_gn/moz.build b/third_party/libwebrtc/api/video/render_resolution_gn/moz.build
+index a0c4da6d58091..15ae70c2156ac 100644
+--- a/third_party/libwebrtc/api/video/render_resolution_gn/moz.build
++++ b/third_party/libwebrtc/api/video/render_resolution_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/video/resolution_gn/moz.build b/third_party/libwebrtc/api/video/resolution_gn/moz.build
+index e55dfe7d2c222..fe470816b693e 100644
+--- a/third_party/libwebrtc/api/video/resolution_gn/moz.build
++++ b/third_party/libwebrtc/api/video/resolution_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/video/video_adaptation_gn/moz.build b/third_party/libwebrtc/api/video/video_adaptation_gn/moz.build
+index c061e657ab8a0..4788ea5e553c9 100644
+--- a/third_party/libwebrtc/api/video/video_adaptation_gn/moz.build
++++ b/third_party/libwebrtc/api/video/video_adaptation_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/video/video_bitrate_allocation_gn/moz.build b/third_party/libwebrtc/api/video/video_bitrate_allocation_gn/moz.build
+index 9581b4202af92..9c1413b14f181 100644
+--- a/third_party/libwebrtc/api/video/video_bitrate_allocation_gn/moz.build
++++ b/third_party/libwebrtc/api/video/video_bitrate_allocation_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/video/video_bitrate_allocator_factory_gn/moz.build b/third_party/libwebrtc/api/video/video_bitrate_allocator_factory_gn/moz.build
+index 71a1a7f2dc3e5..fe3788112df32 100644
+--- a/third_party/libwebrtc/api/video/video_bitrate_allocator_factory_gn/moz.build
++++ b/third_party/libwebrtc/api/video/video_bitrate_allocator_factory_gn/moz.build
+@@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/video/video_bitrate_allocator_gn/moz.build b/third_party/libwebrtc/api/video/video_bitrate_allocator_gn/moz.build
+index aecab75d2eacd..fea9f428f2bef 100644
+--- a/third_party/libwebrtc/api/video/video_bitrate_allocator_gn/moz.build
++++ b/third_party/libwebrtc/api/video/video_bitrate_allocator_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/video/video_codec_constants_gn/moz.build b/third_party/libwebrtc/api/video/video_codec_constants_gn/moz.build
+index 1ff8d8117fa60..9b78d2d8311fa 100644
+--- a/third_party/libwebrtc/api/video/video_codec_constants_gn/moz.build
++++ b/third_party/libwebrtc/api/video/video_codec_constants_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/video/video_frame_gn/moz.build b/third_party/libwebrtc/api/video/video_frame_gn/moz.build
+index 37f7adf1843d4..a44a5b3c64879 100644
+--- a/third_party/libwebrtc/api/video/video_frame_gn/moz.build
++++ b/third_party/libwebrtc/api/video/video_frame_gn/moz.build
+@@ -161,6 +161,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/video/video_frame_i010_gn/moz.build b/third_party/libwebrtc/api/video/video_frame_i010_gn/moz.build
+index 2b8bd493aff92..b2459fc0d73a4 100644
+--- a/third_party/libwebrtc/api/video/video_frame_i010_gn/moz.build
++++ b/third_party/libwebrtc/api/video/video_frame_i010_gn/moz.build
+@@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/video/video_frame_metadata_gn/moz.build b/third_party/libwebrtc/api/video/video_frame_metadata_gn/moz.build
+index 8b4bd96df2395..2cd46e22441c6 100644
+--- a/third_party/libwebrtc/api/video/video_frame_metadata_gn/moz.build
++++ b/third_party/libwebrtc/api/video/video_frame_metadata_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/video/video_frame_type_gn/moz.build b/third_party/libwebrtc/api/video/video_frame_type_gn/moz.build
+index 3416d040b2eaa..f5951d6e30cd7 100644
+--- a/third_party/libwebrtc/api/video/video_frame_type_gn/moz.build
++++ b/third_party/libwebrtc/api/video/video_frame_type_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/video/video_layers_allocation_gn/moz.build b/third_party/libwebrtc/api/video/video_layers_allocation_gn/moz.build
+index d9d7097f2f893..e6f9710eda5de 100644
+--- a/third_party/libwebrtc/api/video/video_layers_allocation_gn/moz.build
++++ b/third_party/libwebrtc/api/video/video_layers_allocation_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/video/video_rtp_headers_gn/moz.build b/third_party/libwebrtc/api/video/video_rtp_headers_gn/moz.build
+index 7c696af228c61..609b8f3c2047b 100644
+--- a/third_party/libwebrtc/api/video/video_rtp_headers_gn/moz.build
++++ b/third_party/libwebrtc/api/video/video_rtp_headers_gn/moz.build
+@@ -153,6 +153,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/video/video_stream_encoder_gn/moz.build b/third_party/libwebrtc/api/video/video_stream_encoder_gn/moz.build
+index f54c465004454..b7874ea832174 100644
+--- a/third_party/libwebrtc/api/video/video_stream_encoder_gn/moz.build
++++ b/third_party/libwebrtc/api/video/video_stream_encoder_gn/moz.build
+@@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/video_codecs/bitstream_parser_api_gn/moz.build b/third_party/libwebrtc/api/video_codecs/bitstream_parser_api_gn/moz.build
+index b1bb1e3323e8e..96630db641217 100644
+--- a/third_party/libwebrtc/api/video_codecs/bitstream_parser_api_gn/moz.build
++++ b/third_party/libwebrtc/api/video_codecs/bitstream_parser_api_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/video_codecs/rtc_software_fallback_wrappers_gn/moz.build b/third_party/libwebrtc/api/video_codecs/rtc_software_fallback_wrappers_gn/moz.build
+index ca9c0f599a999..8b4f3c069f582 100644
+--- a/third_party/libwebrtc/api/video_codecs/rtc_software_fallback_wrappers_gn/moz.build
++++ b/third_party/libwebrtc/api/video_codecs/rtc_software_fallback_wrappers_gn/moz.build
+@@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/video_codecs/scalability_mode_gn/moz.build b/third_party/libwebrtc/api/video_codecs/scalability_mode_gn/moz.build
+index b0c90b8ad2eef..bcec657a2e8a4 100644
+--- a/third_party/libwebrtc/api/video_codecs/scalability_mode_gn/moz.build
++++ b/third_party/libwebrtc/api/video_codecs/scalability_mode_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/video_codecs/video_codecs_api_gn/moz.build b/third_party/libwebrtc/api/video_codecs/video_codecs_api_gn/moz.build
+index f3060e020af9d..b06f0a61bb834 100644
+--- a/third_party/libwebrtc/api/video_codecs/video_codecs_api_gn/moz.build
++++ b/third_party/libwebrtc/api/video_codecs/video_codecs_api_gn/moz.build
+@@ -160,6 +160,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/video_codecs/vp8_temporal_layers_factory_gn/moz.build b/third_party/libwebrtc/api/video_codecs/vp8_temporal_layers_factory_gn/moz.build
+index 3940914214498..f404af52ff917 100644
+--- a/third_party/libwebrtc/api/video_codecs/vp8_temporal_layers_factory_gn/moz.build
++++ b/third_party/libwebrtc/api/video_codecs/vp8_temporal_layers_factory_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/video_track_source_constraints_gn/moz.build b/third_party/libwebrtc/api/video_track_source_constraints_gn/moz.build
+index 636a3df69c9a7..6c8dc9ed7bf37 100644
+--- a/third_party/libwebrtc/api/video_track_source_constraints_gn/moz.build
++++ b/third_party/libwebrtc/api/video_track_source_constraints_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/audio/audio_gn/moz.build b/third_party/libwebrtc/audio/audio_gn/moz.build
+index 2888ef09bd9b4..8cd43e9caa678 100644
+--- a/third_party/libwebrtc/audio/audio_gn/moz.build
++++ b/third_party/libwebrtc/audio/audio_gn/moz.build
+@@ -167,6 +167,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/audio/utility/audio_frame_operations_gn/moz.build b/third_party/libwebrtc/audio/utility/audio_frame_operations_gn/moz.build
+index 315f691f3e09f..46997a10da7aa 100644
+--- a/third_party/libwebrtc/audio/utility/audio_frame_operations_gn/moz.build
++++ b/third_party/libwebrtc/audio/utility/audio_frame_operations_gn/moz.build
+@@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/call/adaptation/resource_adaptation_gn/moz.build b/third_party/libwebrtc/call/adaptation/resource_adaptation_gn/moz.build
+index 3dab96b5a3720..16d001bc0f420 100644
+--- a/third_party/libwebrtc/call/adaptation/resource_adaptation_gn/moz.build
++++ b/third_party/libwebrtc/call/adaptation/resource_adaptation_gn/moz.build
+@@ -164,6 +164,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/call/audio_sender_interface_gn/moz.build b/third_party/libwebrtc/call/audio_sender_interface_gn/moz.build
+index 6ca0ee7739978..ba943f674bdf6 100644
+--- a/third_party/libwebrtc/call/audio_sender_interface_gn/moz.build
++++ b/third_party/libwebrtc/call/audio_sender_interface_gn/moz.build
+@@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/call/bitrate_allocator_gn/moz.build b/third_party/libwebrtc/call/bitrate_allocator_gn/moz.build
+index 57adb400db542..053203704dd3e 100644
+--- a/third_party/libwebrtc/call/bitrate_allocator_gn/moz.build
++++ b/third_party/libwebrtc/call/bitrate_allocator_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/call/bitrate_configurator_gn/moz.build b/third_party/libwebrtc/call/bitrate_configurator_gn/moz.build
+index 59f87d2fdf4da..d3838013378c0 100644
+--- a/third_party/libwebrtc/call/bitrate_configurator_gn/moz.build
++++ b/third_party/libwebrtc/call/bitrate_configurator_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/call/call_gn/moz.build b/third_party/libwebrtc/call/call_gn/moz.build
+index da452122ce12a..db896312b03e7 100644
+--- a/third_party/libwebrtc/call/call_gn/moz.build
++++ b/third_party/libwebrtc/call/call_gn/moz.build
+@@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/call/call_interfaces_gn/moz.build b/third_party/libwebrtc/call/call_interfaces_gn/moz.build
+index 3c7b6a05d3ab3..a3f85dc6dc448 100644
+--- a/third_party/libwebrtc/call/call_interfaces_gn/moz.build
++++ b/third_party/libwebrtc/call/call_interfaces_gn/moz.build
+@@ -161,6 +161,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/call/receive_stream_interface_gn/moz.build b/third_party/libwebrtc/call/receive_stream_interface_gn/moz.build
+index 0b3511082a519..79a9228856cf8 100644
+--- a/third_party/libwebrtc/call/receive_stream_interface_gn/moz.build
++++ b/third_party/libwebrtc/call/receive_stream_interface_gn/moz.build
+@@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/call/rtp_interfaces_gn/moz.build b/third_party/libwebrtc/call/rtp_interfaces_gn/moz.build
+index f2fb2ab649bbc..d138865b6812e 100644
+--- a/third_party/libwebrtc/call/rtp_interfaces_gn/moz.build
++++ b/third_party/libwebrtc/call/rtp_interfaces_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/call/rtp_receiver_gn/moz.build b/third_party/libwebrtc/call/rtp_receiver_gn/moz.build
+index 35c68ca3368d3..e1889430418c3 100644
+--- a/third_party/libwebrtc/call/rtp_receiver_gn/moz.build
++++ b/third_party/libwebrtc/call/rtp_receiver_gn/moz.build
+@@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/call/rtp_sender_gn/moz.build b/third_party/libwebrtc/call/rtp_sender_gn/moz.build
+index c99d9d8e8a667..d2ef2c26bf50d 100644
+--- a/third_party/libwebrtc/call/rtp_sender_gn/moz.build
++++ b/third_party/libwebrtc/call/rtp_sender_gn/moz.build
+@@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/call/version_gn/moz.build b/third_party/libwebrtc/call/version_gn/moz.build
+index 50ff0cff2e551..c048f48b9985a 100644
+--- a/third_party/libwebrtc/call/version_gn/moz.build
++++ b/third_party/libwebrtc/call/version_gn/moz.build
+@@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/call/video_stream_api_gn/moz.build b/third_party/libwebrtc/call/video_stream_api_gn/moz.build
+index 9aa475a12fc68..2f75e5afadd55 100644
+--- a/third_party/libwebrtc/call/video_stream_api_gn/moz.build
++++ b/third_party/libwebrtc/call/video_stream_api_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/common_audio/common_audio_c_arm_asm_gn/moz.build b/third_party/libwebrtc/common_audio/common_audio_c_arm_asm_gn/moz.build
+index 0827bbf31a410..9c26089f8adee 100644
+--- a/third_party/libwebrtc/common_audio/common_audio_c_arm_asm_gn/moz.build
++++ b/third_party/libwebrtc/common_audio/common_audio_c_arm_asm_gn/moz.build
+@@ -136,6 +136,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+         "/third_party/libwebrtc/common_audio/signal_processing/filter_ar_fast_q12_armv7.S"
+     ]
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/common_audio/common_audio_c_gn/moz.build b/third_party/libwebrtc/common_audio/common_audio_c_gn/moz.build
+index 99cceabf2989f..247ada76caf0e 100644
+--- a/third_party/libwebrtc/common_audio/common_audio_c_gn/moz.build
++++ b/third_party/libwebrtc/common_audio/common_audio_c_gn/moz.build
+@@ -213,6 +213,16 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
++    UNIFIED_SOURCES += [
++        "/third_party/libwebrtc/common_audio/signal_processing/complex_bit_reverse.c",
++        "/third_party/libwebrtc/common_audio/signal_processing/complex_fft.c",
++        "/third_party/libwebrtc/common_audio/signal_processing/filter_ar_fast_q12.c"
++    ]
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/common_audio/common_audio_cc_gn/moz.build b/third_party/libwebrtc/common_audio/common_audio_cc_gn/moz.build
+index 1ab56ac809181..7c54dfade59b7 100644
+--- a/third_party/libwebrtc/common_audio/common_audio_cc_gn/moz.build
++++ b/third_party/libwebrtc/common_audio/common_audio_cc_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/common_audio/common_audio_gn/moz.build b/third_party/libwebrtc/common_audio/common_audio_gn/moz.build
+index 79a78f7837942..c4e0d5b97304a 100644
+--- a/third_party/libwebrtc/common_audio/common_audio_gn/moz.build
++++ b/third_party/libwebrtc/common_audio/common_audio_gn/moz.build
+@@ -167,6 +167,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/common_audio/fir_filter_factory_gn/moz.build b/third_party/libwebrtc/common_audio/fir_filter_factory_gn/moz.build
+index 2faac2a93134b..8ce1283652b77 100644
+--- a/third_party/libwebrtc/common_audio/fir_filter_factory_gn/moz.build
++++ b/third_party/libwebrtc/common_audio/fir_filter_factory_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/common_audio/fir_filter_gn/moz.build b/third_party/libwebrtc/common_audio/fir_filter_gn/moz.build
+index af029033e761d..66ffa7f1c4d19 100644
+--- a/third_party/libwebrtc/common_audio/fir_filter_gn/moz.build
++++ b/third_party/libwebrtc/common_audio/fir_filter_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/common_audio/sinc_resampler_gn/moz.build b/third_party/libwebrtc/common_audio/sinc_resampler_gn/moz.build
+index 962dbed44bf80..fbe78886f96fd 100644
+--- a/third_party/libwebrtc/common_audio/sinc_resampler_gn/moz.build
++++ b/third_party/libwebrtc/common_audio/sinc_resampler_gn/moz.build
+@@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_128_gn/moz.build b/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_128_gn/moz.build
+index 6245fdf7ef932..60598ae2b1089 100644
+--- a/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_128_gn/moz.build
++++ b/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_128_gn/moz.build
+@@ -162,6 +162,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+         "/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_128/ooura_fft_neon.cc"
+     ]
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_256_gn/moz.build b/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_256_gn/moz.build
+index 7c2503bc9ccd5..964be76261da5 100644
+--- a/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_256_gn/moz.build
++++ b/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_256_gn/moz.build
+@@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/common_audio/third_party/spl_sqrt_floor/spl_sqrt_floor_gn/moz.build b/third_party/libwebrtc/common_audio/third_party/spl_sqrt_floor/spl_sqrt_floor_gn/moz.build
+index ec09e725fff76..424d4cd5b263f 100644
+--- a/third_party/libwebrtc/common_audio/third_party/spl_sqrt_floor/spl_sqrt_floor_gn/moz.build
++++ b/third_party/libwebrtc/common_audio/third_party/spl_sqrt_floor/spl_sqrt_floor_gn/moz.build
+@@ -147,6 +147,14 @@ if CONFIG["TARGET_CPU"] == "arm":
+         "/third_party/libwebrtc/common_audio/third_party/spl_sqrt_floor/spl_sqrt_floor_arm.S"
+     ]
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
++    UNIFIED_SOURCES += [
++        "/third_party/libwebrtc/common_audio/third_party/spl_sqrt_floor/spl_sqrt_floor.c"
++    ]
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/common_video/common_video_gn/moz.build b/third_party/libwebrtc/common_video/common_video_gn/moz.build
+index fb64d190c30d1..02b32a6d4daaa 100644
+--- a/third_party/libwebrtc/common_video/common_video_gn/moz.build
++++ b/third_party/libwebrtc/common_video/common_video_gn/moz.build
+@@ -162,6 +162,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/common_video/frame_counts_gn/moz.build b/third_party/libwebrtc/common_video/frame_counts_gn/moz.build
+index 08c88c4702cf3..b23c38bd683c0 100644
+--- a/third_party/libwebrtc/common_video/frame_counts_gn/moz.build
++++ b/third_party/libwebrtc/common_video/frame_counts_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/common_video/generic_frame_descriptor/generic_frame_descriptor_gn/moz.build b/third_party/libwebrtc/common_video/generic_frame_descriptor/generic_frame_descriptor_gn/moz.build
+index b16531fbf8e27..4c983cdd33754 100644
+--- a/third_party/libwebrtc/common_video/generic_frame_descriptor/generic_frame_descriptor_gn/moz.build
++++ b/third_party/libwebrtc/common_video/generic_frame_descriptor/generic_frame_descriptor_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/experiments/registered_field_trials_gn/moz.build b/third_party/libwebrtc/experiments/registered_field_trials_gn/moz.build
+index 5e1ddc355d5b3..f54ba694b9795 100644
+--- a/third_party/libwebrtc/experiments/registered_field_trials_gn/moz.build
++++ b/third_party/libwebrtc/experiments/registered_field_trials_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/logging/rtc_event_audio_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_audio_gn/moz.build
+index bf124013de2a6..5ccc734ffb632 100644
+--- a/third_party/libwebrtc/logging/rtc_event_audio_gn/moz.build
++++ b/third_party/libwebrtc/logging/rtc_event_audio_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/logging/rtc_event_bwe_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_bwe_gn/moz.build
+index c7c2a5f880332..2b655652cf267 100644
+--- a/third_party/libwebrtc/logging/rtc_event_bwe_gn/moz.build
++++ b/third_party/libwebrtc/logging/rtc_event_bwe_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/logging/rtc_event_field_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_field_gn/moz.build
+index 630358f349426..505d38c743e66 100644
+--- a/third_party/libwebrtc/logging/rtc_event_field_gn/moz.build
++++ b/third_party/libwebrtc/logging/rtc_event_field_gn/moz.build
+@@ -153,6 +153,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/logging/rtc_event_log_parse_status_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_log_parse_status_gn/moz.build
+index 46e013a0d4d4c..67413d361af9b 100644
+--- a/third_party/libwebrtc/logging/rtc_event_log_parse_status_gn/moz.build
++++ b/third_party/libwebrtc/logging/rtc_event_log_parse_status_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/logging/rtc_event_number_encodings_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_number_encodings_gn/moz.build
+index 4c491af3963ce..22760a576252e 100644
+--- a/third_party/libwebrtc/logging/rtc_event_number_encodings_gn/moz.build
++++ b/third_party/libwebrtc/logging/rtc_event_number_encodings_gn/moz.build
+@@ -145,6 +145,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/logging/rtc_event_pacing_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_pacing_gn/moz.build
+index aec4465f8ac37..4c8b44223ce63 100644
+--- a/third_party/libwebrtc/logging/rtc_event_pacing_gn/moz.build
++++ b/third_party/libwebrtc/logging/rtc_event_pacing_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/logging/rtc_event_rtp_rtcp_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_rtp_rtcp_gn/moz.build
+index 3edc922b8f08f..bda2020ffebbb 100644
+--- a/third_party/libwebrtc/logging/rtc_event_rtp_rtcp_gn/moz.build
++++ b/third_party/libwebrtc/logging/rtc_event_rtp_rtcp_gn/moz.build
+@@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/logging/rtc_event_video_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_video_gn/moz.build
+index 616e73dcf5ec0..bcbf391a109f4 100644
+--- a/third_party/libwebrtc/logging/rtc_event_video_gn/moz.build
++++ b/third_party/libwebrtc/logging/rtc_event_video_gn/moz.build
+@@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/logging/rtc_stream_config_gn/moz.build b/third_party/libwebrtc/logging/rtc_stream_config_gn/moz.build
+index 6fd95dde97d0e..fa2bb3837f814 100644
+--- a/third_party/libwebrtc/logging/rtc_stream_config_gn/moz.build
++++ b/third_party/libwebrtc/logging/rtc_stream_config_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/media/adapted_video_track_source_gn/moz.build b/third_party/libwebrtc/media/adapted_video_track_source_gn/moz.build
+index 1cb4f853abba1..bd46fcffc0b43 100644
+--- a/third_party/libwebrtc/media/adapted_video_track_source_gn/moz.build
++++ b/third_party/libwebrtc/media/adapted_video_track_source_gn/moz.build
+@@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/media/codec_gn/moz.build b/third_party/libwebrtc/media/codec_gn/moz.build
+index cf10ada0cf66b..b749cab4375c4 100644
+--- a/third_party/libwebrtc/media/codec_gn/moz.build
++++ b/third_party/libwebrtc/media/codec_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/media/media_channel_gn/moz.build b/third_party/libwebrtc/media/media_channel_gn/moz.build
+index fc0c50aa726b4..9449c00102e37 100644
+--- a/third_party/libwebrtc/media/media_channel_gn/moz.build
++++ b/third_party/libwebrtc/media/media_channel_gn/moz.build
+@@ -147,6 +147,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/media/media_channel_impl_gn/moz.build b/third_party/libwebrtc/media/media_channel_impl_gn/moz.build
+index b7db93813a60b..5f0b214ebcd7a 100644
+--- a/third_party/libwebrtc/media/media_channel_impl_gn/moz.build
++++ b/third_party/libwebrtc/media/media_channel_impl_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/media/media_constants_gn/moz.build b/third_party/libwebrtc/media/media_constants_gn/moz.build
+index fb7440ec4a070..08c077d93411f 100644
+--- a/third_party/libwebrtc/media/media_constants_gn/moz.build
++++ b/third_party/libwebrtc/media/media_constants_gn/moz.build
+@@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/media/rid_description_gn/moz.build b/third_party/libwebrtc/media/rid_description_gn/moz.build
+index 22f56f08a780b..c604820208e3e 100644
+--- a/third_party/libwebrtc/media/rid_description_gn/moz.build
++++ b/third_party/libwebrtc/media/rid_description_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/media/rtc_media_base_gn/moz.build b/third_party/libwebrtc/media/rtc_media_base_gn/moz.build
+index eb9cb4e29d040..4f7284c512d5b 100644
+--- a/third_party/libwebrtc/media/rtc_media_base_gn/moz.build
++++ b/third_party/libwebrtc/media/rtc_media_base_gn/moz.build
+@@ -147,6 +147,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/media/rtc_media_config_gn/moz.build b/third_party/libwebrtc/media/rtc_media_config_gn/moz.build
+index 4b6ba11d76811..2c88fd713531c 100644
+--- a/third_party/libwebrtc/media/rtc_media_config_gn/moz.build
++++ b/third_party/libwebrtc/media/rtc_media_config_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/media/rtc_sdp_video_format_utils_gn/moz.build b/third_party/libwebrtc/media/rtc_sdp_video_format_utils_gn/moz.build
+index 10b08d64fbe20..e9691926eb785 100644
+--- a/third_party/libwebrtc/media/rtc_sdp_video_format_utils_gn/moz.build
++++ b/third_party/libwebrtc/media/rtc_sdp_video_format_utils_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/media/rtc_simulcast_encoder_adapter_gn/moz.build b/third_party/libwebrtc/media/rtc_simulcast_encoder_adapter_gn/moz.build
+index 1929dd6e9399b..21c90c720512f 100644
+--- a/third_party/libwebrtc/media/rtc_simulcast_encoder_adapter_gn/moz.build
++++ b/third_party/libwebrtc/media/rtc_simulcast_encoder_adapter_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/media/rtp_utils_gn/moz.build b/third_party/libwebrtc/media/rtp_utils_gn/moz.build
+index 22b3cc9d64615..8bbe127ddbb5a 100644
+--- a/third_party/libwebrtc/media/rtp_utils_gn/moz.build
++++ b/third_party/libwebrtc/media/rtp_utils_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/media/stream_params_gn/moz.build b/third_party/libwebrtc/media/stream_params_gn/moz.build
+index 67ed8e9a461d0..389484ae5a68b 100644
+--- a/third_party/libwebrtc/media/stream_params_gn/moz.build
++++ b/third_party/libwebrtc/media/stream_params_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/media/video_adapter_gn/moz.build b/third_party/libwebrtc/media/video_adapter_gn/moz.build
+index 1ce6badaf84c0..8fbf5bde01ee7 100644
+--- a/third_party/libwebrtc/media/video_adapter_gn/moz.build
++++ b/third_party/libwebrtc/media/video_adapter_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/media/video_broadcaster_gn/moz.build b/third_party/libwebrtc/media/video_broadcaster_gn/moz.build
+index c1ebd4508d5a5..0efea5fbdb49a 100644
+--- a/third_party/libwebrtc/media/video_broadcaster_gn/moz.build
++++ b/third_party/libwebrtc/media/video_broadcaster_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/media/video_common_gn/moz.build b/third_party/libwebrtc/media/video_common_gn/moz.build
+index b99fdbd294469..f8eb593f9d784 100644
+--- a/third_party/libwebrtc/media/video_common_gn/moz.build
++++ b/third_party/libwebrtc/media/video_common_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/media/video_source_base_gn/moz.build b/third_party/libwebrtc/media/video_source_base_gn/moz.build
+index b74ce609e95fd..b5d0dba31c190 100644
+--- a/third_party/libwebrtc/media/video_source_base_gn/moz.build
++++ b/third_party/libwebrtc/media/video_source_base_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/async_audio_processing/async_audio_processing_gn/moz.build b/third_party/libwebrtc/modules/async_audio_processing/async_audio_processing_gn/moz.build
+index 495a5d8cac13f..fbaede458a8fc 100644
+--- a/third_party/libwebrtc/modules/async_audio_processing/async_audio_processing_gn/moz.build
++++ b/third_party/libwebrtc/modules/async_audio_processing/async_audio_processing_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_coding/audio_coding_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/audio_coding_gn/moz.build
+index 995b2a2a3b312..6e189825b8932 100644
+--- a/third_party/libwebrtc/modules/audio_coding/audio_coding_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_coding/audio_coding_gn/moz.build
+@@ -158,6 +158,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_coding/audio_coding_module_typedefs_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/audio_coding_module_typedefs_gn/moz.build
+index 470578709e2fb..182b02b3ac5bf 100644
+--- a/third_party/libwebrtc/modules/audio_coding/audio_coding_module_typedefs_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_coding/audio_coding_module_typedefs_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_coding/audio_coding_opus_common_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/audio_coding_opus_common_gn/moz.build
+index e484426fd2ab9..b6195f87e0fd3 100644
+--- a/third_party/libwebrtc/modules/audio_coding/audio_coding_opus_common_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_coding/audio_coding_opus_common_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_coding/audio_encoder_cng_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/audio_encoder_cng_gn/moz.build
+index 1e7e932b55da3..87d4e2c3a375e 100644
+--- a/third_party/libwebrtc/modules/audio_coding/audio_encoder_cng_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_coding/audio_encoder_cng_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_config_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_config_gn/moz.build
+index 92221fcca1a0c..5a2f9abe5853c 100644
+--- a/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_config_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_config_gn/moz.build
+@@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_gn/moz.build
+index cb6c943d7c377..842e71ab1e052 100644
+--- a/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_gn/moz.build
+@@ -164,6 +164,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_coding/default_neteq_factory_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/default_neteq_factory_gn/moz.build
+index a0d24b9a5d28d..5254b2ec5016e 100644
+--- a/third_party/libwebrtc/modules/audio_coding/default_neteq_factory_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_coding/default_neteq_factory_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_coding/g711_c_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/g711_c_gn/moz.build
+index dcf3567d5c55e..81256b0baa340 100644
+--- a/third_party/libwebrtc/modules/audio_coding/g711_c_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_coding/g711_c_gn/moz.build
+@@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_coding/g711_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/g711_gn/moz.build
+index b6962f1786abe..67ffd22812d3b 100644
+--- a/third_party/libwebrtc/modules/audio_coding/g711_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_coding/g711_gn/moz.build
+@@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_coding/g722_c_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/g722_c_gn/moz.build
+index 99188c0a58336..99f4403cfc64a 100644
+--- a/third_party/libwebrtc/modules/audio_coding/g722_c_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_coding/g722_c_gn/moz.build
+@@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_coding/g722_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/g722_gn/moz.build
+index 56ac627776c96..7c1e7e68d34c0 100644
+--- a/third_party/libwebrtc/modules/audio_coding/g722_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_coding/g722_gn/moz.build
+@@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_coding/ilbc_c_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/ilbc_c_gn/moz.build
+index 9c374405df33c..f4cd791e9f317 100644
+--- a/third_party/libwebrtc/modules/audio_coding/ilbc_c_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_coding/ilbc_c_gn/moz.build
+@@ -222,6 +222,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_coding/ilbc_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/ilbc_gn/moz.build
+index f3546882a1a3a..93cd8f1d5ce9c 100644
+--- a/third_party/libwebrtc/modules/audio_coding/ilbc_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_coding/ilbc_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_coding/isac_bwinfo_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/isac_bwinfo_gn/moz.build
+index c0b5ae4a7a4c4..8753166af0278 100644
+--- a/third_party/libwebrtc/modules/audio_coding/isac_bwinfo_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_coding/isac_bwinfo_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_coding/isac_vad_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/isac_vad_gn/moz.build
+index 15040244a1180..fe5c0c394ec86 100644
+--- a/third_party/libwebrtc/modules/audio_coding/isac_vad_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_coding/isac_vad_gn/moz.build
+@@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_coding/legacy_encoded_audio_frame_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/legacy_encoded_audio_frame_gn/moz.build
+index c03333a31981d..beadda7e8a919 100644
+--- a/third_party/libwebrtc/modules/audio_coding/legacy_encoded_audio_frame_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_coding/legacy_encoded_audio_frame_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_coding/neteq_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/neteq_gn/moz.build
+index a017d70518e73..0f2809ec51ba9 100644
+--- a/third_party/libwebrtc/modules/audio_coding/neteq_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_coding/neteq_gn/moz.build
+@@ -188,6 +188,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_coding/pcm16b_c_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/pcm16b_c_gn/moz.build
+index 1e7a8e8f65600..d9941475969b5 100644
+--- a/third_party/libwebrtc/modules/audio_coding/pcm16b_c_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_coding/pcm16b_c_gn/moz.build
+@@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_coding/pcm16b_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/pcm16b_gn/moz.build
+index 2a2a2542335ba..2a25d447216c2 100644
+--- a/third_party/libwebrtc/modules/audio_coding/pcm16b_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_coding/pcm16b_gn/moz.build
+@@ -152,6 +152,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_coding/red_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/red_gn/moz.build
+index 02ef2ce08e9c7..01928268a17a1 100644
+--- a/third_party/libwebrtc/modules/audio_coding/red_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_coding/red_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_coding/webrtc_cng_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/webrtc_cng_gn/moz.build
+index 02f3bf49e1c10..edb2870971b35 100644
+--- a/third_party/libwebrtc/modules/audio_coding/webrtc_cng_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_coding/webrtc_cng_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_coding/webrtc_multiopus_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/webrtc_multiopus_gn/moz.build
+index 9665cd22c68e0..7e110948ffd57 100644
+--- a/third_party/libwebrtc/modules/audio_coding/webrtc_multiopus_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_coding/webrtc_multiopus_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_coding/webrtc_opus_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/webrtc_opus_gn/moz.build
+index 2d219b5cc091b..b432e58ff912a 100644
+--- a/third_party/libwebrtc/modules/audio_coding/webrtc_opus_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_coding/webrtc_opus_gn/moz.build
+@@ -159,6 +159,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_coding/webrtc_opus_wrapper_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/webrtc_opus_wrapper_gn/moz.build
+index 4c1faef881989..2dace42c235e3 100644
+--- a/third_party/libwebrtc/modules/audio_coding/webrtc_opus_wrapper_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_coding/webrtc_opus_wrapper_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_device/audio_device_gn/moz.build b/third_party/libwebrtc/modules/audio_device/audio_device_gn/moz.build
+index acd3896de1055..c093add857353 100644
+--- a/third_party/libwebrtc/modules/audio_device/audio_device_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_device/audio_device_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_mixer/audio_frame_manipulator_gn/moz.build b/third_party/libwebrtc/modules/audio_mixer/audio_frame_manipulator_gn/moz.build
+index 24bd59bd53567..eac3cf70bf93e 100644
+--- a/third_party/libwebrtc/modules/audio_mixer/audio_frame_manipulator_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_mixer/audio_frame_manipulator_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_mixer/audio_mixer_impl_gn/moz.build b/third_party/libwebrtc/modules/audio_mixer/audio_mixer_impl_gn/moz.build
+index c32088c064a8d..9dc3a5f0b7d83 100644
+--- a/third_party/libwebrtc/modules/audio_mixer/audio_mixer_impl_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_mixer/audio_mixer_impl_gn/moz.build
+@@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_erl_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_erl_gn/moz.build
+index f994d264fc0d0..b8abfc845a070 100644
+--- a/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_erl_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_erl_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_gn/moz.build
+index bfab3391fd95a..5199751374e73 100644
+--- a/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_gn/moz.build
+@@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/aec3_common_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/aec3_common_gn/moz.build
+index 8c8af7ad0246e..44a5bc121e81f 100644
+--- a/third_party/libwebrtc/modules/audio_processing/aec3/aec3_common_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/aec3/aec3_common_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/aec3_fft_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/aec3_fft_gn/moz.build
+index f29e375961679..af371904ec807 100644
+--- a/third_party/libwebrtc/modules/audio_processing/aec3/aec3_fft_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/aec3/aec3_fft_gn/moz.build
+@@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/aec3_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/aec3_gn/moz.build
+index b984c66872a14..1560ad3e8cf3c 100644
+--- a/third_party/libwebrtc/modules/audio_processing/aec3/aec3_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/aec3/aec3_gn/moz.build
+@@ -211,6 +211,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/fft_data_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/fft_data_gn/moz.build
+index 636d54205ecc3..e87539fa35259 100644
+--- a/third_party/libwebrtc/modules/audio_processing/aec3/fft_data_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/aec3/fft_data_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/matched_filter_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/matched_filter_gn/moz.build
+index 0399096915b44..4957767a97d1c 100644
+--- a/third_party/libwebrtc/modules/audio_processing/aec3/matched_filter_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/aec3/matched_filter_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/render_buffer_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/render_buffer_gn/moz.build
+index 52ec8e5f7dfcc..59db026889b35 100644
+--- a/third_party/libwebrtc/modules/audio_processing/aec3/render_buffer_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/aec3/render_buffer_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/vector_math_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/vector_math_gn/moz.build
+index 712a4c3571722..84ab4122315b4 100644
+--- a/third_party/libwebrtc/modules/audio_processing/aec3/vector_math_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/aec3/vector_math_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/aec_dump/aec_dump_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec_dump/aec_dump_gn/moz.build
+index 9f186fec9c4bb..59469c1625caf 100644
+--- a/third_party/libwebrtc/modules/audio_processing/aec_dump/aec_dump_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/aec_dump/aec_dump_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/aec_dump/null_aec_dump_factory_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec_dump/null_aec_dump_factory_gn/moz.build
+index f02e31ce448d3..7a8ef95b8b564 100644
+--- a/third_party/libwebrtc/modules/audio_processing/aec_dump/null_aec_dump_factory_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/aec_dump/null_aec_dump_factory_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/aec_dump_interface_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec_dump_interface_gn/moz.build
+index db7c251ecd563..0c3d72a7dd5d0 100644
+--- a/third_party/libwebrtc/modules/audio_processing/aec_dump_interface_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/aec_dump_interface_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/aecm/aecm_core_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aecm/aecm_core_gn/moz.build
+index fc1a743ada419..83fc157f7decd 100644
+--- a/third_party/libwebrtc/modules/audio_processing/aecm/aecm_core_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/aecm/aecm_core_gn/moz.build
+@@ -179,6 +179,14 @@ if CONFIG["TARGET_CPU"] == "arm":
+         "/third_party/libwebrtc/modules/audio_processing/aecm/aecm_core_neon.cc"
+     ]
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
++    SOURCES += [
++        "/third_party/libwebrtc/modules/audio_processing/aecm/aecm_core_c.cc"
++    ]
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc/agc_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc/agc_gn/moz.build
+index c365d82510912..070881ded96b2 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc/agc_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc/agc_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc/gain_control_interface_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc/gain_control_interface_gn/moz.build
+index 7f018adae5f03..8506cfbd594b8 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc/gain_control_interface_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc/gain_control_interface_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc/legacy_agc_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc/legacy_agc_gn/moz.build
+index d129ca31f30f7..47ce5fd532fdc 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc/legacy_agc_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc/legacy_agc_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc/level_estimation_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc/level_estimation_gn/moz.build
+index 1b5ce0bb90583..c43e8fceb193b 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc/level_estimation_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc/level_estimation_gn/moz.build
+@@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/adaptive_digital_gain_controller_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/adaptive_digital_gain_controller_gn/moz.build
+index 3015020227107..aa570bdf4b9b6 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc2/adaptive_digital_gain_controller_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc2/adaptive_digital_gain_controller_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/biquad_filter_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/biquad_filter_gn/moz.build
+index fe132f5f694cd..da0e8c7f46395 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc2/biquad_filter_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc2/biquad_filter_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/clipping_predictor_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/clipping_predictor_gn/moz.build
+index ae1541ded6d8f..b3a96fea24c2a 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc2/clipping_predictor_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc2/clipping_predictor_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/common_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/common_gn/moz.build
+index 64f1d62c2def1..9b5bddda30f94 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc2/common_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc2/common_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/cpu_features_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/cpu_features_gn/moz.build
+index bc5907abea356..ee5749e503637 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc2/cpu_features_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc2/cpu_features_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/fixed_digital_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/fixed_digital_gn/moz.build
+index ed716566a46d6..03ed3a3a293b0 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc2/fixed_digital_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc2/fixed_digital_gn/moz.build
+@@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/gain_applier_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/gain_applier_gn/moz.build
+index 3f2132cc91d8e..d589d866204ef 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc2/gain_applier_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc2/gain_applier_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/gain_map_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/gain_map_gn/moz.build
+index 9736df45221e8..a7fb934a3473e 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc2/gain_map_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc2/gain_map_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_controller_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_controller_gn/moz.build
+index cd4bf219463d7..1d382745e827f 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_controller_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_controller_gn/moz.build
+@@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_stats_reporter_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_stats_reporter_gn/moz.build
+index 59a2714924902..355c5856949ec 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_stats_reporter_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_stats_reporter_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/noise_level_estimator_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/noise_level_estimator_gn/moz.build
+index bce906f682e90..93406719a2d0c 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc2/noise_level_estimator_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc2/noise_level_estimator_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_auto_correlation_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_auto_correlation_gn/moz.build
+index 06d77c98fdb89..07f0840a6fc57 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_auto_correlation_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_auto_correlation_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_common_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_common_gn/moz.build
+index 9c27c5284f733..89078be5920c8 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_common_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_common_gn/moz.build
+@@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_gn/moz.build
+index c06de8a64d6b8..5606c2a7f4e29 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_layers_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_layers_gn/moz.build
+index 68a10c5f8ca57..f982772114898 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_layers_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_layers_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_lp_residual_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_lp_residual_gn/moz.build
+index 8d629f368af1d..5f78b7c60b0f2 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_lp_residual_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_lp_residual_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_pitch_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_pitch_gn/moz.build
+index 89a8148e73b27..f255d2c3348c5 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_pitch_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_pitch_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_ring_buffer_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_ring_buffer_gn/moz.build
+index a650860e3ed12..34cb04366a07c 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_ring_buffer_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_ring_buffer_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_sequence_buffer_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_sequence_buffer_gn/moz.build
+index 33988b17e143a..83d745b203600 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_sequence_buffer_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_sequence_buffer_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_spectral_features_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_spectral_features_gn/moz.build
+index 1e27faa5870dd..6be5b9b81526d 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_spectral_features_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_spectral_features_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_symmetric_matrix_buffer_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_symmetric_matrix_buffer_gn/moz.build
+index 6ffad4636659e..f9fdb459564c3 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_symmetric_matrix_buffer_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_symmetric_matrix_buffer_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/vector_math_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/vector_math_gn/moz.build
+index d3bb22b9a5254..08e88e9d82320 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/vector_math_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/vector_math_gn/moz.build
+@@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/saturation_protector_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/saturation_protector_gn/moz.build
+index 271c46c540d72..b334441c85348 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc2/saturation_protector_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc2/saturation_protector_gn/moz.build
+@@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/speech_level_estimator_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/speech_level_estimator_gn/moz.build
+index cfb4bb80840a1..0d452573df8c5 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc2/speech_level_estimator_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc2/speech_level_estimator_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/vad_wrapper_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/vad_wrapper_gn/moz.build
+index 00e3216b4597f..b3e2fa8ad3953 100644
+--- a/third_party/libwebrtc/modules/audio_processing/agc2/vad_wrapper_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/agc2/vad_wrapper_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/apm_logging_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/apm_logging_gn/moz.build
+index 9b5e11e947d92..f0ba4e3ff14ac 100644
+--- a/third_party/libwebrtc/modules/audio_processing/apm_logging_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/apm_logging_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/audio_buffer_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/audio_buffer_gn/moz.build
+index 986ecc61c766c..23f3f826ab1e9 100644
+--- a/third_party/libwebrtc/modules/audio_processing/audio_buffer_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/audio_buffer_gn/moz.build
+@@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/audio_frame_proxies_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/audio_frame_proxies_gn/moz.build
+index 894361b57458d..2bb4f4a1affcb 100644
+--- a/third_party/libwebrtc/modules/audio_processing/audio_frame_proxies_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/audio_frame_proxies_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/audio_frame_view_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/audio_frame_view_gn/moz.build
+index 7a283f1e109a4..f718e0bebb47d 100644
+--- a/third_party/libwebrtc/modules/audio_processing/audio_frame_view_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/audio_frame_view_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/audio_processing_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/audio_processing_gn/moz.build
+index 4acaa7f014eb4..6856373c6aa8f 100644
+--- a/third_party/libwebrtc/modules/audio_processing/audio_processing_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/audio_processing_gn/moz.build
+@@ -161,6 +161,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/capture_levels_adjuster/capture_levels_adjuster_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/capture_levels_adjuster/capture_levels_adjuster_gn/moz.build
+index ba0901058580d..2a9087fbc8636 100644
+--- a/third_party/libwebrtc/modules/audio_processing/capture_levels_adjuster/capture_levels_adjuster_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/capture_levels_adjuster/capture_levels_adjuster_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/gain_controller2_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/gain_controller2_gn/moz.build
+index 2fd9b99a64dfd..840899c2bdc24 100644
+--- a/third_party/libwebrtc/modules/audio_processing/gain_controller2_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/gain_controller2_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/high_pass_filter_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/high_pass_filter_gn/moz.build
+index 09d5dc9882473..3a7c0d3e7ef91 100644
+--- a/third_party/libwebrtc/modules/audio_processing/high_pass_filter_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/high_pass_filter_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/ns/ns_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/ns/ns_gn/moz.build
+index 93c673ef17031..ca0192aff911f 100644
+--- a/third_party/libwebrtc/modules/audio_processing/ns/ns_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/ns/ns_gn/moz.build
+@@ -167,6 +167,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/optionally_built_submodule_creators_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/optionally_built_submodule_creators_gn/moz.build
+index 0af06a9c3544b..b8e2e57e63dd2 100644
+--- a/third_party/libwebrtc/modules/audio_processing/optionally_built_submodule_creators_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/optionally_built_submodule_creators_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/rms_level_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/rms_level_gn/moz.build
+index 8b21dc34fd6c3..40e4d2abaddc4 100644
+--- a/third_party/libwebrtc/modules/audio_processing/rms_level_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/rms_level_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/transient/transient_suppressor_api_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/transient/transient_suppressor_api_gn/moz.build
+index f3ccbefcdb8e2..c60ead6c16a15 100644
+--- a/third_party/libwebrtc/modules/audio_processing/transient/transient_suppressor_api_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/transient/transient_suppressor_api_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/transient/transient_suppressor_impl_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/transient/transient_suppressor_impl_gn/moz.build
+index 0ec5dcb6c535a..1d397b8332717 100644
+--- a/third_party/libwebrtc/modules/audio_processing/transient/transient_suppressor_impl_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/transient/transient_suppressor_impl_gn/moz.build
+@@ -158,6 +158,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/transient/voice_probability_delay_unit_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/transient/voice_probability_delay_unit_gn/moz.build
+index 50a6a9d55ce52..8125425cc94f1 100644
+--- a/third_party/libwebrtc/modules/audio_processing/transient/voice_probability_delay_unit_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/transient/voice_probability_delay_unit_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/utility/cascaded_biquad_filter_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/utility/cascaded_biquad_filter_gn/moz.build
+index f1b3493b7a961..362afb2cd88cc 100644
+--- a/third_party/libwebrtc/modules/audio_processing/utility/cascaded_biquad_filter_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/utility/cascaded_biquad_filter_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/utility/legacy_delay_estimator_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/utility/legacy_delay_estimator_gn/moz.build
+index 12b385e2e9056..161fa3204ef51 100644
+--- a/third_party/libwebrtc/modules/audio_processing/utility/legacy_delay_estimator_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/utility/legacy_delay_estimator_gn/moz.build
+@@ -144,6 +144,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/utility/pffft_wrapper_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/utility/pffft_wrapper_gn/moz.build
+index f1e1bc555af42..ebad818492f3b 100644
+--- a/third_party/libwebrtc/modules/audio_processing/utility/pffft_wrapper_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/utility/pffft_wrapper_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/audio_processing/vad/vad_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/vad/vad_gn/moz.build
+index 4794a478e8a07..9832d3f2206cd 100644
+--- a/third_party/libwebrtc/modules/audio_processing/vad/vad_gn/moz.build
++++ b/third_party/libwebrtc/modules/audio_processing/vad/vad_gn/moz.build
+@@ -161,6 +161,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/congestion_controller/congestion_controller_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/congestion_controller_gn/moz.build
+index 59d06c939618e..52e2ba8782453 100644
+--- a/third_party/libwebrtc/modules/congestion_controller/congestion_controller_gn/moz.build
++++ b/third_party/libwebrtc/modules/congestion_controller/congestion_controller_gn/moz.build
+@@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/alr_detector_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/alr_detector_gn/moz.build
+index 2a3d216e40c07..9ebbf45b41e0a 100644
+--- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/alr_detector_gn/moz.build
++++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/alr_detector_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/delay_based_bwe_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/delay_based_bwe_gn/moz.build
+index b138b59fc6564..50f1b151b8a1f 100644
+--- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/delay_based_bwe_gn/moz.build
++++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/delay_based_bwe_gn/moz.build
+@@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/estimators_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/estimators_gn/moz.build
+index 47ee346c89e83..5ea300d6f1487 100644
+--- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/estimators_gn/moz.build
++++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/estimators_gn/moz.build
+@@ -160,6 +160,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/goog_cc_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/goog_cc_gn/moz.build
+index fa641fccfe187..cc591aeee423c 100644
+--- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/goog_cc_gn/moz.build
++++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/goog_cc_gn/moz.build
+@@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/link_capacity_estimator_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/link_capacity_estimator_gn/moz.build
+index d229d732df781..9c497d39ff31c 100644
+--- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/link_capacity_estimator_gn/moz.build
++++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/link_capacity_estimator_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v1_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v1_gn/moz.build
+index 8065861f7854c..e3130fd38e809 100644
+--- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v1_gn/moz.build
++++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v1_gn/moz.build
+@@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v2_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v2_gn/moz.build
+index 72c625902ca3e..17370f74758c8 100644
+--- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v2_gn/moz.build
++++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v2_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/probe_controller_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/probe_controller_gn/moz.build
+index cb2bc83d2850c..33ec90a9bf5e3 100644
+--- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/probe_controller_gn/moz.build
++++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/probe_controller_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/pushback_controller_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/pushback_controller_gn/moz.build
+index af00c01323020..445de1ab79391 100644
+--- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/pushback_controller_gn/moz.build
++++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/pushback_controller_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/send_side_bwe_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/send_side_bwe_gn/moz.build
+index 52323451eb320..0337cbd03c3bb 100644
+--- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/send_side_bwe_gn/moz.build
++++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/send_side_bwe_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/congestion_controller/rtp/control_handler_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/rtp/control_handler_gn/moz.build
+index 9226c07dda237..81fa66ddf6428 100644
+--- a/third_party/libwebrtc/modules/congestion_controller/rtp/control_handler_gn/moz.build
++++ b/third_party/libwebrtc/modules/congestion_controller/rtp/control_handler_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/congestion_controller/rtp/transport_feedback_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/rtp/transport_feedback_gn/moz.build
+index c2b8fead8d154..a82b18fa5cd42 100644
+--- a/third_party/libwebrtc/modules/congestion_controller/rtp/transport_feedback_gn/moz.build
++++ b/third_party/libwebrtc/modules/congestion_controller/rtp/transport_feedback_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/desktop_capture/desktop_capture_gn/moz.build b/third_party/libwebrtc/modules/desktop_capture/desktop_capture_gn/moz.build
+index a4fb8b3162bd8..ee039ce2e38a8 100644
+--- a/third_party/libwebrtc/modules/desktop_capture/desktop_capture_gn/moz.build
++++ b/third_party/libwebrtc/modules/desktop_capture/desktop_capture_gn/moz.build
+@@ -277,6 +277,35 @@ if CONFIG["TARGET_CPU"] == "arm":
+         "/third_party/libwebrtc/modules/desktop_capture/linux/wayland/shared_screencast_stream.cc"
+     ]
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["WEBRTC_USE_X11"] = True
++    DEFINES["_GNU_SOURCE"] = True
++
++    OS_LIBS += [
++        "X11",
++        "Xcomposite",
++        "Xdamage",
++        "Xext",
++        "Xfixes",
++        "Xrandr",
++        "Xrender"
++    ]
++
++    UNIFIED_SOURCES += [
++        "/third_party/libwebrtc/modules/desktop_capture/linux/x11/mouse_cursor_monitor_x11.cc",
++        "/third_party/libwebrtc/modules/desktop_capture/linux/x11/screen_capturer_x11.cc",
++        "/third_party/libwebrtc/modules/desktop_capture/linux/x11/shared_x_display.cc",
++        "/third_party/libwebrtc/modules/desktop_capture/linux/x11/window_capturer_x11.cc",
++        "/third_party/libwebrtc/modules/desktop_capture/linux/x11/window_finder_x11.cc",
++        "/third_party/libwebrtc/modules/desktop_capture/linux/x11/window_list_utils.cc",
++        "/third_party/libwebrtc/modules/desktop_capture/linux/x11/x_atom_cache.cc",
++        "/third_party/libwebrtc/modules/desktop_capture/linux/x11/x_error_trap.cc",
++        "/third_party/libwebrtc/modules/desktop_capture/linux/x11/x_server_pixel_buffer.cc",
++        "/third_party/libwebrtc/modules/desktop_capture/linux/x11/x_window_property.cc"
++    ]
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/desktop_capture/primitives_gn/moz.build b/third_party/libwebrtc/modules/desktop_capture/primitives_gn/moz.build
+index 927926f3e987a..e60f2879d7180 100644
+--- a/third_party/libwebrtc/modules/desktop_capture/primitives_gn/moz.build
++++ b/third_party/libwebrtc/modules/desktop_capture/primitives_gn/moz.build
+@@ -132,6 +132,11 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_HAS_NEON"] = True
+     DEFINES["_GNU_SOURCE"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["USE_X11"] = "1"
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/module_api_gn/moz.build b/third_party/libwebrtc/modules/module_api_gn/moz.build
+index 9b77a009fa9ec..80236e4efbbf7 100644
+--- a/third_party/libwebrtc/modules/module_api_gn/moz.build
++++ b/third_party/libwebrtc/modules/module_api_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/module_api_public_gn/moz.build b/third_party/libwebrtc/modules/module_api_public_gn/moz.build
+index 474dec612359e..634cf27e15f0a 100644
+--- a/third_party/libwebrtc/modules/module_api_public_gn/moz.build
++++ b/third_party/libwebrtc/modules/module_api_public_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/module_fec_api_gn/moz.build b/third_party/libwebrtc/modules/module_fec_api_gn/moz.build
+index b69c69c3118c0..3b3b0dbc5cb31 100644
+--- a/third_party/libwebrtc/modules/module_fec_api_gn/moz.build
++++ b/third_party/libwebrtc/modules/module_fec_api_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/pacing/interval_budget_gn/moz.build b/third_party/libwebrtc/modules/pacing/interval_budget_gn/moz.build
+index 2e3ab3d9878e0..9af23bc939192 100644
+--- a/third_party/libwebrtc/modules/pacing/interval_budget_gn/moz.build
++++ b/third_party/libwebrtc/modules/pacing/interval_budget_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/pacing/pacing_gn/moz.build b/third_party/libwebrtc/modules/pacing/pacing_gn/moz.build
+index d7aa189ef37b1..bf250e4433187 100644
+--- a/third_party/libwebrtc/modules/pacing/pacing_gn/moz.build
++++ b/third_party/libwebrtc/modules/pacing/pacing_gn/moz.build
+@@ -162,6 +162,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_gn/moz.build b/third_party/libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_gn/moz.build
+index eab6f3f9d0fca..02e5a63adbfba 100644
+--- a/third_party/libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_gn/moz.build
++++ b/third_party/libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_gn/moz.build
+@@ -166,6 +166,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/rtp_rtcp/leb128_gn/moz.build b/third_party/libwebrtc/modules/rtp_rtcp/leb128_gn/moz.build
+index 6e1dfd18c099e..f1eb5b14cde17 100644
+--- a/third_party/libwebrtc/modules/rtp_rtcp/leb128_gn/moz.build
++++ b/third_party/libwebrtc/modules/rtp_rtcp/leb128_gn/moz.build
+@@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_format_gn/moz.build b/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_format_gn/moz.build
+index ef123804746ac..932c1ce369ee5 100644
+--- a/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_format_gn/moz.build
++++ b/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_format_gn/moz.build
+@@ -197,6 +197,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_gn/moz.build b/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_gn/moz.build
+index 31789273913d5..90e87e42cb182 100644
+--- a/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_gn/moz.build
++++ b/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_gn/moz.build
+@@ -211,6 +211,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/rtp_rtcp/rtp_video_header_gn/moz.build b/third_party/libwebrtc/modules/rtp_rtcp/rtp_video_header_gn/moz.build
+index bdee5bedc6dba..a78ffabadd3e0 100644
+--- a/third_party/libwebrtc/modules/rtp_rtcp/rtp_video_header_gn/moz.build
++++ b/third_party/libwebrtc/modules/rtp_rtcp/rtp_video_header_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/third_party/fft/fft_gn/moz.build b/third_party/libwebrtc/modules/third_party/fft/fft_gn/moz.build
+index 9afa4154ee379..fc523a328e9fc 100644
+--- a/third_party/libwebrtc/modules/third_party/fft/fft_gn/moz.build
++++ b/third_party/libwebrtc/modules/third_party/fft/fft_gn/moz.build
+@@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/third_party/g711/g711_3p_gn/moz.build b/third_party/libwebrtc/modules/third_party/g711/g711_3p_gn/moz.build
+index 2fa1910cc8443..6c2d50e960272 100644
+--- a/third_party/libwebrtc/modules/third_party/g711/g711_3p_gn/moz.build
++++ b/third_party/libwebrtc/modules/third_party/g711/g711_3p_gn/moz.build
+@@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/third_party/g722/g722_3p_gn/moz.build b/third_party/libwebrtc/modules/third_party/g722/g722_3p_gn/moz.build
+index d1ff3aaad3489..57fc6a12afa5d 100644
+--- a/third_party/libwebrtc/modules/third_party/g722/g722_3p_gn/moz.build
++++ b/third_party/libwebrtc/modules/third_party/g722/g722_3p_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/utility/utility_gn/moz.build b/third_party/libwebrtc/modules/utility/utility_gn/moz.build
+index 97d828d64fc18..dafae21d5fbd1 100644
+--- a/third_party/libwebrtc/modules/utility/utility_gn/moz.build
++++ b/third_party/libwebrtc/modules/utility/utility_gn/moz.build
+@@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_capture/video_capture_internal_impl_gn/moz.build b/third_party/libwebrtc/modules/video_capture/video_capture_internal_impl_gn/moz.build
+index 6af27f618bcde..68ef46df66f24 100644
+--- a/third_party/libwebrtc/modules/video_capture/video_capture_internal_impl_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_capture/video_capture_internal_impl_gn/moz.build
+@@ -185,6 +185,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_capture/video_capture_module_gn/moz.build b/third_party/libwebrtc/modules/video_capture/video_capture_module_gn/moz.build
+index 145e549286443..b5c52722f7500 100644
+--- a/third_party/libwebrtc/modules/video_capture/video_capture_module_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_capture/video_capture_module_gn/moz.build
+@@ -158,6 +158,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/chain_diff_calculator_gn/moz.build b/third_party/libwebrtc/modules/video_coding/chain_diff_calculator_gn/moz.build
+index 065cf604b5d31..f2e93630b268e 100644
+--- a/third_party/libwebrtc/modules/video_coding/chain_diff_calculator_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/chain_diff_calculator_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/codec_globals_headers_gn/moz.build b/third_party/libwebrtc/modules/video_coding/codec_globals_headers_gn/moz.build
+index 53a7fc384c3d8..9bb894a49e459 100644
+--- a/third_party/libwebrtc/modules/video_coding/codec_globals_headers_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/codec_globals_headers_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/codecs/av1/av1_svc_config_gn/moz.build b/third_party/libwebrtc/modules/video_coding/codecs/av1/av1_svc_config_gn/moz.build
+index b9784482e9bd3..674553fda2f86 100644
+--- a/third_party/libwebrtc/modules/video_coding/codecs/av1/av1_svc_config_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/codecs/av1/av1_svc_config_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/encoded_frame_gn/moz.build b/third_party/libwebrtc/modules/video_coding/encoded_frame_gn/moz.build
+index a086f7cb0b6f8..c8c63c182bc7a 100644
+--- a/third_party/libwebrtc/modules/video_coding/encoded_frame_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/encoded_frame_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/frame_dependencies_calculator_gn/moz.build b/third_party/libwebrtc/modules/video_coding/frame_dependencies_calculator_gn/moz.build
+index e8fdf3750a0c8..78f33ae389f0d 100644
+--- a/third_party/libwebrtc/modules/video_coding/frame_dependencies_calculator_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/frame_dependencies_calculator_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/frame_helpers_gn/moz.build b/third_party/libwebrtc/modules/video_coding/frame_helpers_gn/moz.build
+index ecd9c1dd8d376..f0fde86029d8a 100644
+--- a/third_party/libwebrtc/modules/video_coding/frame_helpers_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/frame_helpers_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/h264_sprop_parameter_sets_gn/moz.build b/third_party/libwebrtc/modules/video_coding/h264_sprop_parameter_sets_gn/moz.build
+index b92c2ed52823f..03978f5726371 100644
+--- a/third_party/libwebrtc/modules/video_coding/h264_sprop_parameter_sets_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/h264_sprop_parameter_sets_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/h26x_packet_buffer_gn/moz.build b/third_party/libwebrtc/modules/video_coding/h26x_packet_buffer_gn/moz.build
+index 92267a7c583f2..385ac6b02c51b 100644
+--- a/third_party/libwebrtc/modules/video_coding/h26x_packet_buffer_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/h26x_packet_buffer_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/nack_requester_gn/moz.build b/third_party/libwebrtc/modules/video_coding/nack_requester_gn/moz.build
+index 187cf6089c53f..8d44f9aa21772 100644
+--- a/third_party/libwebrtc/modules/video_coding/nack_requester_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/nack_requester_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/packet_buffer_gn/moz.build b/third_party/libwebrtc/modules/video_coding/packet_buffer_gn/moz.build
+index 09929b1d482a1..65658185219d7 100644
+--- a/third_party/libwebrtc/modules/video_coding/packet_buffer_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/packet_buffer_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/svc/scalability_mode_util_gn/moz.build b/third_party/libwebrtc/modules/video_coding/svc/scalability_mode_util_gn/moz.build
+index 6986843464121..3699238b44926 100644
+--- a/third_party/libwebrtc/modules/video_coding/svc/scalability_mode_util_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/svc/scalability_mode_util_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/svc/scalability_structures_gn/moz.build b/third_party/libwebrtc/modules/video_coding/svc/scalability_structures_gn/moz.build
+index 88f469760f7f5..40515fd26fcd5 100644
+--- a/third_party/libwebrtc/modules/video_coding/svc/scalability_structures_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/svc/scalability_structures_gn/moz.build
+@@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/svc/scalable_video_controller_gn/moz.build b/third_party/libwebrtc/modules/video_coding/svc/scalable_video_controller_gn/moz.build
+index d09a4aed3ab50..bd11fa819a394 100644
+--- a/third_party/libwebrtc/modules/video_coding/svc/scalable_video_controller_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/svc/scalable_video_controller_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/svc/svc_rate_allocator_gn/moz.build b/third_party/libwebrtc/modules/video_coding/svc/svc_rate_allocator_gn/moz.build
+index 2bd3634ba957d..cc86bd52980d2 100644
+--- a/third_party/libwebrtc/modules/video_coding/svc/svc_rate_allocator_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/svc/svc_rate_allocator_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/timing/decode_time_percentile_filter_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/decode_time_percentile_filter_gn/moz.build
+index 9c48932149b90..b177a6c6af3cc 100644
+--- a/third_party/libwebrtc/modules/video_coding/timing/decode_time_percentile_filter_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/timing/decode_time_percentile_filter_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/timing/frame_delay_variation_kalman_filter_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/frame_delay_variation_kalman_filter_gn/moz.build
+index 0e5991cffd44d..a1eda8e0e10d3 100644
+--- a/third_party/libwebrtc/modules/video_coding/timing/frame_delay_variation_kalman_filter_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/timing/frame_delay_variation_kalman_filter_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/timing/inter_frame_delay_variation_calculator_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/inter_frame_delay_variation_calculator_gn/moz.build
+index a311c4a8024c1..8c81383d449b6 100644
+--- a/third_party/libwebrtc/modules/video_coding/timing/inter_frame_delay_variation_calculator_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/timing/inter_frame_delay_variation_calculator_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/timing/jitter_estimator_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/jitter_estimator_gn/moz.build
+index 6d87c74bd732f..02fc5944f0d66 100644
+--- a/third_party/libwebrtc/modules/video_coding/timing/jitter_estimator_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/timing/jitter_estimator_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/timing/rtt_filter_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/rtt_filter_gn/moz.build
+index e05eebc11f52e..188f88c23cf81 100644
+--- a/third_party/libwebrtc/modules/video_coding/timing/rtt_filter_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/timing/rtt_filter_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/timing/timestamp_extrapolator_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/timestamp_extrapolator_gn/moz.build
+index 10e36ea24cf2c..033dfbfbe578e 100644
+--- a/third_party/libwebrtc/modules/video_coding/timing/timestamp_extrapolator_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/timing/timestamp_extrapolator_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/timing/timing_module_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/timing_module_gn/moz.build
+index 2ab95ef629911..cd036f90bb3b5 100644
+--- a/third_party/libwebrtc/modules/video_coding/timing/timing_module_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/timing/timing_module_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/video_codec_interface_gn/moz.build b/third_party/libwebrtc/modules/video_coding/video_codec_interface_gn/moz.build
+index 0e18b1aecaed9..3c0c4d1b83721 100644
+--- a/third_party/libwebrtc/modules/video_coding/video_codec_interface_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/video_codec_interface_gn/moz.build
+@@ -152,6 +152,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/video_coding_gn/moz.build b/third_party/libwebrtc/modules/video_coding/video_coding_gn/moz.build
+index 01a6429d0cdf8..813a0d673454a 100644
+--- a/third_party/libwebrtc/modules/video_coding/video_coding_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/video_coding_gn/moz.build
+@@ -168,6 +168,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/video_coding_utility_gn/moz.build b/third_party/libwebrtc/modules/video_coding/video_coding_utility_gn/moz.build
+index 75698c304f785..143d8016cc7ac 100644
+--- a/third_party/libwebrtc/modules/video_coding/video_coding_utility_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/video_coding_utility_gn/moz.build
+@@ -166,6 +166,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_libvpx_interface_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_libvpx_interface_gn/moz.build
+index ce59cc861c99b..fbdbc2bcf8f56 100644
+--- a/third_party/libwebrtc/modules/video_coding/webrtc_libvpx_interface_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/webrtc_libvpx_interface_gn/moz.build
+@@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_gn/moz.build
+index 352458cf8e21a..72e24edaa1e77 100644
+--- a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_gn/moz.build
+@@ -161,6 +161,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_scalability_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_scalability_gn/moz.build
+index 0338ba659e01e..b1519e2f179ac 100644
+--- a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_scalability_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_scalability_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_temporal_layers_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_temporal_layers_gn/moz.build
+index d7ae0d5805b37..6a4d3fcf8fcb2 100644
+--- a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_temporal_layers_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_temporal_layers_gn/moz.build
+@@ -160,6 +160,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_vp9_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_vp9_gn/moz.build
+index c0d16a8e5163e..9fab25c590706 100644
+--- a/third_party/libwebrtc/modules/video_coding/webrtc_vp9_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/webrtc_vp9_gn/moz.build
+@@ -163,6 +163,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_vp9_helpers_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_vp9_helpers_gn/moz.build
+index 6abd453136c93..dd71c3be6b357 100644
+--- a/third_party/libwebrtc/modules/video_coding/webrtc_vp9_helpers_gn/moz.build
++++ b/third_party/libwebrtc/modules/video_coding/webrtc_vp9_helpers_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/moz.build b/third_party/libwebrtc/moz.build
+index 58c3c3520bc36..806f8caa65a6b 100644
+--- a/third_party/libwebrtc/moz.build
++++ b/third_party/libwebrtc/moz.build
+@@ -692,6 +692,13 @@ if CONFIG["OS_TARGET"] == "WINNT" and CONFIG["TARGET_CPU"] == "x86_64":
+         "/third_party/libwebrtc/modules/desktop_capture/desktop_capture_differ_sse2_gn"
+     ]
+ 
++if CONFIG["MOZ_X11"] == "1" and CONFIG["OS_TARGET"] == "Linux" and CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DIRS += [
++        "/third_party/libwebrtc/modules/desktop_capture/desktop_capture_gn",
++        "/third_party/libwebrtc/modules/desktop_capture/primitives_gn"
++    ]
++
+ if CONFIG["MOZ_X11"] == "1" and CONFIG["OS_TARGET"] == "Linux" and CONFIG["TARGET_CPU"] == "ppc64":
+ 
+     DIRS += [
+diff --git a/third_party/libwebrtc/rtc_base/async_dns_resolver_gn/moz.build b/third_party/libwebrtc/rtc_base/async_dns_resolver_gn/moz.build
+index 415f09cfd1fec..8e39a6815b5c2 100644
+--- a/third_party/libwebrtc/rtc_base/async_dns_resolver_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/async_dns_resolver_gn/moz.build
+@@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/async_packet_socket_gn/moz.build b/third_party/libwebrtc/rtc_base/async_packet_socket_gn/moz.build
+index 9f3ce4d4b6004..7d05708ab2f34 100644
+--- a/third_party/libwebrtc/rtc_base/async_packet_socket_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/async_packet_socket_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/audio_format_to_string_gn/moz.build b/third_party/libwebrtc/rtc_base/audio_format_to_string_gn/moz.build
+index 70a2aa730b192..5a18fc497148b 100644
+--- a/third_party/libwebrtc/rtc_base/audio_format_to_string_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/audio_format_to_string_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/bit_buffer_gn/moz.build b/third_party/libwebrtc/rtc_base/bit_buffer_gn/moz.build
+index 3dfd3b19d24b3..a269686bc379e 100644
+--- a/third_party/libwebrtc/rtc_base/bit_buffer_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/bit_buffer_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/bitrate_tracker_gn/moz.build b/third_party/libwebrtc/rtc_base/bitrate_tracker_gn/moz.build
+index 7b1ba50f99cfe..13166faba84ff 100644
+--- a/third_party/libwebrtc/rtc_base/bitrate_tracker_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/bitrate_tracker_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/bitstream_reader_gn/moz.build b/third_party/libwebrtc/rtc_base/bitstream_reader_gn/moz.build
+index c82c4c9965bf7..48329129ba165 100644
+--- a/third_party/libwebrtc/rtc_base/bitstream_reader_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/bitstream_reader_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/buffer_gn/moz.build b/third_party/libwebrtc/rtc_base/buffer_gn/moz.build
+index 5e5d11ff6f7e2..23fccce8d58a0 100644
+--- a/third_party/libwebrtc/rtc_base/buffer_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/buffer_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/byte_buffer_gn/moz.build b/third_party/libwebrtc/rtc_base/byte_buffer_gn/moz.build
+index 89a2c9e84e1c7..fa6463f7dc2eb 100644
+--- a/third_party/libwebrtc/rtc_base/byte_buffer_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/byte_buffer_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/byte_order_gn/moz.build b/third_party/libwebrtc/rtc_base/byte_order_gn/moz.build
+index b95d149625ed0..edb05a89f393b 100644
+--- a/third_party/libwebrtc/rtc_base/byte_order_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/byte_order_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/checks_gn/moz.build b/third_party/libwebrtc/rtc_base/checks_gn/moz.build
+index f147bdc64bd97..ade028b3e1240 100644
+--- a/third_party/libwebrtc/rtc_base/checks_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/checks_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/compile_assert_c_gn/moz.build b/third_party/libwebrtc/rtc_base/compile_assert_c_gn/moz.build
+index 711466336e156..15d74c507a3e0 100644
+--- a/third_party/libwebrtc/rtc_base/compile_assert_c_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/compile_assert_c_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/containers/flat_containers_internal_gn/moz.build b/third_party/libwebrtc/rtc_base/containers/flat_containers_internal_gn/moz.build
+index fa4fdc873993e..fbb9672971b5b 100644
+--- a/third_party/libwebrtc/rtc_base/containers/flat_containers_internal_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/containers/flat_containers_internal_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/containers/flat_map_gn/moz.build b/third_party/libwebrtc/rtc_base/containers/flat_map_gn/moz.build
+index 7c9b3edd16767..b96ccfa67d805 100644
+--- a/third_party/libwebrtc/rtc_base/containers/flat_map_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/containers/flat_map_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/containers/flat_set_gn/moz.build b/third_party/libwebrtc/rtc_base/containers/flat_set_gn/moz.build
+index 02d364fe30a5d..d4c7825e81319 100644
+--- a/third_party/libwebrtc/rtc_base/containers/flat_set_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/containers/flat_set_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/copy_on_write_buffer_gn/moz.build b/third_party/libwebrtc/rtc_base/copy_on_write_buffer_gn/moz.build
+index dd687b90f3ff9..2fdd6c24f6dbf 100644
+--- a/third_party/libwebrtc/rtc_base/copy_on_write_buffer_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/copy_on_write_buffer_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/criticalsection_gn/moz.build b/third_party/libwebrtc/rtc_base/criticalsection_gn/moz.build
+index d860667eb5919..ee5683a29711c 100644
+--- a/third_party/libwebrtc/rtc_base/criticalsection_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/criticalsection_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/divide_round_gn/moz.build b/third_party/libwebrtc/rtc_base/divide_round_gn/moz.build
+index 5946a30db45f2..cd02618cca9b3 100644
+--- a/third_party/libwebrtc/rtc_base/divide_round_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/divide_round_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/dscp_gn/moz.build b/third_party/libwebrtc/rtc_base/dscp_gn/moz.build
+index fd82b23b98e3d..89e4a04d02e56 100644
+--- a/third_party/libwebrtc/rtc_base/dscp_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/dscp_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/event_tracer_gn/moz.build b/third_party/libwebrtc/rtc_base/event_tracer_gn/moz.build
+index 2ea470772f4b1..0632f47c6f3ff 100644
+--- a/third_party/libwebrtc/rtc_base/event_tracer_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/event_tracer_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/experiments/alr_experiment_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/alr_experiment_gn/moz.build
+index 09174a3a20ab9..0223129834085 100644
+--- a/third_party/libwebrtc/rtc_base/experiments/alr_experiment_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/experiments/alr_experiment_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/experiments/balanced_degradation_settings_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/balanced_degradation_settings_gn/moz.build
+index 233c203847c47..1bbb729d23bc9 100644
+--- a/third_party/libwebrtc/rtc_base/experiments/balanced_degradation_settings_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/experiments/balanced_degradation_settings_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/experiments/encoder_info_settings_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/encoder_info_settings_gn/moz.build
+index 9866a74964c7a..892b9d5894825 100644
+--- a/third_party/libwebrtc/rtc_base/experiments/encoder_info_settings_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/experiments/encoder_info_settings_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/experiments/field_trial_parser_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/field_trial_parser_gn/moz.build
+index 520c4db65a2b2..63192262a02f8 100644
+--- a/third_party/libwebrtc/rtc_base/experiments/field_trial_parser_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/experiments/field_trial_parser_gn/moz.build
+@@ -153,6 +153,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/experiments/keyframe_interval_settings_experiment_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/keyframe_interval_settings_experiment_gn/moz.build
+index 397f0dd3ce6fa..c3778a2228961 100644
+--- a/third_party/libwebrtc/rtc_base/experiments/keyframe_interval_settings_experiment_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/experiments/keyframe_interval_settings_experiment_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/experiments/min_video_bitrate_experiment_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/min_video_bitrate_experiment_gn/moz.build
+index 5cd3bb4a2bf0e..0d11a128d3591 100644
+--- a/third_party/libwebrtc/rtc_base/experiments/min_video_bitrate_experiment_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/experiments/min_video_bitrate_experiment_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/experiments/normalize_simulcast_size_experiment_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/normalize_simulcast_size_experiment_gn/moz.build
+index 9c3e585bf9727..9f41518b202de 100644
+--- a/third_party/libwebrtc/rtc_base/experiments/normalize_simulcast_size_experiment_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/experiments/normalize_simulcast_size_experiment_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/experiments/quality_scaler_settings_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/quality_scaler_settings_gn/moz.build
+index d1b4330a18db7..9c69480dda61f 100644
+--- a/third_party/libwebrtc/rtc_base/experiments/quality_scaler_settings_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/experiments/quality_scaler_settings_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/experiments/quality_scaling_experiment_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/quality_scaling_experiment_gn/moz.build
+index 8e75fbc3b0323..411e1effc53ad 100644
+--- a/third_party/libwebrtc/rtc_base/experiments/quality_scaling_experiment_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/experiments/quality_scaling_experiment_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/experiments/rate_control_settings_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/rate_control_settings_gn/moz.build
+index 0051ac37f9e8d..f7be521b76bfd 100644
+--- a/third_party/libwebrtc/rtc_base/experiments/rate_control_settings_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/experiments/rate_control_settings_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/experiments/stable_target_rate_experiment_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/stable_target_rate_experiment_gn/moz.build
+index 2c239310fc087..5724d0c3a2c0f 100644
+--- a/third_party/libwebrtc/rtc_base/experiments/stable_target_rate_experiment_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/experiments/stable_target_rate_experiment_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/frequency_tracker_gn/moz.build b/third_party/libwebrtc/rtc_base/frequency_tracker_gn/moz.build
+index 87a5e335eb061..eb2b13a9d5447 100644
+--- a/third_party/libwebrtc/rtc_base/frequency_tracker_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/frequency_tracker_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/gtest_prod_gn/moz.build b/third_party/libwebrtc/rtc_base/gtest_prod_gn/moz.build
+index 03bb1071f60c2..863c831e74a00 100644
+--- a/third_party/libwebrtc/rtc_base/gtest_prod_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/gtest_prod_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/histogram_percentile_counter_gn/moz.build b/third_party/libwebrtc/rtc_base/histogram_percentile_counter_gn/moz.build
+index 3f7a2c1ffa1f0..c8feb06ebe2ae 100644
+--- a/third_party/libwebrtc/rtc_base/histogram_percentile_counter_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/histogram_percentile_counter_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/ignore_wundef_gn/moz.build b/third_party/libwebrtc/rtc_base/ignore_wundef_gn/moz.build
+index 06009fc8668e3..6928e5a8d0e3d 100644
+--- a/third_party/libwebrtc/rtc_base/ignore_wundef_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/ignore_wundef_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/ip_address_gn/moz.build b/third_party/libwebrtc/rtc_base/ip_address_gn/moz.build
+index c2f9eb412bcaa..9be9bef95fc2a 100644
+--- a/third_party/libwebrtc/rtc_base/ip_address_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/ip_address_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/logging_gn/moz.build b/third_party/libwebrtc/rtc_base/logging_gn/moz.build
+index 2b47ed986c72c..3caf6f16444e4 100644
+--- a/third_party/libwebrtc/rtc_base/logging_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/logging_gn/moz.build
+@@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/macromagic_gn/moz.build b/third_party/libwebrtc/rtc_base/macromagic_gn/moz.build
+index 7a54f63695680..f0797ee8f7d2c 100644
+--- a/third_party/libwebrtc/rtc_base/macromagic_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/macromagic_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/memory/aligned_malloc_gn/moz.build b/third_party/libwebrtc/rtc_base/memory/aligned_malloc_gn/moz.build
+index 06a17077bb825..21579b6836f3a 100644
+--- a/third_party/libwebrtc/rtc_base/memory/aligned_malloc_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/memory/aligned_malloc_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/mod_ops_gn/moz.build b/third_party/libwebrtc/rtc_base/mod_ops_gn/moz.build
+index ea25143a15aa4..bc55301f35567 100644
+--- a/third_party/libwebrtc/rtc_base/mod_ops_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/mod_ops_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/moving_max_counter_gn/moz.build b/third_party/libwebrtc/rtc_base/moving_max_counter_gn/moz.build
+index 967e6e28ba29b..ee61c961c6efc 100644
+--- a/third_party/libwebrtc/rtc_base/moving_max_counter_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/moving_max_counter_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/net_helpers_gn/moz.build b/third_party/libwebrtc/rtc_base/net_helpers_gn/moz.build
+index 7c0cfcf806a71..afcce9669ea0a 100644
+--- a/third_party/libwebrtc/rtc_base/net_helpers_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/net_helpers_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/network/ecn_marking_gn/moz.build b/third_party/libwebrtc/rtc_base/network/ecn_marking_gn/moz.build
+index 9fb05f529e15e..fd974325cd73a 100644
+--- a/third_party/libwebrtc/rtc_base/network/ecn_marking_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/network/ecn_marking_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/network/sent_packet_gn/moz.build b/third_party/libwebrtc/rtc_base/network/sent_packet_gn/moz.build
+index 604cb9a5e8c83..9720569e9f45c 100644
+--- a/third_party/libwebrtc/rtc_base/network/sent_packet_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/network/sent_packet_gn/moz.build
+@@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/network_constants_gn/moz.build b/third_party/libwebrtc/rtc_base/network_constants_gn/moz.build
+index eacf185197862..d86cc1dfdd322 100644
+--- a/third_party/libwebrtc/rtc_base/network_constants_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/network_constants_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/network_route_gn/moz.build b/third_party/libwebrtc/rtc_base/network_route_gn/moz.build
+index 2ae8cf3c3837a..29577a4ef1019 100644
+--- a/third_party/libwebrtc/rtc_base/network_route_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/network_route_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/null_socket_server_gn/moz.build b/third_party/libwebrtc/rtc_base/null_socket_server_gn/moz.build
+index da5eb5b49753a..0115b8aa67a4b 100644
+--- a/third_party/libwebrtc/rtc_base/null_socket_server_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/null_socket_server_gn/moz.build
+@@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/one_time_event_gn/moz.build b/third_party/libwebrtc/rtc_base/one_time_event_gn/moz.build
+index 4de80444bef47..ba09c026e1a69 100644
+--- a/third_party/libwebrtc/rtc_base/one_time_event_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/one_time_event_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/platform_thread_gn/moz.build b/third_party/libwebrtc/rtc_base/platform_thread_gn/moz.build
+index 8c259b6765c4f..702a66b0487c7 100644
+--- a/third_party/libwebrtc/rtc_base/platform_thread_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/platform_thread_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/platform_thread_types_gn/moz.build b/third_party/libwebrtc/rtc_base/platform_thread_types_gn/moz.build
+index 09d6147ce17dd..044a2a040a923 100644
+--- a/third_party/libwebrtc/rtc_base/platform_thread_types_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/platform_thread_types_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/protobuf_utils_gn/moz.build b/third_party/libwebrtc/rtc_base/protobuf_utils_gn/moz.build
+index c2b0d4ce2f3a7..77ed1ccd5d15a 100644
+--- a/third_party/libwebrtc/rtc_base/protobuf_utils_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/protobuf_utils_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/race_checker_gn/moz.build b/third_party/libwebrtc/rtc_base/race_checker_gn/moz.build
+index 1fef37a2babc7..646c506f7bda3 100644
+--- a/third_party/libwebrtc/rtc_base/race_checker_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/race_checker_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/random_gn/moz.build b/third_party/libwebrtc/rtc_base/random_gn/moz.build
+index 6c9b369317a56..b244cf3c63f95 100644
+--- a/third_party/libwebrtc/rtc_base/random_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/random_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/rate_limiter_gn/moz.build b/third_party/libwebrtc/rtc_base/rate_limiter_gn/moz.build
+index 586fc513dc7e5..2383278249423 100644
+--- a/third_party/libwebrtc/rtc_base/rate_limiter_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/rate_limiter_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/rate_statistics_gn/moz.build b/third_party/libwebrtc/rtc_base/rate_statistics_gn/moz.build
+index 76d4f9d980aee..89fc7b6c88d80 100644
+--- a/third_party/libwebrtc/rtc_base/rate_statistics_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/rate_statistics_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/rate_tracker_gn/moz.build b/third_party/libwebrtc/rtc_base/rate_tracker_gn/moz.build
+index c381e91cdc554..93793d6d9d69b 100644
+--- a/third_party/libwebrtc/rtc_base/rate_tracker_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/rate_tracker_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/refcount_gn/moz.build b/third_party/libwebrtc/rtc_base/refcount_gn/moz.build
+index 4059c66e7135d..1d99acfc987a4 100644
+--- a/third_party/libwebrtc/rtc_base/refcount_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/refcount_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/rolling_accumulator_gn/moz.build b/third_party/libwebrtc/rtc_base/rolling_accumulator_gn/moz.build
+index c8e14d5996e0c..624ceec102534 100644
+--- a/third_party/libwebrtc/rtc_base/rolling_accumulator_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/rolling_accumulator_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/rtc_event_gn/moz.build b/third_party/libwebrtc/rtc_base/rtc_event_gn/moz.build
+index a1b2840da3ea2..8dd1830b2cccb 100644
+--- a/third_party/libwebrtc/rtc_base/rtc_event_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/rtc_event_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/rtc_numerics_gn/moz.build b/third_party/libwebrtc/rtc_base/rtc_numerics_gn/moz.build
+index 6bcce7ecf591d..fab2c2acf14b1 100644
+--- a/third_party/libwebrtc/rtc_base/rtc_numerics_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/rtc_numerics_gn/moz.build
+@@ -145,6 +145,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/safe_compare_gn/moz.build b/third_party/libwebrtc/rtc_base/safe_compare_gn/moz.build
+index 1e381892f367d..1d20d4b9a8832 100644
+--- a/third_party/libwebrtc/rtc_base/safe_compare_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/safe_compare_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/safe_conversions_gn/moz.build b/third_party/libwebrtc/rtc_base/safe_conversions_gn/moz.build
+index f409a3834780c..5de066b506b92 100644
+--- a/third_party/libwebrtc/rtc_base/safe_conversions_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/safe_conversions_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/safe_minmax_gn/moz.build b/third_party/libwebrtc/rtc_base/safe_minmax_gn/moz.build
+index 31299792ebebf..a702ead45989d 100644
+--- a/third_party/libwebrtc/rtc_base/safe_minmax_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/safe_minmax_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/sample_counter_gn/moz.build b/third_party/libwebrtc/rtc_base/sample_counter_gn/moz.build
+index 0657de77c15bc..7387bc5630993 100644
+--- a/third_party/libwebrtc/rtc_base/sample_counter_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/sample_counter_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/sanitizer_gn/moz.build b/third_party/libwebrtc/rtc_base/sanitizer_gn/moz.build
+index dcdcffdd8ef45..81c8160cff54f 100644
+--- a/third_party/libwebrtc/rtc_base/sanitizer_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/sanitizer_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/socket_address_gn/moz.build b/third_party/libwebrtc/rtc_base/socket_address_gn/moz.build
+index 2e5c00378acd6..61b9d40f4d365 100644
+--- a/third_party/libwebrtc/rtc_base/socket_address_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/socket_address_gn/moz.build
+@@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/socket_factory_gn/moz.build b/third_party/libwebrtc/rtc_base/socket_factory_gn/moz.build
+index 572b2f62b08cc..65a197c45742a 100644
+--- a/third_party/libwebrtc/rtc_base/socket_factory_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/socket_factory_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/socket_gn/moz.build b/third_party/libwebrtc/rtc_base/socket_gn/moz.build
+index 4b08aeb0de918..710871916811f 100644
+--- a/third_party/libwebrtc/rtc_base/socket_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/socket_gn/moz.build
+@@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/socket_server_gn/moz.build b/third_party/libwebrtc/rtc_base/socket_server_gn/moz.build
+index d4654af6fc1f7..fbf7baddffa28 100644
+--- a/third_party/libwebrtc/rtc_base/socket_server_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/socket_server_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/ssl_adapter_gn/moz.build b/third_party/libwebrtc/rtc_base/ssl_adapter_gn/moz.build
+index 599001039a487..d184a89973898 100644
+--- a/third_party/libwebrtc/rtc_base/ssl_adapter_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/ssl_adapter_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/stringutils_gn/moz.build b/third_party/libwebrtc/rtc_base/stringutils_gn/moz.build
+index 5016b4fce0592..3bd638067b05f 100644
+--- a/third_party/libwebrtc/rtc_base/stringutils_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/stringutils_gn/moz.build
+@@ -147,6 +147,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/swap_queue_gn/moz.build b/third_party/libwebrtc/rtc_base/swap_queue_gn/moz.build
+index b84cec9997f36..05d753843959a 100644
+--- a/third_party/libwebrtc/rtc_base/swap_queue_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/swap_queue_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/synchronization/mutex_gn/moz.build b/third_party/libwebrtc/rtc_base/synchronization/mutex_gn/moz.build
+index c1704d2629495..6b346305bbc0d 100644
+--- a/third_party/libwebrtc/rtc_base/synchronization/mutex_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/synchronization/mutex_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/synchronization/sequence_checker_internal_gn/moz.build b/third_party/libwebrtc/rtc_base/synchronization/sequence_checker_internal_gn/moz.build
+index e4f72d3635309..c3cf0e6275aac 100644
+--- a/third_party/libwebrtc/rtc_base/synchronization/sequence_checker_internal_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/synchronization/sequence_checker_internal_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/synchronization/yield_gn/moz.build b/third_party/libwebrtc/rtc_base/synchronization/yield_gn/moz.build
+index 98232a67bd399..6c775aa652282 100644
+--- a/third_party/libwebrtc/rtc_base/synchronization/yield_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/synchronization/yield_gn/moz.build
+@@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/synchronization/yield_policy_gn/moz.build b/third_party/libwebrtc/rtc_base/synchronization/yield_policy_gn/moz.build
+index 40dcd7ba2f70e..0c08d9e2ba307 100644
+--- a/third_party/libwebrtc/rtc_base/synchronization/yield_policy_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/synchronization/yield_policy_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/system/arch_gn/moz.build b/third_party/libwebrtc/rtc_base/system/arch_gn/moz.build
+index 1d1555984fb07..7c795caae78c9 100644
+--- a/third_party/libwebrtc/rtc_base/system/arch_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/system/arch_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/system/file_wrapper_gn/moz.build b/third_party/libwebrtc/rtc_base/system/file_wrapper_gn/moz.build
+index 807f4726e1026..0055ebd41ff05 100644
+--- a/third_party/libwebrtc/rtc_base/system/file_wrapper_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/system/file_wrapper_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/system/ignore_warnings_gn/moz.build b/third_party/libwebrtc/rtc_base/system/ignore_warnings_gn/moz.build
+index 7a5b33257453f..42561daf5711b 100644
+--- a/third_party/libwebrtc/rtc_base/system/ignore_warnings_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/system/ignore_warnings_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/system/inline_gn/moz.build b/third_party/libwebrtc/rtc_base/system/inline_gn/moz.build
+index 7df25c5644f17..06e4935660aa5 100644
+--- a/third_party/libwebrtc/rtc_base/system/inline_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/system/inline_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/system/no_unique_address_gn/moz.build b/third_party/libwebrtc/rtc_base/system/no_unique_address_gn/moz.build
+index 17a93fe6bf50f..6d1e015fede37 100644
+--- a/third_party/libwebrtc/rtc_base/system/no_unique_address_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/system/no_unique_address_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/system/rtc_export_gn/moz.build b/third_party/libwebrtc/rtc_base/system/rtc_export_gn/moz.build
+index e0c1fd16dc3e2..396a651192e55 100644
+--- a/third_party/libwebrtc/rtc_base/system/rtc_export_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/system/rtc_export_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/system/unused_gn/moz.build b/third_party/libwebrtc/rtc_base/system/unused_gn/moz.build
+index 11c7d7e1a9c32..7e5d26eabfb2c 100644
+--- a/third_party/libwebrtc/rtc_base/system/unused_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/system/unused_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/system/warn_current_thread_is_deadlocked_gn/moz.build b/third_party/libwebrtc/rtc_base/system/warn_current_thread_is_deadlocked_gn/moz.build
+index 72142098bf1c4..94e93e2c94741 100644
+--- a/third_party/libwebrtc/rtc_base/system/warn_current_thread_is_deadlocked_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/system/warn_current_thread_is_deadlocked_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/task_utils/repeating_task_gn/moz.build b/third_party/libwebrtc/rtc_base/task_utils/repeating_task_gn/moz.build
+index b6057410da79c..e6ac836fe84e8 100644
+--- a/third_party/libwebrtc/rtc_base/task_utils/repeating_task_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/task_utils/repeating_task_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/third_party/base64/base64_gn/moz.build b/third_party/libwebrtc/rtc_base/third_party/base64/base64_gn/moz.build
+index cd7049d1e1ad1..ff094d9427734 100644
+--- a/third_party/libwebrtc/rtc_base/third_party/base64/base64_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/third_party/base64/base64_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/third_party/sigslot/sigslot_gn/moz.build b/third_party/libwebrtc/rtc_base/third_party/sigslot/sigslot_gn/moz.build
+index b4ca57145cffb..be9d399baf38b 100644
+--- a/third_party/libwebrtc/rtc_base/third_party/sigslot/sigslot_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/third_party/sigslot/sigslot_gn/moz.build
+@@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/threading_gn/moz.build b/third_party/libwebrtc/rtc_base/threading_gn/moz.build
+index 53ae39a12405f..679258f514ddd 100644
+--- a/third_party/libwebrtc/rtc_base/threading_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/threading_gn/moz.build
+@@ -170,6 +170,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/timeutils_gn/moz.build b/third_party/libwebrtc/rtc_base/timeutils_gn/moz.build
+index 55044da704f09..54b8976af8d06 100644
+--- a/third_party/libwebrtc/rtc_base/timeutils_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/timeutils_gn/moz.build
+@@ -152,6 +152,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/type_traits_gn/moz.build b/third_party/libwebrtc/rtc_base/type_traits_gn/moz.build
+index 6e5a6266c98d0..bd1429ccb868f 100644
+--- a/third_party/libwebrtc/rtc_base/type_traits_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/type_traits_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/unique_id_generator_gn/moz.build b/third_party/libwebrtc/rtc_base/unique_id_generator_gn/moz.build
+index 144e5ff789f9d..d96430b2e7807 100644
+--- a/third_party/libwebrtc/rtc_base/unique_id_generator_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/unique_id_generator_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/units/unit_base_gn/moz.build b/third_party/libwebrtc/rtc_base/units/unit_base_gn/moz.build
+index 1a73da55be6de..ab73c96ec8a87 100644
+--- a/third_party/libwebrtc/rtc_base/units/unit_base_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/units/unit_base_gn/moz.build
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/weak_ptr_gn/moz.build b/third_party/libwebrtc/rtc_base/weak_ptr_gn/moz.build
+index 24bcc6accf790..2f76d89047de2 100644
+--- a/third_party/libwebrtc/rtc_base/weak_ptr_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/weak_ptr_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/zero_memory_gn/moz.build b/third_party/libwebrtc/rtc_base/zero_memory_gn/moz.build
+index 3cb03f6879696..9a3495582c7a5 100644
+--- a/third_party/libwebrtc/rtc_base/zero_memory_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/zero_memory_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/system_wrappers/denormal_disabler_gn/moz.build b/third_party/libwebrtc/system_wrappers/denormal_disabler_gn/moz.build
+index cd0bc1b144b83..6bfcafef69be3 100644
+--- a/third_party/libwebrtc/system_wrappers/denormal_disabler_gn/moz.build
++++ b/third_party/libwebrtc/system_wrappers/denormal_disabler_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/system_wrappers/field_trial_gn/moz.build b/third_party/libwebrtc/system_wrappers/field_trial_gn/moz.build
+index 30aa20ae3ede5..1a9247571a3b5 100644
+--- a/third_party/libwebrtc/system_wrappers/field_trial_gn/moz.build
++++ b/third_party/libwebrtc/system_wrappers/field_trial_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/system_wrappers/metrics_gn/moz.build b/third_party/libwebrtc/system_wrappers/metrics_gn/moz.build
+index 2347fbcbacf53..64db8cecaa80e 100644
+--- a/third_party/libwebrtc/system_wrappers/metrics_gn/moz.build
++++ b/third_party/libwebrtc/system_wrappers/metrics_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/system_wrappers/system_wrappers_gn/moz.build b/third_party/libwebrtc/system_wrappers/system_wrappers_gn/moz.build
+index 161fe336d913c..65d379234a186 100644
+--- a/third_party/libwebrtc/system_wrappers/system_wrappers_gn/moz.build
++++ b/third_party/libwebrtc/system_wrappers/system_wrappers_gn/moz.build
+@@ -168,6 +168,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/test/network/simulated_network_gn/moz.build b/third_party/libwebrtc/test/network/simulated_network_gn/moz.build
+index 26939945bfb98..9ccc1b5e02f2d 100644
+--- a/third_party/libwebrtc/test/network/simulated_network_gn/moz.build
++++ b/third_party/libwebrtc/test/network/simulated_network_gn/moz.build
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/test/rtp_test_utils_gn/moz.build b/third_party/libwebrtc/test/rtp_test_utils_gn/moz.build
+index 5a0d4a3984ef3..4ea4016ab1fce 100644
+--- a/third_party/libwebrtc/test/rtp_test_utils_gn/moz.build
++++ b/third_party/libwebrtc/test/rtp_test_utils_gn/moz.build
+@@ -147,6 +147,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/algorithm/algorithm_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/algorithm/algorithm_gn/moz.build
+index 696c19c0a0908..8fe6e8be0139f 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/algorithm/algorithm_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/algorithm/algorithm_gn/moz.build
+@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
+     DEFINES["_WINDOWS"] = True
+     DEFINES["__STD_C"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/algorithm/container_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/algorithm/container_gn/moz.build
+index 376a6873a7de1..e6157f2d3e2bb 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/algorithm/container_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/algorithm/container_gn/moz.build
+@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
+     DEFINES["_WINDOWS"] = True
+     DEFINES["__STD_C"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/atomic_hook_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/atomic_hook_gn/moz.build
+index 1dbf8b3037110..7cf1035a0bf2d 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/atomic_hook_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/atomic_hook_gn/moz.build
+@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
+     DEFINES["_WINDOWS"] = True
+     DEFINES["__STD_C"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/base_internal_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/base_internal_gn/moz.build
+index c74d13c51a7fd..04eb10e737168 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/base_internal_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/base_internal_gn/moz.build
+@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
+     DEFINES["_WINDOWS"] = True
+     DEFINES["__STD_C"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/config_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/config_gn/moz.build
+index 5cd792ccd5d26..f01a3d7920fab 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/config_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/config_gn/moz.build
+@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
+     DEFINES["_WINDOWS"] = True
+     DEFINES["__STD_C"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/core_headers_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/core_headers_gn/moz.build
+index 26296e769d534..8e63fb471ea10 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/core_headers_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/core_headers_gn/moz.build
+@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
+     DEFINES["_WINDOWS"] = True
+     DEFINES["__STD_C"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/log_severity_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/log_severity_gn/moz.build
+index 284ba12620092..25693df8caa18 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/log_severity_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/log_severity_gn/moz.build
+@@ -101,6 +101,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+         "-mfpu=neon"
+     ]
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/nullability_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/nullability_gn/moz.build
+index f152e046ce649..bcbd06dea2621 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/nullability_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/nullability_gn/moz.build
+@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
+     DEFINES["_WINDOWS"] = True
+     DEFINES["__STD_C"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/raw_logging_internal_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/raw_logging_internal_gn/moz.build
+index 67100a47728f6..bc4df9942bdf5 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/raw_logging_internal_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/raw_logging_internal_gn/moz.build
+@@ -101,6 +101,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+         "-mfpu=neon"
+     ]
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/throw_delegate_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/throw_delegate_gn/moz.build
+index 06b91ef80d221..c89bb5e994930 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/throw_delegate_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/throw_delegate_gn/moz.build
+@@ -101,6 +101,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+         "-mfpu=neon"
+     ]
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/cleanup/cleanup_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/cleanup/cleanup_gn/moz.build
+index 8ed66c3ce2c63..ca4101d72c102 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/cleanup/cleanup_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/cleanup/cleanup_gn/moz.build
+@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
+     DEFINES["_WINDOWS"] = True
+     DEFINES["__STD_C"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/cleanup/cleanup_internal_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/cleanup/cleanup_internal_gn/moz.build
+index 0f3944e348c4c..0e30135bbb61f 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/cleanup/cleanup_internal_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/cleanup/cleanup_internal_gn/moz.build
+@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
+     DEFINES["_WINDOWS"] = True
+     DEFINES["__STD_C"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/container/compressed_tuple_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/container/compressed_tuple_gn/moz.build
+index 758e27e19bdfe..ebac3923d8848 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/container/compressed_tuple_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/container/compressed_tuple_gn/moz.build
+@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
+     DEFINES["_WINDOWS"] = True
+     DEFINES["__STD_C"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/container/inlined_vector_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/container/inlined_vector_gn/moz.build
+index 0aeeb25380b2e..8095e437b2435 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/container/inlined_vector_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/container/inlined_vector_gn/moz.build
+@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
+     DEFINES["_WINDOWS"] = True
+     DEFINES["__STD_C"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/container/inlined_vector_internal_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/container/inlined_vector_internal_gn/moz.build
+index 3b6744eda7335..8c6de006b5c3f 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/container/inlined_vector_internal_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/container/inlined_vector_internal_gn/moz.build
+@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
+     DEFINES["_WINDOWS"] = True
+     DEFINES["__STD_C"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/functional/any_invocable_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/functional/any_invocable_gn/moz.build
+index 63e6206cdfb47..2af18da4caf1f 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/functional/any_invocable_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/functional/any_invocable_gn/moz.build
+@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
+     DEFINES["_WINDOWS"] = True
+     DEFINES["__STD_C"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/functional/bind_front_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/functional/bind_front_gn/moz.build
+index c26f1ed6a4812..64f2808f3c904 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/functional/bind_front_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/functional/bind_front_gn/moz.build
+@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
+     DEFINES["_WINDOWS"] = True
+     DEFINES["__STD_C"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/memory/memory_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/memory/memory_gn/moz.build
+index 398b663a3d1ea..6e8505c311784 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/memory/memory_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/memory/memory_gn/moz.build
+@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
+     DEFINES["_WINDOWS"] = True
+     DEFINES["__STD_C"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/meta/type_traits_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/meta/type_traits_gn/moz.build
+index 6d2e55152f525..67080088dd359 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/meta/type_traits_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/meta/type_traits_gn/moz.build
+@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
+     DEFINES["_WINDOWS"] = True
+     DEFINES["__STD_C"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/numeric/bits_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/numeric/bits_gn/moz.build
+index 765dc92eb6d30..3aaddd05a899c 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/numeric/bits_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/numeric/bits_gn/moz.build
+@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
+     DEFINES["_WINDOWS"] = True
+     DEFINES["__STD_C"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/numeric/int128_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/numeric/int128_gn/moz.build
+index 0d1a183abaf9f..f6a72bb07e575 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/numeric/int128_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/numeric/int128_gn/moz.build
+@@ -101,6 +101,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+         "-mfpu=neon"
+     ]
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/strings/string_view_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/strings/string_view_gn/moz.build
+index 4002fa6263030..62943daaa9896 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/strings/string_view_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/strings/string_view_gn/moz.build
+@@ -101,6 +101,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+         "-mfpu=neon"
+     ]
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/strings/strings_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/strings/strings_gn/moz.build
+index 8105bb2f27d1d..789fb9bc7cd6e 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/strings/strings_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/strings/strings_gn/moz.build
+@@ -106,6 +106,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+         "-mfpu=neon"
+     ]
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/bad_optional_access_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/bad_optional_access_gn/moz.build
+index 25164c3e5f91b..2c5d7f3de36b2 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/bad_optional_access_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/bad_optional_access_gn/moz.build
+@@ -101,6 +101,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+         "-mfpu=neon"
+     ]
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/bad_variant_access_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/bad_variant_access_gn/moz.build
+index 83007237aa435..448a79a6f908e 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/bad_variant_access_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/bad_variant_access_gn/moz.build
+@@ -101,6 +101,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+         "-mfpu=neon"
+     ]
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/optional_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/optional_gn/moz.build
+index 890fa95dc8507..b399b73c72bcc 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/optional_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/optional_gn/moz.build
+@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
+     DEFINES["_WINDOWS"] = True
+     DEFINES["__STD_C"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/span_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/span_gn/moz.build
+index 438c3e8f7ca61..f64a2b73bf2ad 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/span_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/span_gn/moz.build
+@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
+     DEFINES["_WINDOWS"] = True
+     DEFINES["__STD_C"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/variant_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/variant_gn/moz.build
+index b548c0214b550..dc3a973fe547a 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/variant_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/variant_gn/moz.build
+@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
+     DEFINES["_WINDOWS"] = True
+     DEFINES["__STD_C"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/utility/utility_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/utility/utility_gn/moz.build
+index c47e6649127c3..6738c524bc3ad 100644
+--- a/third_party/libwebrtc/third_party/abseil-cpp/absl/utility/utility_gn/moz.build
++++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/utility/utility_gn/moz.build
+@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
+     DEFINES["_WINDOWS"] = True
+     DEFINES["__STD_C"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/third_party/libyuv/libyuv_gn/moz.build b/third_party/libwebrtc/third_party/libyuv/libyuv_gn/moz.build
+index a3038e0c4a61a..b7f3404ef0e7c 100644
+--- a/third_party/libwebrtc/third_party/libyuv/libyuv_gn/moz.build
++++ b/third_party/libwebrtc/third_party/libyuv/libyuv_gn/moz.build
+@@ -133,6 +133,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/third_party/pffft/pffft_gn/moz.build b/third_party/libwebrtc/third_party/pffft/pffft_gn/moz.build
+index 836a04a7c7234..dc7c06ffc21f6 100644
+--- a/third_party/libwebrtc/third_party/pffft/pffft_gn/moz.build
++++ b/third_party/libwebrtc/third_party/pffft/pffft_gn/moz.build
+@@ -105,6 +105,11 @@ if CONFIG["TARGET_CPU"] == "arm":
+         "-mfpu=neon"
+     ]
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["PFFFT_SIMD_DISABLE"] = True
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["PFFFT_SIMD_DISABLE"] = True
+diff --git a/third_party/libwebrtc/third_party/rnnoise/rnn_vad_gn/moz.build b/third_party/libwebrtc/third_party/rnnoise/rnn_vad_gn/moz.build
+index b10b4c330ef81..2dfd79a68cf7a 100644
+--- a/third_party/libwebrtc/third_party/rnnoise/rnn_vad_gn/moz.build
++++ b/third_party/libwebrtc/third_party/rnnoise/rnn_vad_gn/moz.build
+@@ -104,6 +104,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+         "-mfpu=neon"
+     ]
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["_GNU_SOURCE"] = True
+diff --git a/third_party/libwebrtc/video/adaptation/video_adaptation_gn/moz.build b/third_party/libwebrtc/video/adaptation/video_adaptation_gn/moz.build
+index 54334034a2908..a361d16f18130 100644
+--- a/third_party/libwebrtc/video/adaptation/video_adaptation_gn/moz.build
++++ b/third_party/libwebrtc/video/adaptation/video_adaptation_gn/moz.build
+@@ -163,6 +163,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/video/config/encoder_config_gn/moz.build b/third_party/libwebrtc/video/config/encoder_config_gn/moz.build
+index 605a6b14f7f5c..dfe435da93a7a 100644
+--- a/third_party/libwebrtc/video/config/encoder_config_gn/moz.build
++++ b/third_party/libwebrtc/video/config/encoder_config_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/video/config/streams_config_gn/moz.build b/third_party/libwebrtc/video/config/streams_config_gn/moz.build
+index 3014de4682043..83fb010b0b8a8 100644
+--- a/third_party/libwebrtc/video/config/streams_config_gn/moz.build
++++ b/third_party/libwebrtc/video/config/streams_config_gn/moz.build
+@@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/video/decode_synchronizer_gn/moz.build b/third_party/libwebrtc/video/decode_synchronizer_gn/moz.build
+index c1ae808ab1bbf..ff744edf9a7e9 100644
+--- a/third_party/libwebrtc/video/decode_synchronizer_gn/moz.build
++++ b/third_party/libwebrtc/video/decode_synchronizer_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/video/frame_cadence_adapter_gn/moz.build b/third_party/libwebrtc/video/frame_cadence_adapter_gn/moz.build
+index 6e073f2e20c88..e0c3d716a8179 100644
+--- a/third_party/libwebrtc/video/frame_cadence_adapter_gn/moz.build
++++ b/third_party/libwebrtc/video/frame_cadence_adapter_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/video/frame_decode_scheduler_gn/moz.build b/third_party/libwebrtc/video/frame_decode_scheduler_gn/moz.build
+index dfe1ecd08c0cd..4f39955e9f382 100644
+--- a/third_party/libwebrtc/video/frame_decode_scheduler_gn/moz.build
++++ b/third_party/libwebrtc/video/frame_decode_scheduler_gn/moz.build
+@@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/video/frame_decode_timing_gn/moz.build b/third_party/libwebrtc/video/frame_decode_timing_gn/moz.build
+index f1b85291c7701..2754fa11c1634 100644
+--- a/third_party/libwebrtc/video/frame_decode_timing_gn/moz.build
++++ b/third_party/libwebrtc/video/frame_decode_timing_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/video/frame_dumping_decoder_gn/moz.build b/third_party/libwebrtc/video/frame_dumping_decoder_gn/moz.build
+index 001433ce9ffec..9338f84a50f2c 100644
+--- a/third_party/libwebrtc/video/frame_dumping_decoder_gn/moz.build
++++ b/third_party/libwebrtc/video/frame_dumping_decoder_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/video/frame_dumping_encoder_gn/moz.build b/third_party/libwebrtc/video/frame_dumping_encoder_gn/moz.build
+index a3bf0c641a1dd..27a5d945deabc 100644
+--- a/third_party/libwebrtc/video/frame_dumping_encoder_gn/moz.build
++++ b/third_party/libwebrtc/video/frame_dumping_encoder_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/video/render/incoming_video_stream_gn/moz.build b/third_party/libwebrtc/video/render/incoming_video_stream_gn/moz.build
+index 42488b31f3f81..721ef67ace649 100644
+--- a/third_party/libwebrtc/video/render/incoming_video_stream_gn/moz.build
++++ b/third_party/libwebrtc/video/render/incoming_video_stream_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/video/render/video_render_frames_gn/moz.build b/third_party/libwebrtc/video/render/video_render_frames_gn/moz.build
+index 24bd462a0c8ef..c4709991ec748 100644
+--- a/third_party/libwebrtc/video/render/video_render_frames_gn/moz.build
++++ b/third_party/libwebrtc/video/render/video_render_frames_gn/moz.build
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/video/task_queue_frame_decode_scheduler_gn/moz.build b/third_party/libwebrtc/video/task_queue_frame_decode_scheduler_gn/moz.build
+index d1ee8ffccb724..1bae2bfe1b1fd 100644
+--- a/third_party/libwebrtc/video/task_queue_frame_decode_scheduler_gn/moz.build
++++ b/third_party/libwebrtc/video/task_queue_frame_decode_scheduler_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/video/unique_timestamp_counter_gn/moz.build b/third_party/libwebrtc/video/unique_timestamp_counter_gn/moz.build
+index b0eb431cfba75..636f41f80f9ea 100644
+--- a/third_party/libwebrtc/video/unique_timestamp_counter_gn/moz.build
++++ b/third_party/libwebrtc/video/unique_timestamp_counter_gn/moz.build
+@@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/video/video_gn/moz.build b/third_party/libwebrtc/video/video_gn/moz.build
+index 09826d37f927c..3ca669afab8b4 100644
+--- a/third_party/libwebrtc/video/video_gn/moz.build
++++ b/third_party/libwebrtc/video/video_gn/moz.build
+@@ -174,6 +174,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/video/video_receive_stream_timeout_tracker_gn/moz.build b/third_party/libwebrtc/video/video_receive_stream_timeout_tracker_gn/moz.build
+index d24bf03a5991f..f29c6509d473b 100644
+--- a/third_party/libwebrtc/video/video_receive_stream_timeout_tracker_gn/moz.build
++++ b/third_party/libwebrtc/video/video_receive_stream_timeout_tracker_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/video/video_stream_buffer_controller_gn/moz.build b/third_party/libwebrtc/video/video_stream_buffer_controller_gn/moz.build
+index b99c992d4953d..bb35fd9f657ac 100644
+--- a/third_party/libwebrtc/video/video_stream_buffer_controller_gn/moz.build
++++ b/third_party/libwebrtc/video/video_stream_buffer_controller_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/video/video_stream_encoder_impl_gn/moz.build b/third_party/libwebrtc/video/video_stream_encoder_impl_gn/moz.build
+index a51248556ab13..7e4144879dd4b 100644
+--- a/third_party/libwebrtc/video/video_stream_encoder_impl_gn/moz.build
++++ b/third_party/libwebrtc/video/video_stream_encoder_impl_gn/moz.build
+@@ -160,6 +160,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/video/video_stream_encoder_interface_gn/moz.build b/third_party/libwebrtc/video/video_stream_encoder_interface_gn/moz.build
+index 7eeb5d9f42031..e56f626416bc9 100644
+--- a/third_party/libwebrtc/video/video_stream_encoder_interface_gn/moz.build
++++ b/third_party/libwebrtc/video/video_stream_encoder_interface_gn/moz.build
+@@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/webrtc_gn/moz.build b/third_party/libwebrtc/webrtc_gn/moz.build
+index 0a5908916a503..4ba08802c685c 100644
+--- a/third_party/libwebrtc/webrtc_gn/moz.build
++++ b/third_party/libwebrtc/webrtc_gn/moz.build
+@@ -170,6 +170,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+-- 
+2.45.2
+

--- a/firefox-developer-edition/0005-enable-webrtc-for-loongarch64-in-toolkit-moz.configu.patch
+++ b/firefox-developer-edition/0005-enable-webrtc-for-loongarch64-in-toolkit-moz.configu.patch
@@ -1,0 +1,25 @@
+From da56f912ba9a43f5396d814af40b75e270f1ed55 Mon Sep 17 00:00:00 2001
+From: WANG Xuerui <xen0n@gentoo.org>
+Date: Tue, 3 Sep 2024 15:39:18 +0800
+Subject: [PATCH 5/6] enable webrtc for loongarch64 in toolkit/moz.configure
+
+Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
+---
+ toolkit/moz.configure | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/toolkit/moz.configure b/toolkit/moz.configure
+index 1f85d2831f2f7..4291befdc60f8 100644
+--- a/toolkit/moz.configure
++++ b/toolkit/moz.configure
+@@ -1518,6 +1518,7 @@ def webrtc_default(target):
+         "aarch64",
+         "x86",
+         "ia64",
++        "loongarch64",
+         "mips32",
+         "mips64",
+         "ppc",
+-- 
+2.45.2
+

--- a/firefox-developer-edition/0006-Fix-libyuv-unified-source-and-LoongArch-SIMD-build.patch
+++ b/firefox-developer-edition/0006-Fix-libyuv-unified-source-and-LoongArch-SIMD-build.patch
@@ -1,0 +1,81 @@
+From 77afa8d8ca8d7c785284dc02aff7c6b364a9f841 Mon Sep 17 00:00:00 2001
+From: WANG Xuerui <xen0n@gentoo.org>
+Date: Tue, 3 Sep 2024 15:47:26 +0800
+Subject: [PATCH 6/6] Fix libyuv unified-source and LoongArch SIMD build
+
+Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
+---
+ media/libyuv/libyuv/libyuv.gypi       |  4 ++++
+ media/libyuv/libyuv/source/row_lsx.cc | 10 ++++++++++
+ 2 files changed, 14 insertions(+)
+
+diff --git a/media/libyuv/libyuv/libyuv.gypi b/media/libyuv/libyuv/libyuv.gypi
+index 1fd1be71e3414..fbe35fc42e6dc 100644
+--- a/media/libyuv/libyuv/libyuv.gypi
++++ b/media/libyuv/libyuv/libyuv.gypi
+@@ -80,11 +80,14 @@
+       'source/rotate_argb.cc',
+       'source/rotate_common.cc',
+       'source/rotate_gcc.cc',
++      'source/rotate_lsx.cc',
+       'source/rotate_msa.cc',
+       'source/rotate_win.cc',
+       'source/row_any.cc',
+       'source/row_common.cc',
+       'source/row_gcc.cc',
++      'source/row_lasx.cc',
++      'source/row_lsx.cc',
+       'source/row_msa.cc',
+       'source/row_win.cc',
+       'source/scale.cc',
+@@ -92,6 +95,7 @@
+       'source/scale_argb.cc',
+       'source/scale_common.cc',
+       'source/scale_gcc.cc',
++      'source/scale_lsx.cc',
+       'source/scale_msa.cc',
+       'source/scale_rgb.cc',
+       'source/scale_uv.cc',
+diff --git a/media/libyuv/libyuv/source/row_lsx.cc b/media/libyuv/libyuv/source/row_lsx.cc
+index 09f206cab93f2..a8988497e8200 100644
+--- a/media/libyuv/libyuv/source/row_lsx.cc
++++ b/media/libyuv/libyuv/source/row_lsx.cc
+@@ -2769,11 +2769,13 @@ void HalfFloatRow_LSX(const uint16_t* src,
+   }
+ }
+ 
++#ifndef RgbConstants
+ struct RgbConstants {
+   uint8_t kRGBToY[4];
+   uint16_t kAddY;
+   uint16_t pad;
+ };
++#define RgbConstants RgbConstants
+ 
+ // RGB to JPeg coefficients
+ // B * 0.1140 coefficient = 29
+@@ -2799,6 +2801,7 @@ static const struct RgbConstants kRgb24I601Constants = {{25, 129, 66, 0},
+ static const struct RgbConstants kRawI601Constants = {{66, 129, 25, 0},
+                                                       0x1080,
+                                                       0};
++#endif  // RgbConstants
+ 
+ // ARGB expects first 3 values to contain RGB and 4th value is ignored.
+ static void ARGBToYMatrixRow_LSX(const uint8_t* src_argb,
+@@ -2976,6 +2979,13 @@ void RAWToYRow_LSX(const uint8_t* src_raw, uint8_t* dst_y, int width) {
+   RGBToYMatrixRow_LSX(src_raw, dst_y, width, &kRawI601Constants);
+ }
+ 
++// undef for unified sources build
++#undef YUVTORGB_SETUP
++#undef YUVTORGB
++#undef I444TORGB
++#undef STOREARGB
++#undef RGBTOUV
++
+ #ifdef __cplusplus
+ }  // extern "C"
+ }  // namespace libyuv
+-- 
+2.45.2
+

--- a/firefox-developer-edition/0011-Add-missing-loongarch-lsx-code-for-libpng.patch
+++ b/firefox-developer-edition/0011-Add-missing-loongarch-lsx-code-for-libpng.patch
@@ -1,0 +1,554 @@
+From 52c3816b97e244ee2b4008b68bdb03bbb1e7685a Mon Sep 17 00:00:00 2001
+From: Jiajie Chen <c@jia.je>
+Date: Tue, 14 May 2024 16:36:09 -0700
+Subject: [PATCH 09/12] Add missing loongarch lsx code for libpng
+
+---
+ .../libpng/loongarch/filter_lsx_intrinsics.c  | 412 ++++++++++++++++++
+ media/libpng/loongarch/loongarch_lsx_init.c   |  65 +++
+ media/libpng/moz.build                        |   7 +
+ media/libpng/moz.yaml                         |   1 +
+ media/libpng/pnglibconf.h                     |   6 +
+ 5 files changed, 491 insertions(+)
+ create mode 100644 media/libpng/loongarch/filter_lsx_intrinsics.c
+ create mode 100644 media/libpng/loongarch/loongarch_lsx_init.c
+
+diff --git a/media/libpng/loongarch/filter_lsx_intrinsics.c b/media/libpng/loongarch/filter_lsx_intrinsics.c
+new file mode 100644
+index 0000000000..af6cc763a0
+--- /dev/null
++++ b/media/libpng/loongarch/filter_lsx_intrinsics.c
+@@ -0,0 +1,412 @@
++/* filter_lsx_intrinsics.c - LSX optimized filter functions
++ *
++ * Copyright (c) 2021 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Copyright (c) 2018 Cosmin Truta
++ * Copyright (c) 2016 Glenn Randers-Pehrson
++ * Contributed by Jin Bo (jinbo@loongson.cn)
++ *
++ * This code is released under the libpng license.
++ * For conditions of distribution and use, see the disclaimer
++ * and license in png.h
++ */
++
++#include "../pngpriv.h"
++
++#ifdef PNG_READ_SUPPORTED
++
++#if PNG_LOONGARCH_LSX_IMPLEMENTATION == 1 /* intrinsics code from pngpriv.h */
++
++#include <lsxintrin.h>
++
++#define LSX_LD(psrc) __lsx_vld((psrc), 0)
++
++#define LSX_LD_2(psrc, stride, out0, out1) \
++{                                          \
++   out0 = LSX_LD(psrc);                    \
++   out1 = LSX_LD(psrc + stride);           \
++}
++
++#define LSX_LD_4(psrc, stride, out0, out1, out2, out3) \
++{                                                      \
++   LSX_LD_2(psrc, stride, out0, out1);                 \
++   LSX_LD_2(psrc + stride * 2, stride, out2, out3);    \
++}
++
++#define LSX_ST(in, pdst) __lsx_vst(in, (pdst), 0)
++
++#define LSX_ST_2(in0, in1, pdst, stride) \
++{                                        \
++   LSX_ST(in0, pdst);                    \
++   LSX_ST(in1, pdst + stride);           \
++}
++
++#define LSX_ST_4(in0, in1, in2, in3, pdst, stride) \
++{                                                  \
++   LSX_ST_2(in0, in1, pdst, stride);               \
++   LSX_ST_2(in2, in3, pdst + stride * 2, stride);  \
++}
++
++#define LSX_ADD_B(in0, in1, out0) \
++{                                 \
++   out0 = __lsx_vadd_b(in0, in1); \
++}
++
++#define LSX_ADD_B_2(in0, in1, in2, in3, out0, out1) \
++{                                                   \
++   LSX_ADD_B(in0, in1, out0);                       \
++   LSX_ADD_B(in2, in3, out1);                       \
++}
++
++#define LSX_ADD_B_4(in0, in1, in2, in3, in4, in5,     \
++                    in6, in7, out0, out1, out2, out3) \
++{                                                     \
++   LSX_ADD_B_2(in0, in1, in2, in3, out0, out1);       \
++   LSX_ADD_B_2(in4, in5, in6, in7, out2, out3);       \
++}
++
++#define LSX_ABS_B_3(in0, in1, in2, out0, out1, out2) \
++{                                                    \
++   out0 = __lsx_vadda_h(in0, zero);                  \
++   out1 = __lsx_vadda_h(in1, zero);                  \
++   out2 = __lsx_vadda_h(in2, zero);                  \
++}
++
++#define LSX_ILVL_B(in_h, in_l, out0)  \
++{                                     \
++   out0 = __lsx_vilvl_b(in_h, in_l);  \
++}
++
++#define LSX_ILVL_B_2(in0_h, in0_l, in1_h, in1_l, out0, out1) \
++{                                                            \
++   LSX_ILVL_B(in0_h, in0_l, out0);                           \
++   LSX_ILVL_B(in1_h, in1_l, out1);                           \
++}
++
++#define LSX_HSUB_HU_BU_2(in0, in1, out0, out1) \
++{                                              \
++   out0 = __lsx_vhsubw_hu_bu(in0, in0);        \
++   out1 = __lsx_vhsubw_hu_bu(in1, in1);        \
++}
++
++#define LSX_CMP_PICK_SMALLER(in0, in1, in2, in3, in4, in5, out0) \
++{                                                                \
++   __m128i _cmph, _cmpb, _in0, _in3;                             \
++   _cmph = __lsx_vslt_h(in1, in0);                               \
++   _cmpb = __lsx_vpickev_b(_cmph, _cmph);                        \
++   _in0  = __lsx_vmin_bu(in0,in1);                               \
++   _in3  = __lsx_vbitsel_v(in3, in4, _cmpb);                     \
++   _cmph = __lsx_vslt_h(in2, _in0);                              \
++   _cmpb = __lsx_vpickev_b(_cmph, _cmph);                        \
++   _in3  = __lsx_vbitsel_v(_in3, in5, _cmpb);                    \
++   out0  = __lsx_vadd_b(out0, _in3);                             \
++}
++
++void png_read_filter_row_up_lsx(png_row_infop row_info, png_bytep row,
++                                png_const_bytep prev_row)
++{
++   size_t n = row_info->rowbytes;
++   png_bytep rp = row;
++   png_const_bytep pp = prev_row;
++   __m128i vec_0, vec_1, vec_2, vec_3;
++   __m128i vec_4, vec_5, vec_6, vec_7;
++
++   while (n >= 64)
++   {
++      LSX_LD_4(rp, 16, vec_0, vec_1, vec_2, vec_3);
++      LSX_LD_4(pp, 16, vec_4, vec_5, vec_6, vec_7);
++      pp += 64;
++      LSX_ADD_B_4(vec_0 ,vec_4, vec_1, vec_5, vec_2, vec_6,
++                  vec_3, vec_7, vec_0, vec_1, vec_2, vec_3);
++      LSX_ST_4(vec_0, vec_1, vec_2, vec_3, rp, 16);
++      rp += 64;
++      n -= 64;
++   }
++   if (n & 63)
++   {
++      if (n >= 32)
++      {
++         LSX_LD_2(rp, 16, vec_0, vec_1);
++         LSX_LD_2(pp, 16, vec_2, vec_3);
++         pp += 32;
++         LSX_ADD_B_2(vec_0, vec_2, vec_1, vec_3, vec_0, vec_1);
++         LSX_ST_2(vec_0, vec_1, rp, 16);
++         rp += 32;
++         n -= 32;
++      }
++      if (n & 31)
++      {
++         if (n >= 16)
++         {
++            vec_0 = LSX_LD(rp);
++            vec_1 = LSX_LD(pp);
++            pp += 16;
++            LSX_ADD_B(vec_0, vec_1, vec_0);
++            LSX_ST(vec_0, rp);
++            rp += 16;
++            n -= 16;
++         }
++         if (n >= 8)
++         {
++            vec_0 = __lsx_vldrepl_d(rp, 0);
++            vec_1 = __lsx_vldrepl_d(pp, 0);
++            vec_0 = __lsx_vadd_b(vec_0, vec_1);
++            __lsx_vstelm_d(vec_0, rp, 0, 0);
++            rp += 8;
++            pp += 8;
++            n -= 8;
++         }
++         while (n--)
++         {
++            *rp = *rp + *pp++;
++            rp++;
++         }
++      }
++   }
++}
++
++void png_read_filter_row_sub3_lsx(png_row_infop row_info, png_bytep row,
++                                  png_const_bytep prev_row)
++{
++   size_t n = row_info->rowbytes;
++   png_uint_32 tmp;
++   png_bytep nxt = row;
++   __m128i vec_0, vec_1;
++
++   PNG_UNUSED(prev_row);
++
++   vec_0 = __lsx_vldrepl_w(nxt, 0);
++   nxt += 3;
++   n -= 3;
++
++   while (n >= 3)
++   {
++      vec_1 = __lsx_vldrepl_w(nxt, 0);
++      vec_1 = __lsx_vadd_b(vec_1, vec_0);
++      __lsx_vstelm_h(vec_1, nxt, 0, 0);
++      vec_0 = vec_1;
++      nxt += 2;
++      __lsx_vstelm_b(vec_1, nxt, 0, 2);
++      nxt += 1;
++      n -= 3;
++   }
++
++   row = nxt - 3;
++   while (n--)
++   {
++      *nxt = *nxt + *row++;
++      nxt++;
++   }
++}
++
++void png_read_filter_row_sub4_lsx(png_row_infop row_info, png_bytep row,
++                                  png_const_bytep prev_row)
++{
++   size_t n = row_info->rowbytes;
++   __m128i vec_0, vec_1;
++
++   PNG_UNUSED(prev_row);
++
++   vec_0 = __lsx_vldrepl_w(row, 0);
++   row += 4;
++   n -= 4;
++
++   while (n >= 4)
++   {
++      vec_1 = __lsx_vldrepl_w(row, 0);
++      vec_1 = __lsx_vadd_b(vec_1, vec_0);
++      __lsx_vstelm_w(vec_1, row, 0, 0);
++      vec_0 = vec_1;
++      row += 4;
++      n -= 4;
++   }
++}
++
++void png_read_filter_row_avg3_lsx(png_row_infop row_info, png_bytep row,
++                                  png_const_bytep prev_row)
++{
++   size_t n = row_info->rowbytes;
++   png_bytep nxt = row;
++   png_const_bytep prev_nxt = prev_row;
++   __m128i vec_0, vec_1, vec_2;
++
++   vec_0 = __lsx_vldrepl_w(nxt, 0);
++   vec_1 = __lsx_vldrepl_w(prev_nxt, 0);
++   prev_nxt += 3;
++   vec_1 = __lsx_vsrli_b(vec_1, 1);
++   vec_1 = __lsx_vadd_b(vec_1, vec_0);
++   __lsx_vstelm_h(vec_1, nxt, 0, 0);
++   nxt += 2;
++   __lsx_vstelm_b(vec_1, nxt, 0, 2);
++   nxt += 1;
++   n -= 3;
++
++   while (n >= 3)
++   {
++      vec_2 = vec_1;
++      vec_0 = __lsx_vldrepl_w(nxt, 0);
++      vec_1 = __lsx_vldrepl_w(prev_nxt, 0);
++      prev_nxt += 3;
++
++      vec_1 = __lsx_vavg_bu(vec_1, vec_2);
++      vec_1 = __lsx_vadd_b(vec_1, vec_0);
++
++      __lsx_vstelm_h(vec_1, nxt, 0, 0);
++      nxt += 2;
++      __lsx_vstelm_b(vec_1, nxt, 0, 2);
++      nxt += 1;
++      n -= 3;
++   }
++
++   row = nxt - 3;
++   while (n--)
++   {
++      vec_2 = __lsx_vldrepl_b(row, 0);
++      row++;
++      vec_0 = __lsx_vldrepl_b(nxt, 0);
++      vec_1 = __lsx_vldrepl_b(prev_nxt, 0);
++      prev_nxt++;
++
++      vec_1 = __lsx_vavg_bu(vec_1, vec_2);
++      vec_1 = __lsx_vadd_b(vec_1, vec_0);
++
++      __lsx_vstelm_b(vec_1, nxt, 0, 0);
++      nxt++;
++   }
++}
++
++void png_read_filter_row_avg4_lsx(png_row_infop row_info, png_bytep row,
++                                  png_const_bytep prev_row)
++{
++   size_t n = row_info->rowbytes;
++   __m128i vec_0, vec_1, vec_2;
++
++   vec_0 = __lsx_vldrepl_w(row, 0);
++   vec_1 = __lsx_vldrepl_w(prev_row, 0);
++   prev_row += 4;
++   vec_1 = __lsx_vsrli_b(vec_1, 1);
++   vec_1 = __lsx_vadd_b(vec_1, vec_0);
++   __lsx_vstelm_w(vec_1, row, 0, 0);
++   row += 4;
++   n -= 4;
++
++   while (n >= 4)
++   {
++      vec_2 = vec_1;
++      vec_0 = __lsx_vldrepl_w(row, 0);
++      vec_1 = __lsx_vldrepl_w(prev_row, 0);
++      prev_row += 4;
++
++      vec_1 = __lsx_vavg_bu(vec_1, vec_2);
++      vec_1 = __lsx_vadd_b(vec_1, vec_0);
++
++      __lsx_vstelm_w(vec_1, row, 0, 0);
++      row += 4;
++      n -= 4;
++   }
++}
++
++void png_read_filter_row_paeth3_lsx(png_row_infop row_info,
++                                    png_bytep row,
++                                    png_const_bytep prev_row)
++{
++   size_t n = row_info->rowbytes;
++   png_bytep nxt = row;
++   png_const_bytep prev_nxt = prev_row;
++   __m128i vec_a, vec_b, vec_c, vec_d;
++   __m128i vec_pa, vec_pb, vec_pc;
++   __m128i zero = {0};
++
++   vec_a = __lsx_vldrepl_w(nxt, 0);
++   vec_b = __lsx_vldrepl_w(prev_nxt, 0);
++   prev_nxt += 3;
++   vec_d = __lsx_vadd_b(vec_a, vec_b);
++   __lsx_vstelm_h(vec_d, nxt, 0, 0);
++   nxt += 2;
++   __lsx_vstelm_b(vec_d, nxt, 0, 2);
++   nxt += 1;
++   n -= 3;
++
++   while (n >= 3)
++   {
++      vec_a = vec_d;
++      vec_c = vec_b;
++      vec_b = __lsx_vldrepl_w(prev_nxt, 0);
++      prev_nxt += 3;
++      vec_d = __lsx_vldrepl_w(nxt, 0);
++
++      LSX_ILVL_B_2(vec_b, vec_c, vec_a, vec_c, vec_pa, vec_pb);
++      LSX_HSUB_HU_BU_2(vec_pa, vec_pb, vec_pa, vec_pb);
++      vec_pc = __lsx_vadd_h(vec_pa, vec_pb);
++      LSX_ABS_B_3(vec_pa, vec_pb, vec_pc, vec_pa, vec_pb, vec_pc);
++      LSX_CMP_PICK_SMALLER(vec_pa, vec_pb, vec_pc, vec_a, vec_b, vec_c, vec_d);
++
++      __lsx_vstelm_h(vec_d, nxt, 0, 0);
++      nxt += 2;
++      __lsx_vstelm_b(vec_d, nxt, 0, 2);
++      nxt += 1;
++      n -= 3;
++   }
++
++   prev_row = prev_nxt - 3;
++   row = nxt - 3;
++   while (n--)
++   {
++      vec_a = __lsx_vldrepl_b(row, 0);
++      row++;
++      vec_b = __lsx_vldrepl_b(prev_nxt, 0);
++      prev_nxt++;
++      vec_c = __lsx_vldrepl_b(prev_row, 0);
++      prev_row++;
++      vec_d = __lsx_vldrepl_b(nxt, 0);
++
++      LSX_ILVL_B_2(vec_b, vec_c, vec_a, vec_c, vec_pa, vec_pb);
++      LSX_HSUB_HU_BU_2(vec_pa, vec_pb, vec_pa, vec_pb);
++      vec_pc = __lsx_vadd_h(vec_pa, vec_pb);
++      LSX_ABS_B_3(vec_pa, vec_pb, vec_pc, vec_pa, vec_pb, vec_pc);
++      LSX_CMP_PICK_SMALLER(vec_pa, vec_pb, vec_pc, vec_a, vec_b, vec_c, vec_d);
++
++      __lsx_vstelm_b(vec_d, nxt, 0, 0);
++      nxt++;
++   }
++}
++
++void png_read_filter_row_paeth4_lsx(png_row_infop row_info,
++                                    png_bytep row,
++                                    png_const_bytep prev_row)
++{
++   size_t n = row_info->rowbytes;
++   __m128i vec_a, vec_b, vec_c, vec_d;
++   __m128i vec_pa, vec_pb, vec_pc;
++   __m128i zero = {0};
++
++   vec_a = __lsx_vldrepl_w(row, 0);
++   vec_b = __lsx_vldrepl_w(prev_row, 0);
++   prev_row += 4;
++   vec_d = __lsx_vadd_b(vec_a, vec_b);
++   __lsx_vstelm_w(vec_d, row, 0, 0);
++   row += 4;
++   n -= 4;
++
++   while (n >= 4)
++   {
++      vec_a = vec_d;
++      vec_c = vec_b;
++      vec_b = __lsx_vldrepl_w(prev_row, 0);
++      prev_row += 4;
++      vec_d = __lsx_vldrepl_w(row, 0);
++
++      LSX_ILVL_B_2(vec_b, vec_c, vec_a, vec_c, vec_pa, vec_pb);
++      LSX_HSUB_HU_BU_2(vec_pa, vec_pb, vec_pa, vec_pb);
++      vec_pc = __lsx_vadd_h(vec_pa, vec_pb);
++      LSX_ABS_B_3(vec_pa, vec_pb, vec_pc, vec_pa, vec_pb, vec_pc);
++      LSX_CMP_PICK_SMALLER(vec_pa, vec_pb, vec_pc, vec_a, vec_b, vec_c, vec_d);
++
++      __lsx_vstelm_w(vec_d, row, 0, 0);
++      row += 4;
++      n -= 4;
++   }
++}
++
++#endif /* PNG_LOONGARCH_LSX_IMPLEMENTATION == 1 (intrinsics) */
++#endif /* PNG_READ_SUPPORTED */
+diff --git a/media/libpng/loongarch/loongarch_lsx_init.c b/media/libpng/loongarch/loongarch_lsx_init.c
+new file mode 100644
+index 0000000000..2c80fe81b6
+--- /dev/null
++++ b/media/libpng/loongarch/loongarch_lsx_init.c
+@@ -0,0 +1,65 @@
++/* loongarch_lsx_init.c - LSX optimized filter functions
++ *
++ * Copyright (c) 2021 Loongson Technology Corporation Limited
++ * All rights reserved.
++ * Contributed by Jin Bo <jinbo@loongson.cn>
++ *
++ * This code is released under the libpng license.
++ * For conditions of distribution and use, see the disclaimer
++ * and license in png.h
++ */
++
++#include "../pngpriv.h"
++
++#ifdef PNG_READ_SUPPORTED
++#if PNG_LOONGARCH_LSX_IMPLEMENTATION == 1
++
++#include <sys/auxv.h>
++
++#define LA_HWCAP_LSX    (1<<4)
++static int png_has_lsx(void)
++{
++    int flags = 0;
++    int flag  = (int)getauxval(AT_HWCAP);
++
++    if (flag & LA_HWCAP_LSX)
++        return 1;
++
++    return 0;
++}
++
++void
++png_init_filter_functions_lsx(png_structp pp, unsigned int bpp)
++{
++   /* IMPORTANT: any new external functions used here must be declared using
++    * PNG_INTERNAL_FUNCTION in ../pngpriv.h.  This is required so that the
++    * 'prefix' option to configure works:
++    *
++    *    ./configure --with-libpng-prefix=foobar_
++    *
++    * Verify you have got this right by running the above command, doing a build
++    * and examining pngprefix.h; it must contain a #define for every external
++    * function you add.  (Notice that this happens automatically for the
++    * initialization function.)
++    */
++
++   if (png_has_lsx())
++   {
++      pp->read_filter[PNG_FILTER_VALUE_UP-1] = png_read_filter_row_up_lsx;
++      if (bpp == 3)
++      {
++         pp->read_filter[PNG_FILTER_VALUE_SUB-1] = png_read_filter_row_sub3_lsx;
++         pp->read_filter[PNG_FILTER_VALUE_AVG-1] = png_read_filter_row_avg3_lsx;
++         pp->read_filter[PNG_FILTER_VALUE_PAETH-1] = png_read_filter_row_paeth3_lsx;
++      }
++      else if (bpp == 4)
++      {
++         pp->read_filter[PNG_FILTER_VALUE_SUB-1] = png_read_filter_row_sub4_lsx;
++         pp->read_filter[PNG_FILTER_VALUE_AVG-1] = png_read_filter_row_avg4_lsx;
++         pp->read_filter[PNG_FILTER_VALUE_PAETH-1] = png_read_filter_row_paeth4_lsx;
++      }
++   }
++}
++
++#endif /* PNG_LOONGARCH_LSX_IMPLEMENTATION == 1 */
++#endif /* PNG_READ_SUPPORTED */
+diff --git a/media/libpng/moz.build b/media/libpng/moz.build
+index 663eb929fe..fc2218e100 100644
+--- a/media/libpng/moz.build
++++ b/media/libpng/moz.build
+@@ -65,6 +65,13 @@ if CONFIG['HAVE_ALTIVEC']:
+         'powerpc/powerpc_init.c'
+     ]
+ 
++if CONFIG['TARGET_CPU'] == 'loongarch64':
++    DEFINES['MOZ_PNG_USE_LOONGARCH_LSX'] = True
++    UNIFIED_SOURCES += [
++        'loongarch/filter_lsx_intrinsics.c',
++        'loongarch/loongarch_lsx_init.c'
++    ]
++
+ if CONFIG['MOZ_TREE_FREETYPE']:
+     DEFINES['FT_CONFIG_OPTION_USE_PNG'] = True
+ 
+diff --git a/media/libpng/moz.yaml b/media/libpng/moz.yaml
+index 4d193089ac..e3c63908cc 100644
+--- a/media/libpng/moz.yaml
++++ b/media/libpng/moz.yaml
+@@ -37,6 +37,7 @@ vendoring:
+     - arm
+     - contrib/arm-neon/linux.c
+     - intel
++    - loongarch
+     - mips
+     - powerpc
+     - ANNOUNCE
+diff --git a/media/libpng/pnglibconf.h b/media/libpng/pnglibconf.h
+index 1cbb828436..7d50038c28 100644
+--- a/media/libpng/pnglibconf.h
++++ b/media/libpng/pnglibconf.h
+@@ -75,6 +75,12 @@
+ #  define PNG_POWERPC_VSX_OPT 0 /* Do not use VSX optimization */
+ #endif
+ 
++#ifdef MOZ_PNG_USE_LOONGARCH_LSX
++#  undef PNG_LOONGARCH_LSX_OPT /* Let libpng decide */
++#else
++#  define PNG_LOONGARCH_LSX_OPT 0 /* Do not use LSX optimization */
++#endif
++
+ #define PNG_READ_SUPPORTED
+ #define PNG_PROGRESSIVE_READ_SUPPORTED
+ #define PNG_READ_APNG_SUPPORTED
+-- 
+2.46.0
+

--- a/firefox-developer-edition/loong.patch
+++ b/firefox-developer-edition/loong.patch
@@ -1,0 +1,66 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 7dd56a8..3a8d3eb 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -113,6 +113,20 @@ prepare() {
+   patch -Np1 -i ../firefox-install-dir.patch
+ 
+   echo -n "$_google_api_key" >google-api-key
++  
++  # Patches for loong64
++  patch -Np1 -i ../0001-Add-support-for-LoongArch64.patch
++  patch -Np1 -i ../0003-update-gn_processor.py-to-support-linux-on-loong64.patch
++  patch -Np1 -i ../0004-Re-generate-libwebrtc-moz.build-files.patch
++  patch -Np1 -i ../0005-enable-webrtc-for-loongarch64-in-toolkit-moz.configu.patch
++  patch -Np1 -i ../0006-Fix-libyuv-unified-source-and-LoongArch-SIMD-build.patch
++  patch -Np1 -i ../0011-Add-missing-loongarch-lsx-code-for-libpng.patch
++
++  # Add ` -mcmodel=medium` to CFLAGS etc.
++  # to avoid `relocation R_LARCH_B26 overflow`
++  export CFLAGS="${CFLAGS} -mcmodel=medium"
++  export CXXFLAGS="${CXXFLAGS} -mcmodel=medium"
++  export RUSTFLAGS="${RUSTFLAGS} -C code-model=medium"
+ 
+   cat >../mozconfig <<END
+ ac_add_options --enable-application=browser
+@@ -125,7 +139,6 @@ ac_add_options --enable-optimize
+ ac_add_options --enable-rust-simd
+ ac_add_options --enable-linker=lld
+ ac_add_options --disable-install-strip
+-ac_add_options --disable-elf-hack
+ ac_add_options --disable-bootstrap
+ ac_add_options --with-wasi-sysroot=/usr/share/wasi-sysroot
+ 
+@@ -151,7 +164,7 @@ ac_add_options --with-system-nss
+ # Features
+ ac_add_options --enable-alsa
+ ac_add_options --enable-jack
+-ac_add_options --enable-crashreporter
++ac_add_options --disable-crashreporter
+ ac_add_options --disable-updater
+ ac_add_options --disable-tests
+ END
+@@ -286,4 +299,23 @@ Version=2
+ END
+ }
+ 
++source+=('0001-Add-support-for-LoongArch64.patch'
++         '0003-update-gn_processor.py-to-support-linux-on-loong64.patch'
++         '0004-Re-generate-libwebrtc-moz.build-files.patch'
++         '0005-enable-webrtc-for-loongarch64-in-toolkit-moz.configu.patch'
++         '0006-Fix-libyuv-unified-source-and-LoongArch-SIMD-build.patch'
++         '0011-Add-missing-loongarch-lsx-code-for-libpng.patch')
++sha256sums+=('348e1a20000db9fac4715580581163495de4380d446ab01177671719b41082b3'
++             '5c29035ab562b0f722b1975f02def279f3cccf3fd3d153c6e54126289b095c99'
++             'd0ef34bade8bed6072166eafc651b0703f90732f257215390421adb76c96e2b3'
++             '9bd75fce6d86d5d755e6ab047e7eaa39f87a19e596ee20e3f6c03cd4c4a7d348'
++             '62574c6426173eebd80d4676ede30214050e2b6be87e293f906aaba85214b277'
++             'da6733b8ca23d9de4f4c2ee1ff2bdc111128da4ec403e385bb576f2e229d1f6e')
++b2sums+=('28f29b1fe9f8f2a80f9ea5ddebd459c21f54ee0523bd5781888d213945333613c963abbab175ca8a2386270d0caaaa0f247c26f725a2695fb520ef5f094f978d'
++         '178bb4227daadd9c6872cc3ed0c795257023fadd8e5572e28a1c6f0825066be4e6fbb23bd3b67f7883645ac6dd567aeacdff20e383ba3482860852d256d7a75e'
++         '0495057c581f405b08b28debfaf2f98801b1a7344269985f7660fa803ca2caa8b55427d406b22684ee5980faac3dfb3de763e5b3ff892cc9b1487a21ae2c2f7f'
++         '8fead507b6662bb2c0bdc85a55c9ce0d7780376235adff616f0aa0fa7c9121d57bebbbbd996a75e129f92478fe41fae17948a887ca5f45d24284a243ee3048a5'
++         '814ee097d8539a7170f099ce1d3e2350ca6f2b8b7a252b4abfca0065d78d463773fb1f64014d7869fe3916ba20286f0e9612b8700c8b0a8410e0ee0a85236bf1'
++         '4b0f39835f67b6b1ab120f4cb038e1afd169b84b4f8bf18b669468b6ac3543de3e131947aca616ca5db6f9cb0f97c58dd6115af9c0138a41f5f990a5b6e304c7')
++
+ # vim:set sw=2 sts=-1 et:


### PR DESCRIPTION
* Import patches from `firefox`
  * Remove --disable-elf-hack (not applicable to loong)
  * Disable crashreporter (not applicable to loong)
  * Fix the support of lsx/lasx in libyuv and libpng
  * Fix webrtc
  * Generic loong64 support