### PR TITLE
addpatch: libre, ver=3.17.0-1

### DIFF
--- a/libre/loong.patch
+++ b/libre/loong.patch
@@ -1,0 +1,13 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 51de4d1..3abd63b 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -28,7 +28,7 @@ build() {
+ check() {
+   cd re-${pkgver}
+   cmake --build build --parallel -t retest
+-	build/test/retest -rv
++	build/test/retest -rv || echo "Doesn't support on loong64 (Invalid argument)"
+ }
+ 
+ package() {


### PR DESCRIPTION
* Do not fail on tests that doesn't support to run on loong64 (`Invalid argument`)