### PR TITLE
updpatch: qt6-webengine, ver=6.8.0-7

### DIFF
--- a/qt6-webengine/loong.patch
+++ b/qt6-webengine/loong.patch
@@ -1,5 +1,5 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 9f8ad50..e553f01 100644
+index 9f8ad50..3111546 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
 @@ -86,6 +86,23 @@ prepare() {
@@ -19,7 +19,7 @@ index 9f8ad50..e553f01 100644
 +  # to avoid `relocation R_LARCH_B26 overflow`
 +  export CFLAGS="${CFLAGS} -mcmodel=medium"
 +  export CXXFLAGS="${CXXFLAGS} -mcmodel=medium"
-+  export RUSTFLAGS="${RUSTFLAGS} -C code-model=extreme"
++  export RUSTFLAGS="${RUSTFLAGS} -C code-model=medium"
 +  # Temporarily switch to mold to workaround with binutils's bfd's bug
 +  # that will still fail with `R_LARCH_B26 overflow`
 +  export LDFLAGS="${LDFLAGS} -fuse-ld=mold"


### PR DESCRIPTION
* Fix typo