### PR TITLE
addpatch: oha, ver=1.4.7-1

### DIFF
--- a/oha/loong.patch
+++ b/oha/loong.patch
@@ -1,0 +1,11 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index db7fd3e..e7a8386 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -31,4 +31,6 @@ package() {
+   install -Dm644 LICENSE "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
+ }
+ 
++makedepends+=(cmake clang)
++
+ # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
* Add cmake and clang to makedepends
  * since `aws-lc-sys` needs to be built from source in loong64 and requires them