### PR TITLE
addpatch: grpc, ver=1.65.5-5

### DIFF
--- a/grpc/loong.patch
+++ b/grpc/loong.patch
@@ -1,0 +1,13 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index d723bc5..1bac371 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -107,7 +107,7 @@ build() {
+ check() {
+   cd "$srcdir/$pkgbase-$pkgver"
+   local _pyver=$(python -c "import sys; print('{0}{1}'.format(*sys.version_info[:2]))")
+-  PYTHONPATH="pyb/lib.linux-$CARCH-cpython-$_pyver" python -c 'import grpc'
++  PYTHONPATH="pyb/lib.linux-$(uname -m)-cpython-$_pyver" python -c 'import grpc'
+ }
+ 
+ package_grpc() {


### PR DESCRIPTION
* Fix python arch name (`$CARCH` -> `$(uname -m)`)