### PR TITLE
addpatch: potrace, ver=1.16-3

### DIFF
--- a/potrace/loong.patch
+++ b/potrace/loong.patch
@@ -1,0 +1,15 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index e42bd22..92fcc48 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -28,3 +28,10 @@ package() {
+ 	cd "$_archive"
+ 	make DESTDIR="$pkgdir" install
+ }
++
++prepare() {
++	cd "$_archive"
++	autoreconf -fvi
++}
++
++options=(!lto)

--- a/update_config
+++ b/update_config
@@ -288,7 +288,6 @@ libwpd
 yubico-pam
 poedit
 virt-what
-potrace
 loudmouth
 libidl2
 libsigrok


### PR DESCRIPTION
* Disable lto due to lto-wrapper fails on unreachable assembly