### PR TITLE
addpatch: python-cairocffi, ver=1.6.1-2

### DIFF
--- a/python-cairocffi/loong.patch
+++ b/python-cairocffi/loong.patch
@@ -1,0 +1,13 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 100756f..d47a822 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -10,7 +10,7 @@ arch=('any')
+ url="https://doc.courtbouillon.org/cairocffi"
+ license=('BSD')
+ depends=('python-cffi' 'cairo')
+-makedepends=('python-build' 'python-installer' 'python-flit-core' 'python-xcffib' 'gdk-pixbuf2')
++makedepends=('python-build' 'python-installer' 'python-flit-core' 'gdk-pixbuf2')
+ checkdepends=('python-pytest' 'python-numpy' 'python-pikepdf')
+ optdepends=('gdk-pixbuf2: for cairocffi.pixbuf'
+             'python-xcffib: for cairo xcb support')


### PR DESCRIPTION
* Disable `python-xcffib` since it's missing (requires haskell packages)