### PR TITLE
updpatch: rust, ver=1:1.82.0-1

### DIFF
--- a/rust/LoongArch64-fix-fp16.patch
+++ b/rust/LoongArch64-fix-fp16.patch
@@ -1,0 +1,10 @@
+--- a/vendor/compiler_builtins-0.1.123/configure.rs
++++ b/vendor/compiler_builtins-0.1.123/configure.rs
+@@ -72,6 +72,7 @@ pub fn configure_f16_f128(target: &Target) {
+         "sparc" | "sparcv9" => (true, false),
+         // `f16` miscompiles <https://github.com/llvm/llvm-project/issues/96438>
+         "wasm32" | "wasm64" => (false, true),
++        "loongarch64" => (false, true),
+         // Most everything else works as of LLVM 19
+         _ => (true, true),
+     };

--- a/rust/loong.patch
+++ b/rust/loong.patch
@@ -1,5 +1,5 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 0b08895..233e3c9 100644
+index e084296..1bf7764 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
 @@ -7,7 +7,6 @@
@@ -19,7 +19,7 @@ index 0b08895..233e3c9 100644
    libffi
    lld
    llvm
-@@ -74,6 +71,10 @@ validpgpkeys=(
+@@ -76,6 +73,10 @@ validpgpkeys=(
  prepare() {
    cd rustc-$pkgver-src
  
@@ -30,7 +30,19 @@ index 0b08895..233e3c9 100644
    # Patch bootstrap so that rust-analyzer-proc-macro-srv
    # is in /usr/lib instead of /usr/libexec
    patch -Np1 -i ../0001-bootstrap-Change-libexec-dir.patch
-@@ -99,9 +100,8 @@ link-shared = true
+@@ -93,6 +94,11 @@ prepare() {
+   # https://github.com/rust-lang/rust/pull/130034
+   patch -Np1 -i ../0005-Fix-enabling-wasm-component-ld-to-match-other-tools.patch
+ 
++  # Rust 1.82's' llvm fp16 is not complete, so we temporarily disable it
++  patch -Np1 -i ../LoongArch64-fix-fp16.patch
++  # The hash will change after patching
++  sed -i 's/0eee6428706eeb832d63c24ee6674b65c47eed8e7542b4aca9686e13651c1765/5e2a3cfeccbb43fe6c74a957a9573f9807685253146b4ca33a4de11ea2207a71/' vendor/compiler_builtins-0.1.123/.cargo-checksum.json
++
+   cat >config.toml <<END
+ # see src/bootstrap/defaults/
+ profile = "dist"
+@@ -105,9 +111,8 @@ link-shared = true
  
  [build]
  target = [
@@ -42,9 +54,9 @@ index 0b08895..233e3c9 100644
    "wasm32-unknown-unknown",
    "wasm32-wasi",
    "wasm32-wasip1",
-@@ -149,20 +149,14 @@ jemalloc = true
- [dist]
+@@ -157,20 +162,14 @@ jemalloc = true
  compression-formats = ["gz"]
+ compression-profile = "fast"
  
 -[target.x86_64-unknown-linux-gnu]
 +[target.`uname -m`-unknown-linux-gnu]
@@ -65,7 +77,7 @@ index 0b08895..233e3c9 100644
  sanitizers = false
  musl-root = "/usr/lib/musl"
  
-@@ -230,12 +224,9 @@ build() {
+@@ -238,12 +237,9 @@ build() {
  
    # rustbuild always installs copies of the shared libraries to /usr/lib,
    # overwrite them with symlinks to the per-architecture versions
@@ -80,3 +92,11 @@ index 0b08895..233e3c9 100644
    _pick dest-wasm usr/lib/rustlib/wasm32-*
    _pick dest-src  usr/lib/rustlib/src
  }
+@@ -323,4 +319,7 @@ package_rust-src() {
+     rustc-$pkgver-src/{COPYRIGHT,LICENSE-MIT}
+ }
+ 
++source+=("LoongArch64-fix-fp16.patch")
++b2sums+=('a6260527f013860a7f7f8f5d7f7d110137e75a9b1534efca335e11d563ab172e1a62449ac43342f3dc00f02f62ec378856fe7e4edac972055712cb59ed47860e')
++
+ # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
* Temporarily disable f16 in loong64 since our llvm doesn't support it