### PR TITLE
addpatch: lcdproc, ver=0.5.9-10

### DIFF
--- a/lcdproc/loong.patch
+++ b/lcdproc/loong.patch
@@ -1,0 +1,18 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 7fe2a83..9f01874 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -32,6 +32,7 @@ sha512sums=('48e11a587570376b9524591f4c23deace9ac1609b83ba9e17f2a4e950d5598f8f88
+ prepare() {
+     cd "$pkgname-$pkgver"
+     patch -p1 -i "$srcdir/lcdproc-0.5.9-fix-fno-common-build.patch"
++    autoreconf -fiv
+ }
+ 
+ build() {
+@@ -54,3 +55,5 @@ package() {
+     install -Dm644 "$srcdir/lcdd.service" "$pkgdir/usr/lib/systemd/system/lcdd.service"
+     install -Dm644 "$srcdir/lcdproc.service" "$pkgdir/usr/lib/systemd/system/lcdproc.service"
+ }
++
++options=(!lto)


### PR DESCRIPTION
* Update config.{sub,guess}
* Disable LTO due to lto-wrapper fails on unreachable x86 inline assembly:
  ```
  In function ‘port_out’,
      inlined from ‘t6963_low_dsp_ready’ at t6963_low.c:181:3:
  port.h:351:9: error: impossible constraint in ‘asm’
    351 |         __asm__ volatile ("outb %0,%1\n"::"a" (val), "d"(port)
        |         ^
  make[4]: *** [/tmp/cca6TJKK.mk:2: /tmp/ccT5025n.ltrans0.ltrans.o] Error 1
  lto-wrapper: fatal error: make returned 2 exit status
  ```