### PR TITLE
addpatch: python-pyopencl, ver=1:2024.2.6-2

### DIFF
--- a/python-pyopencl/loong.patch
+++ b/python-pyopencl/loong.patch
@@ -1,0 +1,19 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index aa432d9..8ca1eff 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -33,14 +33,12 @@ makedepends=(
+ )
+ # NOTE: we install all available OpenCL drivers so that tests don't fail on PLATFORM_NOT_FOUND_KHR
+ checkdepends=(
+-    'intel-compute-runtime'
+     'opencl-clover-mesa'
+     'opencl-nvidia'
+     'opencl-rusticl-mesa'
+     'python-pytest'
+     'python-pytools'
+     'python-six'
+-    'rocm-opencl-runtime'
+ )
+ source=(
+     "git+https://github.com/inducer/pyopencl.git?signed#tag=v${pkgver}"


### PR DESCRIPTION
* Remove missing `intel-compute-runtime` `rocm-opencl-runtime` from `checkdepends`