### PR TITLE
addpatch: kernelshark, ver=2.3.0-1

### DIFF
--- a/kernelshark/fix-foreach.patch
+++ b/kernelshark/fix-foreach.patch
@@ -1,0 +1,30 @@
+From 9e33324644fff49b7aa15d34f836e72af8b32c78 Mon Sep 17 00:00:00 2001
+From: Jerome Marchand <jmarchan@redhat.com>
+Date: Tue, 11 Jun 2024 17:33:34 +0200
+Subject: [PATCH] kernelshark: fix compiling error in LatencyPlot.cpp
+
+Include the <algorithm> header to use std::for_each.
+
+Fixes the following compilation error:
+kernel-shark/src/plugins/LatencyPlot.cpp: In function void draw_latency(kshark_cpp_argv*, int, int, int):
+kernel-shark/src/plugins/LatencyPlot.cpp:306:14: error: for_each is not a member of std
+  306 |         std::for_each(range.first, range.second, lamPlotLat);
+      |              ^~~~~~~~
+
+Signed-off-by: Jerome Marchand <jmarchan@redhat.com>
+---
+ src/plugins/LatencyPlot.cpp | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/plugins/LatencyPlot.cpp b/src/plugins/LatencyPlot.cpp
+index d4129174..5e3393ba 100644
+--- a/src/plugins/LatencyPlot.cpp
++++ b/src/plugins/LatencyPlot.cpp
+@@ -15,6 +15,7 @@
+ // C++
+ #include <unordered_map>
+ #include <iostream>
++#include <algorithm>
+ 
+ // KernelShark
+ #include "plugins/latency_plot.h"

--- a/kernelshark/loong.patch
+++ b/kernelshark/loong.patch
@@ -1,0 +1,36 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 2cc3b9f..8f9f7ea 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -36,9 +36,18 @@ provides=(
+   libkshark-plot.so
+   libkshark-gui.so
+ )
+-source=($pkgname-$pkgver.tar.gz::https://git.kernel.org/pub/scm/utils/trace-cmd/kernel-shark.git/snapshot/kernel-shark-$pkgname-v$pkgver.tar.gz)
+-sha512sums=('ba5e7ebc713d296bef211174869445ccb3dffb8a96d0634776bd28c183487225e7c8082c8be5957795973833d6ac67851fb46f75cf68aae66eb3e5e06c081f5f')
+-b2sums=('818448c3d2e01412e12fc3406b13ffd4d6ab7d442aef7867048913996edbc7f64b2c2c9e88810d6c0bd9e8a6ee9726369ab097d2164ec9966660f098e123c702')
++source=(
++  $pkgname-$pkgver.tar.gz::https://git.kernel.org/pub/scm/utils/trace-cmd/kernel-shark.git/snapshot/kernel-shark-$pkgname-v$pkgver.tar.gz
++  'fix-foreach.patch'
++)
++sha512sums=(
++  'ba5e7ebc713d296bef211174869445ccb3dffb8a96d0634776bd28c183487225e7c8082c8be5957795973833d6ac67851fb46f75cf68aae66eb3e5e06c081f5f'
++  'af176f982d0545a39b483e47e4791472dbb7306e4ad388ea29d85bad5d6a4a30a41086c5864f297ad92acc769bb4ae8549d5345fb3e43739475a987fb0717dab'
++)
++b2sums=(
++  '818448c3d2e01412e12fc3406b13ffd4d6ab7d442aef7867048913996edbc7f64b2c2c9e88810d6c0bd9e8a6ee9726369ab097d2164ec9966660f098e123c702'
++  'ead20e727d67e0930fba4b35ffcee0818646271f96d7031c980ecb1833ecdf94655f2f55b4d076d955a327306f2965ac9ea378331884938077441f27c9862033'
++)
+ 
+ prepare() {
+   cd kernel-shark-$pkgname-v$pkgver
+@@ -46,6 +55,9 @@ prepare() {
+   # replace FreeSans with ttf-fira-sans
+   sed -e 's/FreeSans/FiraSans-Regular/g' \
+       -i CMakeLists.txt
++    
++  # fix for_each error
++  patch -p1 -i "$srcdir/fix-foreach.patch" 
+ }
+ 
+ build() {


### PR DESCRIPTION
- Get the patch from upstream and fixed the build error: for_each’ is not a member of std’.
