### PR TITLE
updpatch: emscripten, ver=3.1.71-2

### DIFF
--- a/emscripten/loong.patch
+++ b/emscripten/loong.patch
@@ -1,5 +1,5 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 5f763de..89911e5 100644
+index 6c76398..e6761f1 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
 @@ -42,6 +42,7 @@ build() {
@@ -10,12 +10,3 @@ index 5f763de..89911e5 100644
        -DCMAKE_INSTALL_PREFIX=/usr
    ninja -C build
  
-@@ -63,7 +64,7 @@ build() {
-     -DLLVM_INSTALL_TOOLCHAIN_ONLY=ON \
-     -DLLVM_INCLUDE_EXAMPLES=OFF \
-     -DLLVM_INCLUDE_TESTS=OFF \
--    -DLLVM_TARGETS_TO_BUILD="X86;WebAssembly" \
-+    -DLLVM_TARGETS_TO_BUILD="host;WebAssembly" \
-     -DLLVM_ENABLE_PROJECTS="lld;clang" \
-     -DCLANG_INCLUDE_TESTS=OFF
-   ninja -C build


### PR DESCRIPTION
* Using LLVM target `host` has been [accepted by upstream](https://gitlab.archlinux.org/archlinux/packaging/packages/emscripten/-/commit/c26f897ec897adf0e0dfc6f23fe3f4def9a81e27)