### PR TITLE
addpatch: openucx, ver=1.17.0-3

### DIFF
--- a/openucx/loong.patch
+++ b/openucx/loong.patch
@@ -1,0 +1,43 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index bd63230..9e1b2c4 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -14,16 +14,6 @@ depends=(
+   zlib
+   zstd
+ )
+-makedepends=(
+-  rdma-core
+-  cuda
+-  rocm-language-runtime
+-)
+-optdepends=(
+-  'rdma-core: for InfiniBand and RDMA support'
+-  'cuda: for CUDA support'
+-  'rocm-language-runtime: for ROCm support'
+-)
+ provides=(
+   libucm.so
+   libucp.so
+@@ -35,10 +25,11 @@ source=("$pkgname-$pkgver.tar.gz::https://github.com/openucx/$_name/archive/refs
+ sha256sums=('36db6b00b0939d746e86f9e0d32dc445faaa109e46dc643fb5ad779492abfaef')
+ 
+ build() {
++  patch -p1 -d $_name-$pkgver -i "${srcdir}/Introduce-non-temporal-buffer-transfer.patch"
++  patch -p1 -d $_name-$pkgver -i "${srcdir}/Add-LoongArch64.patch"
+   local configure_options=(
+     --prefix=/usr
+     --sysconfdir=/etc
+-    --with-cuda=/opt/cuda
+     --with-rocm=/opt/rocm
+     --with-verbs
+     --with-rc
+@@ -73,3 +64,8 @@ package() {
+   # install the license
+   install -vDm 644 $_name-$pkgver/LICENSE -t "$pkgdir/usr/share/licenses/$pkgname/"
+ }
++
++source+=( "Introduce-non-temporal-buffer-transfer.patch::https://github.com/openucx/ucx/commit/a86933eb32646381b6c637395ee9756f59ca2a9f.patch"
++          "Add-LoongArch64.patch::https://github.com/openucx/ucx/pull/9899/commits/4462aa94599ee6eb56eb1a751867445a779c995e.patch")
++sha256sums+=( 'cecb16dc59e5d5b5ac2b1eafa687772da7ce496c734ff697f17b8453031dcef8'
++              'cede74a55c78fbf41c8542c55f3717b11e26f91ba83f642831fd04b0ab3a2b04')


### PR DESCRIPTION
* Apply Loong support patch from PR: https://github.com/openucx/ucx/pull/9899/commits/4462aa94599ee6eb56eb1a751867445a779c995e
* Backport https://github.com/openucx/ucx/commit/a86933eb32646381b6c637395ee9756f59ca2a9f since Loong support patch needs this
* Disable cuda
* Remove rdma-core and rocm from makedepends and optdepends since they are not ready