### PR TITLE
addpatch: spring, ver=106.0-4

### DIFF
--- a/spring/disable-streflop-for-cutils.patch
+++ b/spring/disable-streflop-for-cutils.patch
@@ -1,0 +1,17 @@
+diff --git a/AI/Interfaces/Java/CMakeLists.txt b/AI/Interfaces/Java/CMakeLists.txt
+index 7738190..decaae5 100644
+--- a/AI/Interfaces/Java/CMakeLists.txt
++++ b/AI/Interfaces/Java/CMakeLists.txt
+@@ -539,8 +539,10 @@ if    (BUILD_${myName}_AIINTERFACE)
+ 	include_directories(BEFORE "${rts}/lib/streflop" "${myNativeSourceDir}" "${myNativeGeneratedSourceDir}")
+ 	add_library(${myNativeTarget} MODULE ${myNativeSources} ${myNativeGeneratedSources} ${ai_common_SRC} ${myVersionDepFile})
+ 	add_dependencies(${myNativeTarget} generateVersionFiles)
+-	target_link_libraries(${myNativeTarget} CUtils streflop)
+-	set_target_properties(${myNativeTarget} PROPERTIES COMPILE_FLAGS "-DUSING_STREFLOP")
++	if (ENABLE_STREFLOP)
++		target_link_libraries(${myNativeTarget} CUtils streflop)
++		set_target_properties(${myNativeTarget} PROPERTIES COMPILE_FLAGS "-DUSING_STREFLOP")
++	endif()
+ 	set_target_properties(${myNativeTarget} PROPERTIES OUTPUT_NAME   "AIInterface")
+ 	fix_lib_name(${myNativeTarget})
+ 

