### PR TITLE
rmvpatch: xfsprogs, ver=6.11.0-1

### DIFF
--- a/xfsprogs/loong.patch
+++ b/xfsprogs/loong.patch
@@ -1,9 +1,0 @@
---- a/PKGBUILD
-+++ b/PKGBUILD
-@@ -50,5 +50,5 @@ build() {
- package() {
-   cd ${pkgname}-dev
-   make PKG_USER=root PKG_GROUP=root DIST_ROOT="${pkgdir}" \
--       PKG_ROOT_SBIN_DIR="/usr/bin" install install-dev
-+       PKG_ROOT_SBIN_DIR="/usr/bin" install install-dev -j1
- }


### PR DESCRIPTION
* `-j1` is no more needed