### PR TITLE
addpatch: vaultwarden, ver=1.32.5-1

### DIFF
--- a/vaultwarden/loong.patch
+++ b/vaultwarden/loong.patch
@@ -1,0 +1,20 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 8b3f2de..82e56c5 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -51,6 +51,9 @@ prepare() {
+   s,/path/to/log,/var/log/$pkgname.log,
+   /^# ROCKET_TLS/a ROCKET_LIMITS={json=10485760}" .env.template
+ 
++  # generate bindgen at build time
++  cargo add mysqlclient-sys@0.4.1 --features buildtime_bindgen
++
+   # download dependencies
+   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+ }
+@@ -93,3 +96,5 @@ package() {
+   # binary
+   install -vDm755 -t "$pkgdir/usr/bin" target/release*/$pkgname
+ }
++
++depends_loong64=(mariadb-libs clang)


### PR DESCRIPTION
* Generate Rust bindgen for libmysqlclient at build time
* See also: https://github.com/felixonmars/archriscv-packages/pull/4310/commits/38ef6e8baa353bdcb4e634f18a897e75b6390345