--- a/spring/loong.patch
+++ b/spring/loong.patch
@@ -1,0 +1,50 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index c2b4e95..01b8365 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -26,6 +26,13 @@ prepare() {
+ 
+   patch -Np1 -i ../spring-gcc12.patch
+   patch -Np1 -i ../spring-gcc13.patch # missing includes
++  patch -Np1 -i ../disable-streflop-for-cutils.patch
++  patch -Np1 -i ../support-loong64-build.patch
++  patch -Np1 -i ../use-simde.patch
++  # Workaround for bug of simde
++  # error: conflicting types for ‘__m128i’; have ‘simde__m128i’
++  export CFLAGS="${CFLAGS} -DSIMDE_NO_NATIVE"
++  export CXXFLAGS="${CXXFLAGS} -DSIMDE_NO_NATIVE"
+   #remove bundled libraries
+   rm -r tools/pr-downloader/src/lib/jsoncpp
+   rm -r tools/pr-downloader/src/lib/minizip
+@@ -34,12 +41,18 @@ prepare() {
+ build() {
+   cd spring_$pkgver
+ 
++  # disable streflop, remove arch-specific flags
++  # https://springrts.com/mantis/view.php?id=1846
++  # https://springrts.com/mantis/view.php?id=1788
+   cmake \
+     -Bbuild \
+     -DCMAKE_INSTALL_PREFIX=/usr \
+     -DDATADIR=share/spring \
+     -DJAVA_HOME=/usr/lib/jvm/java-8-openjdk \
+     -DCMAKE_SKIP_RPATH=ON \
++    -DPRD_JSONCPP_INTERNAL=OFF \
++    -DENABLE_STREFLOP=OFF \
++    -DMARCH_FLAG=loongarch64 \
+     -DPRD_JSONCPP_INTERNAL=OFF
+   make -C build
+ }
+@@ -53,4 +66,12 @@ package() {
+   echo '$HOME/.spring' > "$pkgdir/etc/spring/datadir"
+ }
+ 
++makedepends+=('simde')
++source+=( "disable-streflop-for-cutils.patch"
++          "support-loong64-build.patch"
++          "use-simde.patch")
++sha512sums+=( '9fc1ecdcfba4df8135b02ea59d09873372ea0381e6e9c465cc2d5c7f822bc128108028359054367c9ebc4abffafc0016d7509d75755e65b179e7edef611584bd'
++              '02d2bb82335f1f0e03b597fc5b9bc434030000468e9f63ffacdc28e5603ed45ea1a916689e49fa6b38983a54dace3dd5fabe0d0a4321c84dc52c9da90f0cd480'
++              'dd885fbec0b6423c4c7667e05babeb2f6a48c878661fd502236b1f1743cb6f7a47f702f7e22030a684bfbd8d4190980999a0bf13e74cff3d2138782c884be8c6')
++
+ # vim sw=2:ts=2 et:

--- a/spring/support-loong64-build.patch
+++ b/spring/support-loong64-build.patch
@@ -1,0 +1,20 @@
+--- a/rts/System/MainDefines.h
++++ b/rts/System/MainDefines.h
+@@ -23,7 +23,7 @@
+ #endif
+ 
+ 
+-#if (defined(__alpha__) || defined(__arm__) || defined(__aarch64__) || defined(__mips__) || defined(__powerpc__) || defined(__sparc__) || defined(__m68k__) || defined(__ia64__) || defined(__e2k__))
++#if (defined(__alpha__) || defined(__arm__) || defined(__aarch64__) || defined(__riscv) || defined(__mips__) || defined(__powerpc__) || defined(__sparc__) || defined(__m68k__) || defined(__ia64__) || defined(__e2k__)) || defined(__loongarch__)
+ #define __is_x86_arch__ 0
+ #elif (defined(__i386__) || defined(__x86_64__) || defined(__amd64__) || defined(_M_AMD64) || defined(_M_IX86) || defined(_M_X64))
+ #define __is_x86_arch__ 1
+@@ -33,7 +33,7 @@
+ 
+ 
+ /* define a common indicator for 32bit or 64bit-ness */
+-#if defined _WIN64 || defined __LP64__ || defined __ppc64__ || defined __ILP64__ || defined __SILP64__ || defined __LLP64__ || defined(__sparcv9) || defined(__e2k__)
++#if defined _WIN64 || defined __LP64__ || defined __ppc64__ || defined __ILP64__ || defined __SILP64__ || defined __LLP64__ || defined(__sparcv9) || defined(__e2k__) || (defined(__riscv_xlen) && __riscv_xlen == 64) || defined(__loongarch_lp64)
+ #define __arch64__
+ #define __archBits__ 64
+ #else

--- a/spring/use-simde.patch
+++ b/spring/use-simde.patch
@@ -1,0 +1,80 @@
+diff --git a/include/SDL2/SDL_cpuinfo.h b/include/SDL2/SDL_cpuinfo.h
+index 6d72bbb..aecc892 100644
+--- a/include/SDL2/SDL_cpuinfo.h
++++ b/include/SDL2/SDL_cpuinfo.h
+@@ -51,15 +51,24 @@
+ #endif
+ #ifdef __MMX__
+ #include <mmintrin.h>
++#else
++#define SIMDE_ENABLE_NATIVE_ALIASES 1
++#include <simde/x86/mmx.h>
+ #endif
+ #ifdef __3dNOW__
+ #include <mm3dnow.h>
+ #endif
+ #ifdef __SSE__
+ #include <xmmintrin.h>
++#else
++#define SIMDE_ENABLE_NATIVE_ALIASES 1
++#include <simde/x86/sse.h>
+ #endif
+ #ifdef __SSE2__
+ #include <emmintrin.h>
++#else
++#define SIMDE_ENABLE_NATIVE_ALIASES 1
++#include <simde/x86/sse2.h>
+ #endif
+ #endif
+ 
+diff --git a/rts/System/FastMath.h b/rts/System/FastMath.h
+index 6377f87..e8f5193 100644
+--- a/rts/System/FastMath.h
++++ b/rts/System/FastMath.h
+@@ -4,7 +4,12 @@
+ #define FASTMATH_H
+ 
+ #ifndef DEDICATED_NOSSE
++#ifdef __SSE1__
+ #include <xmmintrin.h>
++#else
++#define SIMDE_ENABLE_NATIVE_ALIASES 1
++#include <simde/x86/sse.h>
++#endif
+ #endif
+ #include <cinttypes>
+ 
+diff --git a/rts/System/Matrix44f.h b/rts/System/Matrix44f.h
+index 423c764..e7fd1f3 100644
+--- a/rts/System/Matrix44f.h
++++ b/rts/System/Matrix44f.h
+@@ -6,6 +6,13 @@
+ #include "System/float3.h"
+ #include "System/float4.h"
+ 
++#ifdef __SSE1__
++#include <xmmintrin.h>
++#else
++#define SIMDE_ENABLE_NATIVE_ALIASES 1
++#include <simde/x86/sse.h>
++#endif
++
+ class CMatrix44f
+ {
+ public:
+diff --git a/test/engine/System/testMatrix44f.cpp b/test/engine/System/testMatrix44f.cpp
+index 2ebccfc..92ff77f 100644
+--- a/test/engine/System/testMatrix44f.cpp
++++ b/test/engine/System/testMatrix44f.cpp
+@@ -1,6 +1,11 @@
+ /* This file is part of the Spring engine (GPL v2 or later), see LICENSE.html */
+ 
++#ifdef __SSE1__
+ #include <xmmintrin.h> //SSE1
++#else
++#define SIMDE_ENABLE_NATIVE_ALIASES 1
++#include <simde/x86/sse.h>
++#endif
+ 
+ #include "System/Matrix44f.h"
+ #include "System/float4.h"


### PR DESCRIPTION
* See also: https://github.com/felixonmars/archriscv-packages/tree/e0bb650954d22acf9627ddf0fbec7bb0df4aa73f/spring
* Support loong64
* Add missing header
* Disable streflop: https://springrts.com/mantis/view.php?id=1846
* Remove arch-specific flags: https://springrts.com/mantis/view.php?id=1788
* Use simde to provide SSE intrinsics
  * Bug: `error: conflicting declaration ‘typedef simde__m128i __m128i’`
  * Temporarily switch to SIMDE_NO_NATIVE
  * This actually disables SIMD