### PR TITLE
addpatch: scummvm, ver=2.8.1-1

### DIFF
--- a/scummvm/loong.patch
+++ b/scummvm/loong.patch
@@ -1,0 +1,17 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 573f64f..7e6479a 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -29,3 +29,12 @@ package() {
+   cd ${pkgname}-${pkgver}
+   make DESTDIR="${pkgdir}" install
+ }
++
++prepare() {
++  export CXXFLAGS="${CXXFLAGS} -fpermissive"
++  patch -p1 -d ${pkgname}-${pkgver} -i "${srcdir}/compile-fix-for-GCC-14.patch"
++}
++
++source+=("compile-fix-for-GCC-14.patch::https://github.com/scummvm/scummvm/commit/a04bb51bf5984896ba1b9c9fadef0b1f7ae73f8b.patch")
++sha512sums+=('63190391923a72e9c4e0f25d9402ab458e520157a57e7171665ae770533863f11e8a8990371d2366268e573a0a3af7a20fe170ef19a174e9c8ba9ae9119d3dec')
++b2sums+=('80eb050e2847f2a7cca1b6d54f8990ab7c4caf616b706352249fa5731191b2dbc1960c2045d649d8e3e266abc2f0a3cbe790a5e9803edcd540d8d96b2be126ab')


### PR DESCRIPTION
* Backport [commit a04bb51](https://github.com/scummvm/scummvm/commit/a04bb51bf5984896ba1b9c9fadef0b1f7ae73f8b) to fix build for gcc14