### PR TITLE
updpatch: firefox-developer-edition, ver=134.0b10-1

### DIFF
--- a/firefox-developer-edition/0001-Add-support-for-LoongArch64.patch
+++ b/firefox-developer-edition/0001-Add-support-for-LoongArch64.patch
@@ -1,7 +1,7 @@
-From 19140a75d513f3f3d5c12d42a65d2c892e934e3f Mon Sep 17 00:00:00 2001
+From b9c73089a9d53c9fd082c3d8a5eb63b1d17ae7c5 Mon Sep 17 00:00:00 2001
 From: Jiangjin Wang <kaymw@aosc.io>
 Date: Sun, 22 Oct 2023 22:13:17 -0700
-Subject: [PATCH 1/6] Add support for LoongArch64
+Subject: [PATCH] Add support for LoongArch64
 
 Adapted from LoongArchLinux. Rebased to Firefox 130.0.0.
 
@@ -9,14 +9,14 @@ Co-Authored-By: loongson <loongson@loongson.cn>
 Co-Authored-By: WANG Xuerui <xen0n@gentoo.org>
 Signed-off-by: WANG Xuerui <xen0n@gentoo.org>
 ---
- third_party/libwebrtc/build/build_config.h             | 4 ++++
+ third_party/chromium/build/build_config.h              | 4 ++++
  toolkit/components/telemetry/pingsender/pingsender.cpp | 1 +
  2 files changed, 5 insertions(+)
 
-diff --git a/third_party/libwebrtc/build/build_config.h b/third_party/libwebrtc/build/build_config.h
-index c39ae9da50f99..28191de02654b 100644
---- a/third_party/libwebrtc/build/build_config.h
-+++ b/third_party/libwebrtc/build/build_config.h
+diff --git a/third_party/chromium/build/build_config.h b/third_party/chromium/build/build_config.h
+index c39ae9da50f..28191de0265 100644
+--- a/third_party/chromium/build/build_config.h
++++ b/third_party/chromium/build/build_config.h
 @@ -210,6 +210,10 @@
  #define ARCH_CPU_SPARC 1
  #define ARCH_CPU_32_BITS 1
@@ -29,7 +29,7 @@ index c39ae9da50f99..28191de02654b 100644
  #error Please add support for your architecture in build/build_config.h
  #endif
 diff --git a/toolkit/components/telemetry/pingsender/pingsender.cpp b/toolkit/components/telemetry/pingsender/pingsender.cpp
-index 30f2907c720e1..e6645227a2949 100644
+index 30f2907c720..e6645227a29 100644
 --- a/toolkit/components/telemetry/pingsender/pingsender.cpp
 +++ b/toolkit/components/telemetry/pingsender/pingsender.cpp
 @@ -10,6 +10,7 @@
@@ -40,6 +40,3 @@ index 30f2907c720e1..e6645227a2949 100644
  #include <vector>
  
  #include <zlib.h>
--- 
-2.45.2
-

--- a/firefox-developer-edition/0002-update-skia-generate_mozbuild.py-to-fix-lasx.patch
+++ b/firefox-developer-edition/0002-update-skia-generate_mozbuild.py-to-fix-lasx.patch
@@ -1,0 +1,47 @@
+Generated using Skia revision 06cd249f39638e88c4b5c0fa2b1c87f5dbc0660c,
+grafted onto Firefox sources, and with the resulting moz.build cherry-picked.
+
+diff --git a/gfx/skia/generate_mozbuild.py b/gfx/skia/generate_mozbuild.py
+index ef45446141947..a0bdae70eca66 100755
+--- a/gfx/skia/generate_mozbuild.py
++++ b/gfx/skia/generate_mozbuild.py
+@@ -133,7 +133,10 @@ def parse_sources(output):
+   return set(v.replace('//', 'skia/') for v in output.decode('utf-8').split() if v.endswith('.cpp') or v.endswith('.S'))
+ 
+ def generate_opt_sources():
+-  cpus = [('intel', 'x86', [':hsw'])]
++  cpus = [
++    ('intel', 'x86', [':hsw']),
++    ('loong64', 'loong64', [':lasx'])
++  ]
+ 
+   opt_sources = {}
+   for key, cpu, deps in cpus:
+@@ -424,6 +427,11 @@ def write_mozbuild(sources):
+     write_sources(f, sources['arm64'], 4)
+     write_cflags(f, sources['arm64'], opt_allowlist, 'skia_opt_flags', 4)
+ 
++  if sources['loong64']:
++    f.write("elif CONFIG['TARGET_CPU'] == 'loongarch64':\n")
++    write_sources(f, sources['loong64'], 4)
++    write_cflags(f, sources['loong64'], opt_allowlist, 'skia_opt_flags', 4)
++
+   if sources['none']:
+     f.write("else:\n")
+     write_sources(f, sources['none'], 4)
+diff --git a/gfx/skia/moz.build b/gfx/skia/moz.build
+index cd3fcc9467644..8dfdcd23841ab 100644
+--- a/gfx/skia/moz.build
++++ b/gfx/skia/moz.build
+@@ -573,6 +573,11 @@ if CONFIG['INTEL_ARCHITECTURE']:
+     ]
+     SOURCES['skia/modules/skcms/src/skcms_TransformHsw.cc'].flags += skia_opt_flags
+     SOURCES['skia/src/opts/SkOpts_hsw.cpp'].flags += skia_opt_flags
++elif CONFIG['TARGET_CPU'] == 'loongarch64':
++    SOURCES += [
++        'skia/src/opts/SkOpts_lasx.cpp',
++    ]
++    SOURCES['skia/src/opts/SkOpts_lasx.cpp'].flags += skia_opt_flags
+ 
+ 
+ # We allow warnings for third-party code that can be updated from upstream.

--- a/firefox-developer-edition/0004-Re-generate-libwebrtc-moz.build-files.patch
+++ b/firefox-developer-edition/0004-Re-generate-libwebrtc-moz.build-files.patch
@@ -1,5 +1,463 @@
+From cc967ae247892592968ded65eaba20cac46b78c3 Mon Sep 17 00:00:00 2001
+From: Mingcong Bai <jeffbai@aosc.io>
+Date: Tue, 26 Nov 2024 19:46:01 +0800
+Subject: [PATCH] chore: regenerate libwebrtc moz.build files
+
+Regenerate moz.build files to incorporate loong64 libwebrtc enablement in
+gn_processor.py.
+
+Generation command:
+
+  ./mach python \
+       python/mozbuild/mozbuild/gn_processor.py \
+       dom/media/webrtc/third_party_build/gn-configs/webrtc.json
+
+Inspired-by: WANG Xuerui <xen0n@gentoo.org>
+Signed-off-by: Mingcong Bai <jeffbai@aosc.io>
+---
+ .../resource_adaptation_api_gn/moz.build      |  4 +++
+ .../libwebrtc/api/array_view_gn/moz.build     |  4 +++
+ .../api/async_dns_resolver_gn/moz.build       |  4 +++
+ .../api/audio/aec3_config_gn/moz.build        |  4 +++
+ .../api/audio/aec3_factory_gn/moz.build       |  4 +++
+ .../api/audio/audio_device_gn/moz.build       |  4 +++
+ .../api/audio/audio_frame_api_gn/moz.build    |  4 +++
+ .../audio/audio_frame_processor_gn/moz.build  |  4 +++
+ .../api/audio/audio_mixer_api_gn/moz.build    |  4 +++
+ .../api/audio/audio_processing_gn/moz.build   |  4 +++
+ .../audio_processing_statistics_gn/moz.build  |  4 +++
+ .../api/audio/echo_control_gn/moz.build       |  4 +++
+ .../L16/audio_decoder_L16_gn/moz.build        |  4 +++
+ .../L16/audio_encoder_L16_gn/moz.build        |  4 +++
+ .../audio_codecs_api_gn/moz.build             |  4 +++
+ .../moz.build                                 |  4 +++
+ .../moz.build                                 |  4 +++
+ .../g711/audio_decoder_g711_gn/moz.build      |  4 +++
+ .../g711/audio_encoder_g711_gn/moz.build      |  4 +++
+ .../g722/audio_decoder_g722_gn/moz.build      |  4 +++
+ .../audio_encoder_g722_config_gn/moz.build    |  4 +++
+ .../g722/audio_encoder_g722_gn/moz.build      |  4 +++
+ .../ilbc/audio_decoder_ilbc_gn/moz.build      |  4 +++
+ .../audio_encoder_ilbc_config_gn/moz.build    |  4 +++
+ .../ilbc/audio_encoder_ilbc_gn/moz.build      |  4 +++
+ .../opus/audio_decoder_multiopus_gn/moz.build |  4 +++
+ .../audio_decoder_opus_config_gn/moz.build    |  4 +++
+ .../opus/audio_decoder_opus_gn/moz.build      |  4 +++
+ .../opus/audio_encoder_multiopus_gn/moz.build |  4 +++
+ .../audio_encoder_opus_config_gn/moz.build    |  4 +++
+ .../opus/audio_encoder_opus_gn/moz.build      |  4 +++
+ .../api/audio_options_api_gn/moz.build        |  4 +++
+ .../api/bitrate_allocation_gn/moz.build       |  4 +++
+ .../libwebrtc/api/call_api_gn/moz.build       |  4 +++
+ .../frame_decryptor_interface_gn/moz.build    |  4 +++
+ .../frame_encryptor_interface_gn/moz.build    |  4 +++
+ .../libwebrtc/api/crypto/options_gn/moz.build |  4 +++
+ .../environment_factory_gn/moz.build          |  4 +++
+ .../api/environment/environment_gn/moz.build  |  4 +++
+ .../api/fec_controller_api_gn/moz.build       |  4 +++
+ .../api/field_trials_registry_gn/moz.build    |  4 +++
+ .../api/field_trials_view_gn/moz.build        |  4 +++
+ .../frame_transformer_interface_gn/moz.build  |  4 +++
+ .../libwebrtc/api/function_view_gn/moz.build  |  4 +++
+ .../api/libjingle_logging_api_gn/moz.build    |  4 +++
+ .../libjingle_peerconnection_api_gn/moz.build |  4 +++
+ .../libwebrtc/api/location_gn/moz.build       |  4 +++
+ .../api/make_ref_counted_gn/moz.build         |  4 +++
+ .../api/media_stream_interface_gn/moz.build   |  4 +++
+ .../api/metronome/metronome_gn/moz.build      |  4 +++
+ .../moz.build                                 |  4 +++
+ .../api/neteq/neteq_api_gn/moz.build          |  4 +++
+ .../neteq/neteq_controller_api_gn/moz.build   |  4 +++
+ .../api/neteq/tick_timer_gn/moz.build         |  4 +++
+ .../network_state_predictor_api_gn/moz.build  |  4 +++
+ .../libwebrtc/api/priority_gn/moz.build       |  4 +++
+ .../libwebrtc/api/ref_count_gn/moz.build      |  4 +++
+ .../libwebrtc/api/refcountedbase_gn/moz.build |  4 +++
+ .../libwebrtc/api/rtc_error_gn/moz.build      |  4 +++
+ .../rtc_event_log/rtc_event_log_gn/moz.build  |  4 +++
+ .../libwebrtc/api/rtp_headers_gn/moz.build    |  4 +++
+ .../api/rtp_packet_info_gn/moz.build          |  4 +++
+ .../api/rtp_packet_sender_gn/moz.build        |  4 +++
+ .../libwebrtc/api/rtp_parameters_gn/moz.build |  4 +++
+ .../api/rtp_sender_interface_gn/moz.build     |  4 +++
+ .../moz.build                                 |  4 +++
+ .../rtp_transceiver_direction_gn/moz.build    |  4 +++
+ .../libwebrtc/api/scoped_refptr_gn/moz.build  |  4 +++
+ .../api/sequence_checker_gn/moz.build         |  4 +++
+ .../api/simulated_network_api_gn/moz.build    |  4 +++
+ .../default_task_queue_factory_gn/moz.build   |  4 +++
+ .../pending_task_safety_flag_gn/moz.build     |  4 +++
+ .../api/task_queue/task_queue_gn/moz.build    |  4 +++
+ .../moz.build                                 |  4 +++
+ .../transport/bandwidth_usage_gn/moz.build    |  4 +++
+ .../transport/bitrate_settings_gn/moz.build   |  4 +++
+ .../datagram_transport_interface_gn/moz.build |  4 +++
+ .../field_trial_based_config_gn/moz.build     |  4 +++
+ .../api/transport/goog_cc_gn/moz.build        |  4 +++
+ .../transport/network_control_gn/moz.build    |  4 +++
+ .../rtp/dependency_descriptor_gn/moz.build    |  4 +++
+ .../api/transport/rtp/rtp_source_gn/moz.build |  4 +++
+ .../api/transport/stun_types_gn/moz.build     |  4 +++
+ .../libwebrtc/api/transport_api_gn/moz.build  |  4 +++
+ .../api/units/data_rate_gn/moz.build          |  4 +++
+ .../api/units/data_size_gn/moz.build          |  4 +++
+ .../api/units/frequency_gn/moz.build          |  4 +++
+ .../api/units/time_delta_gn/moz.build         |  4 +++
+ .../api/units/timestamp_gn/moz.build          |  4 +++
+ .../moz.build                                 |  4 +++
+ .../api/video/encoded_frame_gn/moz.build      |  4 +++
+ .../api/video/encoded_image_gn/moz.build      |  4 +++
+ .../api/video/frame_buffer_gn/moz.build       |  4 +++
+ .../recordable_encoded_frame_gn/moz.build     |  4 +++
+ .../api/video/render_resolution_gn/moz.build  |  4 +++
+ .../api/video/resolution_gn/moz.build         |  4 +++
+ .../api/video/video_adaptation_gn/moz.build   |  4 +++
+ .../video_bitrate_allocation_gn/moz.build     |  4 +++
+ .../moz.build                                 |  4 +++
+ .../video_bitrate_allocator_gn/moz.build      |  4 +++
+ .../video/video_codec_constants_gn/moz.build  |  4 +++
+ .../api/video/video_frame_gn/moz.build        |  4 +++
+ .../api/video/video_frame_i010_gn/moz.build   |  4 +++
+ .../video/video_frame_metadata_gn/moz.build   |  4 +++
+ .../api/video/video_frame_type_gn/moz.build   |  4 +++
+ .../video_layers_allocation_gn/moz.build      |  4 +++
+ .../api/video/video_rtp_headers_gn/moz.build  |  4 +++
+ .../video/video_stream_encoder_gn/moz.build   |  4 +++
+ .../bitstream_parser_api_gn/moz.build         |  4 +++
+ .../moz.build                                 |  4 +++
+ .../scalability_mode_gn/moz.build             |  4 +++
+ .../video_codecs_api_gn/moz.build             |  4 +++
+ .../vp8_temporal_layers_factory_gn/moz.build  |  4 +++
+ .../moz.build                                 |  4 +++
+ .../libwebrtc/audio/audio_gn/moz.build        |  4 +++
+ .../audio_frame_operations_gn/moz.build       |  4 +++
+ .../resource_adaptation_gn/moz.build          |  4 +++
+ .../call/audio_sender_interface_gn/moz.build  |  4 +++
+ .../call/bitrate_allocator_gn/moz.build       |  4 +++
+ .../call/bitrate_configurator_gn/moz.build    |  4 +++
+ third_party/libwebrtc/call/call_gn/moz.build  |  4 +++
+ .../call/call_interfaces_gn/moz.build         |  4 +++
+ .../receive_stream_interface_gn/moz.build     |  4 +++
+ .../call/rtp_interfaces_gn/moz.build          |  4 +++
+ .../libwebrtc/call/rtp_receiver_gn/moz.build  |  4 +++
+ .../libwebrtc/call/rtp_sender_gn/moz.build    |  4 +++
+ .../libwebrtc/call/version_gn/moz.build       |  4 +++
+ .../call/video_stream_api_gn/moz.build        |  4 +++
+ .../common_audio_c_arm_asm_gn/moz.build       |  4 +++
+ .../common_audio/common_audio_c_gn/moz.build  | 10 +++++++
+ .../common_audio/common_audio_cc_gn/moz.build |  4 +++
+ .../common_audio/common_audio_gn/moz.build    |  4 +++
+ .../fir_filter_factory_gn/moz.build           |  4 +++
+ .../common_audio/fir_filter_gn/moz.build      |  4 +++
+ .../common_audio/sinc_resampler_gn/moz.build  |  4 +++
+ .../ooura/fft_size_128_gn/moz.build           |  4 +++
+ .../ooura/fft_size_256_gn/moz.build           |  4 +++
+ .../spl_sqrt_floor_gn/moz.build               |  8 +++++
+ .../common_video/common_video_gn/moz.build    |  4 +++
+ .../common_video/frame_counts_gn/moz.build    |  4 +++
+ .../generic_frame_descriptor_gn/moz.build     |  4 +++
+ .../registered_field_trials_gn/moz.build      |  4 +++
+ .../logging/rtc_event_audio_gn/moz.build      |  4 +++
+ .../logging/rtc_event_bwe_gn/moz.build        |  4 +++
+ .../logging/rtc_event_field_gn/moz.build      |  4 +++
+ .../rtc_event_log_parse_status_gn/moz.build   |  4 +++
+ .../rtc_event_number_encodings_gn/moz.build   |  4 +++
+ .../logging/rtc_event_pacing_gn/moz.build     |  4 +++
+ .../logging/rtc_event_rtp_rtcp_gn/moz.build   |  4 +++
+ .../logging/rtc_event_video_gn/moz.build      |  4 +++
+ .../logging/rtc_stream_config_gn/moz.build    |  4 +++
+ .../adapted_video_track_source_gn/moz.build   |  4 +++
+ .../libwebrtc/media/codec_gn/moz.build        |  4 +++
+ .../media/media_channel_gn/moz.build          |  4 +++
+ .../media/media_channel_impl_gn/moz.build     |  4 +++
+ .../media/media_constants_gn/moz.build        |  4 +++
+ .../media/rid_description_gn/moz.build        |  4 +++
+ .../media/rtc_media_base_gn/moz.build         |  4 +++
+ .../media/rtc_media_config_gn/moz.build       |  4 +++
+ .../rtc_sdp_video_format_utils_gn/moz.build   |  4 +++
+ .../moz.build                                 |  4 +++
+ .../libwebrtc/media/rtp_utils_gn/moz.build    |  4 +++
+ .../media/stream_params_gn/moz.build          |  4 +++
+ .../media/video_adapter_gn/moz.build          |  4 +++
+ .../media/video_broadcaster_gn/moz.build      |  4 +++
+ .../libwebrtc/media/video_common_gn/moz.build |  4 +++
+ .../media/video_source_base_gn/moz.build      |  4 +++
+ .../async_audio_processing_gn/moz.build       |  4 +++
+ .../audio_coding/audio_coding_gn/moz.build    |  4 +++
+ .../audio_coding_module_typedefs_gn/moz.build |  4 +++
+ .../audio_coding_opus_common_gn/moz.build     |  4 +++
+ .../audio_encoder_cng_gn/moz.build            |  4 +++
+ .../audio_network_adaptor_config_gn/moz.build |  4 +++
+ .../audio_network_adaptor_gn/moz.build        |  4 +++
+ .../default_neteq_factory_gn/moz.build        |  4 +++
+ .../modules/audio_coding/g711_c_gn/moz.build  |  4 +++
+ .../modules/audio_coding/g711_gn/moz.build    |  4 +++
+ .../modules/audio_coding/g722_c_gn/moz.build  |  4 +++
+ .../modules/audio_coding/g722_gn/moz.build    |  4 +++
+ .../modules/audio_coding/ilbc_c_gn/moz.build  |  4 +++
+ .../modules/audio_coding/ilbc_gn/moz.build    |  4 +++
+ .../audio_coding/isac_bwinfo_gn/moz.build     |  4 +++
+ .../audio_coding/isac_vad_gn/moz.build        |  4 +++
+ .../legacy_encoded_audio_frame_gn/moz.build   |  4 +++
+ .../modules/audio_coding/neteq_gn/moz.build   |  4 +++
+ .../audio_coding/pcm16b_c_gn/moz.build        |  4 +++
+ .../modules/audio_coding/pcm16b_gn/moz.build  |  4 +++
+ .../modules/audio_coding/red_gn/moz.build     |  4 +++
+ .../audio_coding/webrtc_cng_gn/moz.build      |  4 +++
+ .../webrtc_multiopus_gn/moz.build             |  4 +++
+ .../audio_coding/webrtc_opus_gn/moz.build     |  4 +++
+ .../webrtc_opus_wrapper_gn/moz.build          |  4 +++
+ .../audio_device/audio_device_gn/moz.build    |  4 +++
+ .../audio_frame_manipulator_gn/moz.build      |  4 +++
+ .../audio_mixer/audio_mixer_impl_gn/moz.build |  4 +++
+ .../aec3/adaptive_fir_filter_erl_gn/moz.build |  4 +++
+ .../aec3/adaptive_fir_filter_gn/moz.build     |  4 +++
+ .../aec3/aec3_common_gn/moz.build             |  4 +++
+ .../aec3/aec3_fft_gn/moz.build                |  4 +++
+ .../audio_processing/aec3/aec3_gn/moz.build   |  4 +++
+ .../aec3/fft_data_gn/moz.build                |  4 +++
+ .../aec3/matched_filter_gn/moz.build          |  4 +++
+ .../aec3/render_buffer_gn/moz.build           |  4 +++
+ .../aec3/vector_math_gn/moz.build             |  4 +++
+ .../aec_dump/aec_dump_gn/moz.build            |  4 +++
+ .../null_aec_dump_factory_gn/moz.build        |  4 +++
+ .../aec_dump_interface_gn/moz.build           |  4 +++
+ .../aecm/aecm_core_gn/moz.build               |  8 +++++
+ .../audio_processing/agc/agc_gn/moz.build     |  4 +++
+ .../agc/gain_control_interface_gn/moz.build   |  4 +++
+ .../agc/legacy_agc_gn/moz.build               |  4 +++
+ .../agc/level_estimation_gn/moz.build         |  4 +++
+ .../moz.build                                 |  4 +++
+ .../agc2/biquad_filter_gn/moz.build           |  4 +++
+ .../agc2/clipping_predictor_gn/moz.build      |  4 +++
+ .../audio_processing/agc2/common_gn/moz.build |  4 +++
+ .../agc2/cpu_features_gn/moz.build            |  4 +++
+ .../agc2/fixed_digital_gn/moz.build           |  4 +++
+ .../agc2/gain_applier_gn/moz.build            |  4 +++
+ .../agc2/gain_map_gn/moz.build                |  4 +++
+ .../agc2/input_volume_controller_gn/moz.build |  4 +++
+ .../input_volume_stats_reporter_gn/moz.build  |  4 +++
+ .../agc2/noise_level_estimator_gn/moz.build   |  4 +++
+ .../rnn_vad_auto_correlation_gn/moz.build     |  4 +++
+ .../agc2/rnn_vad/rnn_vad_common_gn/moz.build  |  4 +++
+ .../agc2/rnn_vad/rnn_vad_gn/moz.build         |  4 +++
+ .../agc2/rnn_vad/rnn_vad_layers_gn/moz.build  |  4 +++
+ .../rnn_vad/rnn_vad_lp_residual_gn/moz.build  |  4 +++
+ .../agc2/rnn_vad/rnn_vad_pitch_gn/moz.build   |  4 +++
+ .../rnn_vad/rnn_vad_ring_buffer_gn/moz.build  |  4 +++
+ .../rnn_vad_sequence_buffer_gn/moz.build      |  4 +++
+ .../rnn_vad_spectral_features_gn/moz.build    |  4 +++
+ .../moz.build                                 |  4 +++
+ .../agc2/rnn_vad/vector_math_gn/moz.build     |  4 +++
+ .../agc2/saturation_protector_gn/moz.build    |  4 +++
+ .../agc2/speech_level_estimator_gn/moz.build  |  4 +++
+ .../agc2/vad_wrapper_gn/moz.build             |  4 +++
+ .../audio_processing/apm_logging_gn/moz.build |  4 +++
+ .../audio_buffer_gn/moz.build                 |  4 +++
+ .../audio_frame_proxies_gn/moz.build          |  4 +++
+ .../audio_frame_view_gn/moz.build             |  4 +++
+ .../audio_processing_gn/moz.build             |  4 +++
+ .../capture_levels_adjuster_gn/moz.build      |  4 +++
+ .../gain_controller2_gn/moz.build             |  4 +++
+ .../high_pass_filter_gn/moz.build             |  4 +++
+ .../audio_processing/ns/ns_gn/moz.build       |  4 +++
+ .../audio_processing/rms_level_gn/moz.build   |  4 +++
+ .../cascaded_biquad_filter_gn/moz.build       |  4 +++
+ .../legacy_delay_estimator_gn/moz.build       |  4 +++
+ .../utility/pffft_wrapper_gn/moz.build        |  4 +++
+ .../audio_processing/vad/vad_gn/moz.build     |  4 +++
+ .../congestion_controller_gn/moz.build        |  4 +++
+ .../goog_cc/alr_detector_gn/moz.build         |  4 +++
+ .../goog_cc/delay_based_bwe_gn/moz.build      |  4 +++
+ .../goog_cc/estimators_gn/moz.build           |  4 +++
+ .../goog_cc/goog_cc_gn/moz.build              |  4 +++
+ .../link_capacity_estimator_gn/moz.build      |  4 +++
+ .../goog_cc/loss_based_bwe_v1_gn/moz.build    |  4 +++
+ .../goog_cc/loss_based_bwe_v2_gn/moz.build    |  4 +++
+ .../goog_cc/probe_controller_gn/moz.build     |  4 +++
+ .../goog_cc/pushback_controller_gn/moz.build  |  4 +++
+ .../goog_cc/send_side_bwe_gn/moz.build        |  4 +++
+ .../rtp/control_handler_gn/moz.build          |  4 +++
+ .../rtp/transport_feedback_gn/moz.build       |  4 +++
+ .../desktop_capture_gn/moz.build              | 29 +++++++++++++++++++
+ .../desktop_capture/primitives_gn/moz.build   |  5 ++++
+ .../libwebrtc/modules/module_api_gn/moz.build |  4 +++
+ .../modules/module_api_public_gn/moz.build    |  4 +++
+ .../modules/module_fec_api_gn/moz.build       |  4 +++
+ .../pacing/interval_budget_gn/moz.build       |  4 +++
+ .../modules/pacing/pacing_gn/moz.build        |  4 +++
+ .../moz.build                                 |  4 +++
+ .../remote_bitrate_estimator_gn/moz.build     |  4 +++
+ .../moz.build                                 |  4 +++
+ .../moz.build                                 |  4 +++
+ .../modules/rtp_rtcp/leb128_gn/moz.build      |  4 +++
+ .../rtp_rtcp/ntp_time_util_gn/moz.build       |  4 +++
+ .../rtp_rtcp/rtp_rtcp_format_gn/moz.build     |  4 +++
+ .../modules/rtp_rtcp/rtp_rtcp_gn/moz.build    |  4 +++
+ .../rtp_rtcp/rtp_video_header_gn/moz.build    |  4 +++
+ .../modules/third_party/fft/fft_gn/moz.build  |  4 +++
+ .../third_party/g711/g711_3p_gn/moz.build     |  4 +++
+ .../third_party/g722/g722_3p_gn/moz.build     |  4 +++
+ .../modules/utility/utility_gn/moz.build      |  4 +++
+ .../video_capture_internal_impl_gn/moz.build  |  4 +++
+ .../video_capture_module_gn/moz.build         |  4 +++
+ .../chain_diff_calculator_gn/moz.build        |  4 +++
+ .../codec_globals_headers_gn/moz.build        |  4 +++
+ .../codecs/av1/av1_svc_config_gn/moz.build    |  4 +++
+ .../video_coding/encoded_frame_gn/moz.build   |  4 +++
+ .../moz.build                                 |  4 +++
+ .../video_coding/frame_helpers_gn/moz.build   |  4 +++
+ .../h264_sprop_parameter_sets_gn/moz.build    |  4 +++
+ .../h26x_packet_buffer_gn/moz.build           |  4 +++
+ .../video_coding/nack_requester_gn/moz.build  |  4 +++
+ .../video_coding/packet_buffer_gn/moz.build   |  4 +++
+ .../svc/scalability_mode_util_gn/moz.build    |  4 +++
+ .../svc/scalability_structures_gn/moz.build   |  4 +++
+ .../scalable_video_controller_gn/moz.build    |  4 +++
+ .../svc/svc_rate_allocator_gn/moz.build       |  4 +++
+ .../moz.build                                 |  4 +++
+ .../moz.build                                 |  4 +++
+ .../moz.build                                 |  4 +++
+ .../timing/jitter_estimator_gn/moz.build      |  4 +++
+ .../timing/rtt_filter_gn/moz.build            |  4 +++
+ .../timestamp_extrapolator_gn/moz.build       |  4 +++
+ .../timing/timing_module_gn/moz.build         |  4 +++
+ .../video_codec_interface_gn/moz.build        |  4 +++
+ .../video_coding/video_coding_gn/moz.build    |  4 +++
+ .../video_coding_utility_gn/moz.build         |  4 +++
+ .../webrtc_libvpx_interface_gn/moz.build      |  4 +++
+ .../video_coding/webrtc_vp8_gn/moz.build      |  4 +++
+ .../webrtc_vp8_scalability_gn/moz.build       |  4 +++
+ .../webrtc_vp8_temporal_layers_gn/moz.build   |  4 +++
+ .../video_coding/webrtc_vp9_gn/moz.build      |  4 +++
+ .../webrtc_vp9_helpers_gn/moz.build           |  4 +++
+ third_party/libwebrtc/moz.build               |  7 +++++
+ .../rtc_base/async_dns_resolver_gn/moz.build  |  4 +++
+ .../rtc_base/async_packet_socket_gn/moz.build |  4 +++
+ .../audio_format_to_string_gn/moz.build       |  4 +++
+ .../rtc_base/bit_buffer_gn/moz.build          |  4 +++
+ .../rtc_base/bitrate_tracker_gn/moz.build     |  4 +++
+ .../rtc_base/bitstream_reader_gn/moz.build    |  4 +++
+ .../libwebrtc/rtc_base/buffer_gn/moz.build    |  4 +++
+ .../rtc_base/byte_buffer_gn/moz.build         |  4 +++
+ .../rtc_base/byte_order_gn/moz.build          |  4 +++
+ .../libwebrtc/rtc_base/checks_gn/moz.build    |  4 +++
+ .../rtc_base/compile_assert_c_gn/moz.build    |  4 +++
+ .../flat_containers_internal_gn/moz.build     |  4 +++
+ .../rtc_base/containers/flat_map_gn/moz.build |  4 +++
+ .../rtc_base/containers/flat_set_gn/moz.build |  4 +++
+ .../copy_on_write_buffer_gn/moz.build         |  4 +++
+ .../rtc_base/criticalsection_gn/moz.build     |  4 +++
+ .../rtc_base/divide_round_gn/moz.build        |  4 +++
+ .../libwebrtc/rtc_base/dscp_gn/moz.build      |  4 +++
+ .../rtc_base/event_tracer_gn/moz.build        |  4 +++
+ .../experiments/alr_experiment_gn/moz.build   |  4 +++
+ .../moz.build                                 |  4 +++
+ .../encoder_info_settings_gn/moz.build        |  4 +++
+ .../field_trial_parser_gn/moz.build           |  4 +++
+ .../moz.build                                 |  4 +++
+ .../min_video_bitrate_experiment_gn/moz.build |  4 +++
+ .../moz.build                                 |  4 +++
+ .../quality_scaler_settings_gn/moz.build      |  4 +++
+ .../quality_scaling_experiment_gn/moz.build   |  4 +++
+ .../rate_control_settings_gn/moz.build        |  4 +++
+ .../moz.build                                 |  4 +++
+ .../rtc_base/frequency_tracker_gn/moz.build   |  4 +++
+ .../rtc_base/gtest_prod_gn/moz.build          |  4 +++
+ .../histogram_percentile_counter_gn/moz.build |  4 +++
+ .../rtc_base/ignore_wundef_gn/moz.build       |  4 +++
+ .../rtc_base/ip_address_gn/moz.build          |  4 +++
+ .../libwebrtc/rtc_base/logging_gn/moz.build   |  4 +++
+ .../rtc_base/macromagic_gn/moz.build          |  4 +++
+ .../memory/aligned_malloc_gn/moz.build        |  4 +++
+ .../libwebrtc/rtc_base/mod_ops_gn/moz.build   |  4 +++
+ .../rtc_base/moving_max_counter_gn/moz.build  |  4 +++
+ .../rtc_base/net_helpers_gn/moz.build         |  4 +++
+ .../rtc_base/network/ecn_marking_gn/moz.build |  4 +++
+ .../rtc_base/network/sent_packet_gn/moz.build |  4 +++
+ .../rtc_base/network_constants_gn/moz.build   |  4 +++
+ .../rtc_base/network_route_gn/moz.build       |  4 +++
+ .../rtc_base/null_socket_server_gn/moz.build  |  4 +++
+ .../rtc_base/one_time_event_gn/moz.build      |  4 +++
+ .../rtc_base/platform_thread_gn/moz.build     |  4 +++
+ .../platform_thread_types_gn/moz.build        |  4 +++
+ .../rtc_base/protobuf_utils_gn/moz.build      |  4 +++
+ .../rtc_base/race_checker_gn/moz.build        |  4 +++
+ .../libwebrtc/rtc_base/random_gn/moz.build    |  4 +++
+ .../rtc_base/rate_limiter_gn/moz.build        |  4 +++
+ .../rtc_base/rate_statistics_gn/moz.build     |  4 +++
+ .../rtc_base/rate_tracker_gn/moz.build        |  4 +++
+ .../libwebrtc/rtc_base/refcount_gn/moz.build  |  4 +++
+ .../rtc_base/rolling_accumulator_gn/moz.build |  4 +++
+ .../libwebrtc/rtc_base/rtc_event_gn/moz.build |  4 +++
+ .../rtc_base/rtc_numerics_gn/moz.build        |  4 +++
+ .../rtc_base/safe_compare_gn/moz.build        |  4 +++
+ .../rtc_base/safe_conversions_gn/moz.build    |  4 +++
+ .../rtc_base/safe_minmax_gn/moz.build         |  4 +++
+ .../rtc_base/sample_counter_gn/moz.build      |  4 +++
+ .../libwebrtc/rtc_base/sanitizer_gn/moz.build |  4 +++
+ .../rtc_base/socket_address_gn/moz.build      |  4 +++
+ .../rtc_base/socket_factory_gn/moz.build      |  4 +++
+ .../libwebrtc/rtc_base/socket_gn/moz.build    |  4 +++
+ .../rtc_base/socket_server_gn/moz.build       |  4 +++
+ .../rtc_base/ssl_adapter_gn/moz.build         |  4 +++
+ .../rtc_base/stringutils_gn/moz.build         |  4 +++
+ .../rtc_base/strong_alias_gn/moz.build        |  4 +++
+ .../rtc_base/swap_queue_gn/moz.build          |  4 +++
+ .../synchronization/mutex_gn/moz.build        |  4 +++
+ .../sequence_checker_internal_gn/moz.build    |  4 +++
+ .../synchronization/yield_gn/moz.build        |  4 +++
+ .../synchronization/yield_policy_gn/moz.build |  4 +++
+ .../rtc_base/system/arch_gn/moz.build         |  4 +++
+ .../rtc_base/system/file_wrapper_gn/moz.build |  4 +++
+ .../system/ignore_warnings_gn/moz.build       |  4 +++
+ .../rtc_base/system/inline_gn/moz.build       |  4 +++
+ .../system/no_unique_address_gn/moz.build     |  4 +++
+ .../rtc_base/system/rtc_export_gn/moz.build   |  4 +++
+ .../rtc_base/system/unused_gn/moz.build       |  4 +++
+ .../moz.build                                 |  4 +++
+ .../task_utils/repeating_task_gn/moz.build    |  4 +++
+ .../third_party/base64/base64_gn/moz.build    |  4 +++
+ .../third_party/sigslot/sigslot_gn/moz.build  |  4 +++
+ .../libwebrtc/rtc_base/threading_gn/moz.build |  4 +++
+ .../libwebrtc/rtc_base/timeutils_gn/moz.build |  4 +++
+ .../rtc_base/type_traits_gn/moz.build         |  4 +++
+ .../rtc_base/unique_id_generator_gn/moz.build |  4 +++
+ .../rtc_base/units/unit_base_gn/moz.build     |  4 +++
+ .../libwebrtc/rtc_base/weak_ptr_gn/moz.build  |  4 +++
+ .../rtc_base/zero_memory_gn/moz.build         |  4 +++
+ .../denormal_disabler_gn/moz.build            |  4 +++
+ .../system_wrappers/field_trial_gn/moz.build  |  4 +++
+ .../system_wrappers/metrics_gn/moz.build      |  4 +++
+ .../system_wrappers_gn/moz.build              |  4 +++
+ .../network/simulated_network_gn/moz.build    |  4 +++
+ .../test/rtp_test_utils_gn/moz.build          |  4 +++
+ .../third_party/libyuv/libyuv_gn/moz.build    |  4 +++
+ .../third_party/pffft/pffft_gn/moz.build      |  5 ++++
+ .../third_party/rnnoise/rnn_vad_gn/moz.build  |  4 +++
+ .../adaptation/video_adaptation_gn/moz.build  |  4 +++
+ .../video/config/encoder_config_gn/moz.build  |  4 +++
+ .../video/config/streams_config_gn/moz.build  |  4 +++
+ .../video/decode_synchronizer_gn/moz.build    |  4 +++
+ .../video/frame_cadence_adapter_gn/moz.build  |  4 +++
+ .../video/frame_decode_scheduler_gn/moz.build |  4 +++
+ .../video/frame_decode_timing_gn/moz.build    |  4 +++
+ .../video/frame_dumping_decoder_gn/moz.build  |  4 +++
+ .../video/frame_dumping_encoder_gn/moz.build  |  4 +++
+ .../render/incoming_video_stream_gn/moz.build |  4 +++
+ .../render/video_render_frames_gn/moz.build   |  4 +++
+ .../moz.build                                 |  4 +++
+ .../unique_timestamp_counter_gn/moz.build     |  4 +++
+ .../libwebrtc/video/video_gn/moz.build        |  4 +++
+ .../moz.build                                 |  4 +++
+ .../moz.build                                 |  4 +++
+ .../video_stream_encoder_impl_gn/moz.build    |  4 +++
+ .../moz.build                                 |  4 +++
+ third_party/libwebrtc/webrtc_gn/moz.build     |  4 +++
+ 439 files changed, 1800 insertions(+)
+
 diff --git a/third_party/libwebrtc/api/adaptation/resource_adaptation_api_gn/moz.build b/third_party/libwebrtc/api/adaptation/resource_adaptation_api_gn/moz.build
-index 2dbd5881583e3..b63b665289b5a 100644
+index a80e5f32ad..cde6fefd2a 100644
 --- a/third_party/libwebrtc/api/adaptation/resource_adaptation_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/adaptation/resource_adaptation_api_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -14,7 +472,7 @@ index 2dbd5881583e3..b63b665289b5a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/array_view_gn/moz.build b/third_party/libwebrtc/api/array_view_gn/moz.build
-index df2c86715cacd..0a60fd48bb19b 100644
+index 25221b2af7..9e0e2baa4f 100644
 --- a/third_party/libwebrtc/api/array_view_gn/moz.build
 +++ b/third_party/libwebrtc/api/array_view_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -29,7 +487,7 @@ index df2c86715cacd..0a60fd48bb19b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/async_dns_resolver_gn/moz.build b/third_party/libwebrtc/api/async_dns_resolver_gn/moz.build
-index 4d678a1de7c96..90dd37068d148 100644
+index bf95db7b24..119da97923 100644
 --- a/third_party/libwebrtc/api/async_dns_resolver_gn/moz.build
 +++ b/third_party/libwebrtc/api/async_dns_resolver_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -44,7 +502,7 @@ index 4d678a1de7c96..90dd37068d148 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/aec3_config_gn/moz.build b/third_party/libwebrtc/api/audio/aec3_config_gn/moz.build
-index cbd6f2e6f0d53..785f61c7f9c33 100644
+index 2c964a4fd0..c6f47c5e01 100644
 --- a/third_party/libwebrtc/api/audio/aec3_config_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/aec3_config_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -59,7 +517,7 @@ index cbd6f2e6f0d53..785f61c7f9c33 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/aec3_factory_gn/moz.build b/third_party/libwebrtc/api/audio/aec3_factory_gn/moz.build
-index 746585483f964..b702e63d8d1c1 100644
+index e02b226aca..fbe73e30fd 100644
 --- a/third_party/libwebrtc/api/audio/aec3_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/aec3_factory_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -74,7 +532,7 @@ index 746585483f964..b702e63d8d1c1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/audio_device_gn/moz.build b/third_party/libwebrtc/api/audio/audio_device_gn/moz.build
-index 9609692094c15..4b1e3244c5b73 100644
+index 0fc7d75079..4eb634da1a 100644
 --- a/third_party/libwebrtc/api/audio/audio_device_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/audio_device_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -89,7 +547,7 @@ index 9609692094c15..4b1e3244c5b73 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/audio_frame_api_gn/moz.build b/third_party/libwebrtc/api/audio/audio_frame_api_gn/moz.build
-index e2561db08f06e..5da158eb823a1 100644
+index c0e06e7a78..ce0bceeecd 100644
 --- a/third_party/libwebrtc/api/audio/audio_frame_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/audio_frame_api_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -104,7 +562,7 @@ index e2561db08f06e..5da158eb823a1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/audio_frame_processor_gn/moz.build b/third_party/libwebrtc/api/audio/audio_frame_processor_gn/moz.build
-index 7dd1c4b91100e..d33585f69fe68 100644
+index bc6ea25161..4a330e94b4 100644
 --- a/third_party/libwebrtc/api/audio/audio_frame_processor_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/audio_frame_processor_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -119,7 +577,7 @@ index 7dd1c4b91100e..d33585f69fe68 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/audio_mixer_api_gn/moz.build b/third_party/libwebrtc/api/audio/audio_mixer_api_gn/moz.build
-index 36d43783a3e7d..f8d9e41c9a370 100644
+index cedd56ac79..4b161cf7e0 100644
 --- a/third_party/libwebrtc/api/audio/audio_mixer_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/audio_mixer_api_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -134,7 +592,7 @@ index 36d43783a3e7d..f8d9e41c9a370 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/audio_processing_gn/moz.build b/third_party/libwebrtc/api/audio/audio_processing_gn/moz.build
-index 7226d2a92a40a..a3ed2ed8a94dd 100644
+index 10ae1f65fa..4b84f10ea5 100644
 --- a/third_party/libwebrtc/api/audio/audio_processing_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/audio_processing_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -149,7 +607,7 @@ index 7226d2a92a40a..a3ed2ed8a94dd 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/audio_processing_statistics_gn/moz.build b/third_party/libwebrtc/api/audio/audio_processing_statistics_gn/moz.build
-index d7629659d6bac..ede61bc1f955a 100644
+index 061ff48b84..576e21b323 100644
 --- a/third_party/libwebrtc/api/audio/audio_processing_statistics_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/audio_processing_statistics_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -164,7 +622,7 @@ index d7629659d6bac..ede61bc1f955a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio/echo_control_gn/moz.build b/third_party/libwebrtc/api/audio/echo_control_gn/moz.build
-index 06f43e765114c..cc5e401aa4f8a 100644
+index f1cfe20bed..2b424db2a8 100644
 --- a/third_party/libwebrtc/api/audio/echo_control_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio/echo_control_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -179,7 +637,7 @@ index 06f43e765114c..cc5e401aa4f8a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/L16/audio_decoder_L16_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/L16/audio_decoder_L16_gn/moz.build
-index 5811f4d9321bc..f530738ade2e5 100644
+index ff6ba51fed..49c434ebb7 100644
 --- a/third_party/libwebrtc/api/audio_codecs/L16/audio_decoder_L16_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/L16/audio_decoder_L16_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -194,7 +652,7 @@ index 5811f4d9321bc..f530738ade2e5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/L16/audio_encoder_L16_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/L16/audio_encoder_L16_gn/moz.build
-index f4fb06ef3f093..452bc02291fba 100644
+index 50f3967770..1e14f02b88 100644
 --- a/third_party/libwebrtc/api/audio_codecs/L16/audio_encoder_L16_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/L16/audio_encoder_L16_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -209,7 +667,7 @@ index f4fb06ef3f093..452bc02291fba 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/audio_codecs_api_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/audio_codecs_api_gn/moz.build
-index faed7e9b0f615..c0e23d412af50 100644
+index 66899306c2..e36c41ab63 100644
 --- a/third_party/libwebrtc/api/audio_codecs/audio_codecs_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/audio_codecs_api_gn/moz.build
 @@ -153,6 +153,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -224,7 +682,7 @@ index faed7e9b0f615..c0e23d412af50 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/builtin_audio_decoder_factory_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/builtin_audio_decoder_factory_gn/moz.build
-index 5de9c2960769a..d04a8351a0f6e 100644
+index 235eb30deb..03b6208676 100644
 --- a/third_party/libwebrtc/api/audio_codecs/builtin_audio_decoder_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/builtin_audio_decoder_factory_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -239,7 +697,7 @@ index 5de9c2960769a..d04a8351a0f6e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/builtin_audio_encoder_factory_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/builtin_audio_encoder_factory_gn/moz.build
-index 5ff7dfd0ffd44..dd8118bf090a4 100644
+index d6edc362eb..e99d62d1e4 100644
 --- a/third_party/libwebrtc/api/audio_codecs/builtin_audio_encoder_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/builtin_audio_encoder_factory_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -254,7 +712,7 @@ index 5ff7dfd0ffd44..dd8118bf090a4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/g711/audio_decoder_g711_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/g711/audio_decoder_g711_gn/moz.build
-index e1c8fa6a08bcd..132315de16c5c 100644
+index cd6f3fcf49..238380a0ce 100644
 --- a/third_party/libwebrtc/api/audio_codecs/g711/audio_decoder_g711_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/g711/audio_decoder_g711_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -269,7 +727,7 @@ index e1c8fa6a08bcd..132315de16c5c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/g711/audio_encoder_g711_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/g711/audio_encoder_g711_gn/moz.build
-index 39513d15b310e..12e706e63a9a2 100644
+index 88ab3c83b6..e1f22f02ff 100644
 --- a/third_party/libwebrtc/api/audio_codecs/g711/audio_encoder_g711_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/g711/audio_encoder_g711_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -284,7 +742,7 @@ index 39513d15b310e..12e706e63a9a2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/g722/audio_decoder_g722_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/g722/audio_decoder_g722_gn/moz.build
-index cf9228dcab3c2..4b5fab47cbeeb 100644
+index 033fdb4bb6..eb013f2828 100644
 --- a/third_party/libwebrtc/api/audio_codecs/g722/audio_decoder_g722_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/g722/audio_decoder_g722_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -299,7 +757,7 @@ index cf9228dcab3c2..4b5fab47cbeeb 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_config_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_config_gn/moz.build
-index 3b1a814ac7b2f..aab75ab622b29 100644
+index ecb9b406a2..00b7cf4f17 100644
 --- a/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_config_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_config_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -314,7 +772,7 @@ index 3b1a814ac7b2f..aab75ab622b29 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_gn/moz.build
-index 57bdfeaf74c0e..bf6097f6d1371 100644
+index cd28eb3465..5283d734c6 100644
 --- a/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/g722/audio_encoder_g722_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -329,7 +787,7 @@ index 57bdfeaf74c0e..bf6097f6d1371 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/ilbc/audio_decoder_ilbc_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/ilbc/audio_decoder_ilbc_gn/moz.build
-index ae2d4f5dc9b45..e89cb12925c3a 100644
+index e259a3b72e..e3dfd6dc00 100644
 --- a/third_party/libwebrtc/api/audio_codecs/ilbc/audio_decoder_ilbc_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/ilbc/audio_decoder_ilbc_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -344,7 +802,7 @@ index ae2d4f5dc9b45..e89cb12925c3a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_config_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_config_gn/moz.build
-index 2ec1c97ea2406..f97c0e70bb9f3 100644
+index cfa5320921..a7c7751696 100644
 --- a/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_config_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_config_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -359,7 +817,7 @@ index 2ec1c97ea2406..f97c0e70bb9f3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_gn/moz.build
-index ff9d947abb855..f153ba6833814 100644
+index 87b566eb9c..3d48772f5b 100644
 --- a/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/ilbc/audio_encoder_ilbc_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -374,7 +832,7 @@ index ff9d947abb855..f153ba6833814 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_multiopus_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_multiopus_gn/moz.build
-index 06926f2550c69..66ab66c8f34b3 100644
+index 728c782d1a..9b0b2c2587 100644
 --- a/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_multiopus_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_multiopus_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -389,7 +847,7 @@ index 06926f2550c69..66ab66c8f34b3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_config_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_config_gn/moz.build
-index a40417692306e..c25005f9737ad 100644
+index c27e08d89c..723555805b 100644
 --- a/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_config_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_config_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -404,7 +862,7 @@ index a40417692306e..c25005f9737ad 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_gn/moz.build
-index a52b290d08bcd..d131b519ffd26 100644
+index d6fe84b97b..53041423c5 100644
 --- a/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/opus/audio_decoder_opus_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -419,7 +877,7 @@ index a52b290d08bcd..d131b519ffd26 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_multiopus_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_multiopus_gn/moz.build
-index 1847aa9f23348..9952f0f04c168 100644
+index 15d75c1a6d..e4087613ab 100644
 --- a/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_multiopus_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_multiopus_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -434,7 +892,7 @@ index 1847aa9f23348..9952f0f04c168 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_config_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_config_gn/moz.build
-index b4ed20ad85894..895171c2d11a9 100644
+index f0b9b2ddb3..b9a38d720f 100644
 --- a/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_config_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_config_gn/moz.build
 @@ -144,6 +144,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -449,7 +907,7 @@ index b4ed20ad85894..895171c2d11a9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_gn/moz.build b/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_gn/moz.build
-index dc73c7abc386d..8f4a2bf4f154a 100644
+index e2fb4d316a..460195dcae 100644
 --- a/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_codecs/opus/audio_encoder_opus_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -464,7 +922,7 @@ index dc73c7abc386d..8f4a2bf4f154a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/audio_options_api_gn/moz.build b/third_party/libwebrtc/api/audio_options_api_gn/moz.build
-index 974d1dbdf2c7a..0b52d3c7819f1 100644
+index 9cddf47802..fc4ff69dec 100644
 --- a/third_party/libwebrtc/api/audio_options_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/audio_options_api_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -479,7 +937,7 @@ index 974d1dbdf2c7a..0b52d3c7819f1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/bitrate_allocation_gn/moz.build b/third_party/libwebrtc/api/bitrate_allocation_gn/moz.build
-index 500eff54bbfd6..0daeeeffaceeb 100644
+index a5170774bd..f11130fece 100644
 --- a/third_party/libwebrtc/api/bitrate_allocation_gn/moz.build
 +++ b/third_party/libwebrtc/api/bitrate_allocation_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -494,7 +952,7 @@ index 500eff54bbfd6..0daeeeffaceeb 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/call_api_gn/moz.build b/third_party/libwebrtc/api/call_api_gn/moz.build
-index 372f0888fbba4..c694ed5d84f5a 100644
+index 439d2b4431..889b8161f3 100644
 --- a/third_party/libwebrtc/api/call_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/call_api_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -509,7 +967,7 @@ index 372f0888fbba4..c694ed5d84f5a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/crypto/frame_decryptor_interface_gn/moz.build b/third_party/libwebrtc/api/crypto/frame_decryptor_interface_gn/moz.build
-index 2a9b6d96dd757..640dde634d168 100644
+index 8c4ad8dd1e..41451b2349 100644
 --- a/third_party/libwebrtc/api/crypto/frame_decryptor_interface_gn/moz.build
 +++ b/third_party/libwebrtc/api/crypto/frame_decryptor_interface_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -524,7 +982,7 @@ index 2a9b6d96dd757..640dde634d168 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/crypto/frame_encryptor_interface_gn/moz.build b/third_party/libwebrtc/api/crypto/frame_encryptor_interface_gn/moz.build
-index f1716e6b62674..a2119ffc20e1f 100644
+index b3d5fc80f2..db4a92f2b4 100644
 --- a/third_party/libwebrtc/api/crypto/frame_encryptor_interface_gn/moz.build
 +++ b/third_party/libwebrtc/api/crypto/frame_encryptor_interface_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -539,10 +997,10 @@ index f1716e6b62674..a2119ffc20e1f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/crypto/options_gn/moz.build b/third_party/libwebrtc/api/crypto/options_gn/moz.build
-index fae93b139253d..eb25f7ce47a7d 100644
+index 5ce60513e9..c1609251bd 100644
 --- a/third_party/libwebrtc/api/crypto/options_gn/moz.build
 +++ b/third_party/libwebrtc/api/crypto/options_gn/moz.build
-@@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
      DEFINES["WEBRTC_ARCH_ARM_V7"] = True
      DEFINES["WEBRTC_HAS_NEON"] = True
  
@@ -554,7 +1012,7 @@ index fae93b139253d..eb25f7ce47a7d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/environment/environment_factory_gn/moz.build b/third_party/libwebrtc/api/environment/environment_factory_gn/moz.build
-index 9388642ab5e6a..6f3bff64f1a64 100644
+index dfb310b078..25023964b5 100644
 --- a/third_party/libwebrtc/api/environment/environment_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/environment/environment_factory_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -569,7 +1027,7 @@ index 9388642ab5e6a..6f3bff64f1a64 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/environment/environment_gn/moz.build b/third_party/libwebrtc/api/environment/environment_gn/moz.build
-index 5b7b361ac342f..59ebfd8ef91d1 100644
+index 484b89746f..d5624d5933 100644
 --- a/third_party/libwebrtc/api/environment/environment_gn/moz.build
 +++ b/third_party/libwebrtc/api/environment/environment_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -584,7 +1042,7 @@ index 5b7b361ac342f..59ebfd8ef91d1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/fec_controller_api_gn/moz.build b/third_party/libwebrtc/api/fec_controller_api_gn/moz.build
-index 653eae8f233f9..49f4eede6882d 100644
+index e8caeb29b0..7386a6cc9b 100644
 --- a/third_party/libwebrtc/api/fec_controller_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/fec_controller_api_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -599,7 +1057,7 @@ index 653eae8f233f9..49f4eede6882d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/field_trials_registry_gn/moz.build b/third_party/libwebrtc/api/field_trials_registry_gn/moz.build
-index 76e121ec9f5ef..ea669bd624c78 100644
+index ee276a6abe..4697153d47 100644
 --- a/third_party/libwebrtc/api/field_trials_registry_gn/moz.build
 +++ b/third_party/libwebrtc/api/field_trials_registry_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -614,7 +1072,7 @@ index 76e121ec9f5ef..ea669bd624c78 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/field_trials_view_gn/moz.build b/third_party/libwebrtc/api/field_trials_view_gn/moz.build
-index a6ac64bf50c65..2a3e4ded29f84 100644
+index 9dcf0f1332..19d8b2d7c2 100644
 --- a/third_party/libwebrtc/api/field_trials_view_gn/moz.build
 +++ b/third_party/libwebrtc/api/field_trials_view_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -629,10 +1087,10 @@ index a6ac64bf50c65..2a3e4ded29f84 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/frame_transformer_interface_gn/moz.build b/third_party/libwebrtc/api/frame_transformer_interface_gn/moz.build
-index 2ed19fd691d74..ad99d0d4c1649 100644
+index b47d843d10..91e96d9657 100644
 --- a/third_party/libwebrtc/api/frame_transformer_interface_gn/moz.build
 +++ b/third_party/libwebrtc/api/frame_transformer_interface_gn/moz.build
-@@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
      DEFINES["WEBRTC_ARCH_ARM_V7"] = True
      DEFINES["WEBRTC_HAS_NEON"] = True
  
@@ -644,7 +1102,7 @@ index 2ed19fd691d74..ad99d0d4c1649 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/function_view_gn/moz.build b/third_party/libwebrtc/api/function_view_gn/moz.build
-index feea8c2c0ba69..8b1ff5ec3a264 100644
+index 6eccd0a4fd..1cc0aeedd2 100644
 --- a/third_party/libwebrtc/api/function_view_gn/moz.build
 +++ b/third_party/libwebrtc/api/function_view_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -659,7 +1117,7 @@ index feea8c2c0ba69..8b1ff5ec3a264 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/libjingle_logging_api_gn/moz.build b/third_party/libwebrtc/api/libjingle_logging_api_gn/moz.build
-index 6729abedf9bdc..2e97c3bc61bc0 100644
+index 14951db5b9..228854aff2 100644
 --- a/third_party/libwebrtc/api/libjingle_logging_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/libjingle_logging_api_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -674,7 +1132,7 @@ index 6729abedf9bdc..2e97c3bc61bc0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/libjingle_peerconnection_api_gn/moz.build b/third_party/libwebrtc/api/libjingle_peerconnection_api_gn/moz.build
-index f815d7da4e62c..084545fc52ea8 100644
+index d75066b595..16c37a7bb7 100644
 --- a/third_party/libwebrtc/api/libjingle_peerconnection_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/libjingle_peerconnection_api_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -689,7 +1147,7 @@ index f815d7da4e62c..084545fc52ea8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/location_gn/moz.build b/third_party/libwebrtc/api/location_gn/moz.build
-index 706b1d5026cc6..fe442cba8c1bb 100644
+index 87a5892861..3bac98a819 100644
 --- a/third_party/libwebrtc/api/location_gn/moz.build
 +++ b/third_party/libwebrtc/api/location_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -704,7 +1162,7 @@ index 706b1d5026cc6..fe442cba8c1bb 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/make_ref_counted_gn/moz.build b/third_party/libwebrtc/api/make_ref_counted_gn/moz.build
-index 6bedaf55cd032..0b1eb1b16cfff 100644
+index 7f956665ed..9dff392de0 100644
 --- a/third_party/libwebrtc/api/make_ref_counted_gn/moz.build
 +++ b/third_party/libwebrtc/api/make_ref_counted_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -719,7 +1177,7 @@ index 6bedaf55cd032..0b1eb1b16cfff 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/media_stream_interface_gn/moz.build b/third_party/libwebrtc/api/media_stream_interface_gn/moz.build
-index 8cc4995908e8f..75524f59d042e 100644
+index fea8af2692..4cdf3121c8 100644
 --- a/third_party/libwebrtc/api/media_stream_interface_gn/moz.build
 +++ b/third_party/libwebrtc/api/media_stream_interface_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -734,7 +1192,7 @@ index 8cc4995908e8f..75524f59d042e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/metronome/metronome_gn/moz.build b/third_party/libwebrtc/api/metronome/metronome_gn/moz.build
-index 5ffa4ac6c78f4..e26be50d5a96a 100644
+index 57a1e2ca46..bc06a5e82e 100644
 --- a/third_party/libwebrtc/api/metronome/metronome_gn/moz.build
 +++ b/third_party/libwebrtc/api/metronome/metronome_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -749,7 +1207,7 @@ index 5ffa4ac6c78f4..e26be50d5a96a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/neteq/default_neteq_controller_factory_gn/moz.build b/third_party/libwebrtc/api/neteq/default_neteq_controller_factory_gn/moz.build
-index 0486a791d10f2..ad94f63893193 100644
+index 10d65f922e..06c3b44ce1 100644
 --- a/third_party/libwebrtc/api/neteq/default_neteq_controller_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/neteq/default_neteq_controller_factory_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -764,10 +1222,10 @@ index 0486a791d10f2..ad94f63893193 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/neteq/neteq_api_gn/moz.build b/third_party/libwebrtc/api/neteq/neteq_api_gn/moz.build
-index ec0207e6b81a6..ee453a5ba4923 100644
+index a4512f3c1f..f23592fa02 100644
 --- a/third_party/libwebrtc/api/neteq/neteq_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/neteq/neteq_api_gn/moz.build
-@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
      DEFINES["WEBRTC_ARCH_ARM_V7"] = True
      DEFINES["WEBRTC_HAS_NEON"] = True
  
@@ -779,10 +1237,10 @@ index ec0207e6b81a6..ee453a5ba4923 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/neteq/neteq_controller_api_gn/moz.build b/third_party/libwebrtc/api/neteq/neteq_controller_api_gn/moz.build
-index 830a41cbcb2fe..c896a2a54931b 100644
+index 8ca00de799..de8c078131 100644
 --- a/third_party/libwebrtc/api/neteq/neteq_controller_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/neteq/neteq_controller_api_gn/moz.build
-@@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+@@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
      DEFINES["WEBRTC_ARCH_ARM_V7"] = True
      DEFINES["WEBRTC_HAS_NEON"] = True
  
@@ -794,7 +1252,7 @@ index 830a41cbcb2fe..c896a2a54931b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/neteq/tick_timer_gn/moz.build b/third_party/libwebrtc/api/neteq/tick_timer_gn/moz.build
-index 4f4101599f071..782b2f92bf77f 100644
+index 97f27314b0..5e92ffd880 100644
 --- a/third_party/libwebrtc/api/neteq/tick_timer_gn/moz.build
 +++ b/third_party/libwebrtc/api/neteq/tick_timer_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -809,7 +1267,7 @@ index 4f4101599f071..782b2f92bf77f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/network_state_predictor_api_gn/moz.build b/third_party/libwebrtc/api/network_state_predictor_api_gn/moz.build
-index 84ec637233068..00f9a3ed0f648 100644
+index 27f989b8b2..a020c5d4f2 100644
 --- a/third_party/libwebrtc/api/network_state_predictor_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/network_state_predictor_api_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -824,10 +1282,10 @@ index 84ec637233068..00f9a3ed0f648 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/priority_gn/moz.build b/third_party/libwebrtc/api/priority_gn/moz.build
-index e90b551e4d69f..15cd85663ab50 100644
+index f412b0d8fb..691e36e41a 100644
 --- a/third_party/libwebrtc/api/priority_gn/moz.build
 +++ b/third_party/libwebrtc/api/priority_gn/moz.build
-@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
      DEFINES["WEBRTC_ARCH_ARM_V7"] = True
      DEFINES["WEBRTC_HAS_NEON"] = True
  
@@ -839,7 +1297,7 @@ index e90b551e4d69f..15cd85663ab50 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/ref_count_gn/moz.build b/third_party/libwebrtc/api/ref_count_gn/moz.build
-index b5ded03ae3a44..8ec15b650b3ca 100644
+index 98c49cbfca..08b95e84f5 100644
 --- a/third_party/libwebrtc/api/ref_count_gn/moz.build
 +++ b/third_party/libwebrtc/api/ref_count_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -854,7 +1312,7 @@ index b5ded03ae3a44..8ec15b650b3ca 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/refcountedbase_gn/moz.build b/third_party/libwebrtc/api/refcountedbase_gn/moz.build
-index 42e693bf022a7..87e00c5de1d3e 100644
+index 7f6d1e6cf3..96e8bbb564 100644
 --- a/third_party/libwebrtc/api/refcountedbase_gn/moz.build
 +++ b/third_party/libwebrtc/api/refcountedbase_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -869,7 +1327,7 @@ index 42e693bf022a7..87e00c5de1d3e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/rtc_error_gn/moz.build b/third_party/libwebrtc/api/rtc_error_gn/moz.build
-index 1ff7960b4dd04..4bda31aba12f5 100644
+index fd4c614cf3..d857a8e586 100644
 --- a/third_party/libwebrtc/api/rtc_error_gn/moz.build
 +++ b/third_party/libwebrtc/api/rtc_error_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -884,7 +1342,7 @@ index 1ff7960b4dd04..4bda31aba12f5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/rtc_event_log/rtc_event_log_gn/moz.build b/third_party/libwebrtc/api/rtc_event_log/rtc_event_log_gn/moz.build
-index e478cf3e4c3cc..e33d4042d5c35 100644
+index 2f1418300a..2383188cf3 100644
 --- a/third_party/libwebrtc/api/rtc_event_log/rtc_event_log_gn/moz.build
 +++ b/third_party/libwebrtc/api/rtc_event_log/rtc_event_log_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -899,7 +1357,7 @@ index e478cf3e4c3cc..e33d4042d5c35 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/rtp_headers_gn/moz.build b/third_party/libwebrtc/api/rtp_headers_gn/moz.build
-index 5b5cac9bf0461..5effef5b2c4e0 100644
+index 033677891b..9426659435 100644
 --- a/third_party/libwebrtc/api/rtp_headers_gn/moz.build
 +++ b/third_party/libwebrtc/api/rtp_headers_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -914,7 +1372,7 @@ index 5b5cac9bf0461..5effef5b2c4e0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/rtp_packet_info_gn/moz.build b/third_party/libwebrtc/api/rtp_packet_info_gn/moz.build
-index 7bd7a37fb3611..0f24dd2a9bc4e 100644
+index c75ba8f4c4..594b7dae70 100644
 --- a/third_party/libwebrtc/api/rtp_packet_info_gn/moz.build
 +++ b/third_party/libwebrtc/api/rtp_packet_info_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -928,8 +1386,23 @@ index 7bd7a37fb3611..0f24dd2a9bc4e 100644
  if CONFIG["TARGET_CPU"] == "mips32":
  
      DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/rtp_packet_sender_gn/moz.build b/third_party/libwebrtc/api/rtp_packet_sender_gn/moz.build
+index 69412fc87e..e5c7d798a3 100644
+--- a/third_party/libwebrtc/api/rtp_packet_sender_gn/moz.build
++++ b/third_party/libwebrtc/api/rtp_packet_sender_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/rtp_parameters_gn/moz.build b/third_party/libwebrtc/api/rtp_parameters_gn/moz.build
-index ada3bfe3a22b4..2355c94b66390 100644
+index b92b2259d0..c3905894f0 100644
 --- a/third_party/libwebrtc/api/rtp_parameters_gn/moz.build
 +++ b/third_party/libwebrtc/api/rtp_parameters_gn/moz.build
 @@ -144,6 +144,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -944,7 +1417,7 @@ index ada3bfe3a22b4..2355c94b66390 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/rtp_sender_interface_gn/moz.build b/third_party/libwebrtc/api/rtp_sender_interface_gn/moz.build
-index 5b41bb13cbbe3..9981f77bfc6ec 100644
+index fd0316a345..0d5cce701c 100644
 --- a/third_party/libwebrtc/api/rtp_sender_interface_gn/moz.build
 +++ b/third_party/libwebrtc/api/rtp_sender_interface_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -959,7 +1432,7 @@ index 5b41bb13cbbe3..9981f77bfc6ec 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/rtp_sender_setparameters_callback_gn/moz.build b/third_party/libwebrtc/api/rtp_sender_setparameters_callback_gn/moz.build
-index 89f5c0fcc1184..46d09e7890da8 100644
+index 2dbb1256e4..b86a61e6d3 100644
 --- a/third_party/libwebrtc/api/rtp_sender_setparameters_callback_gn/moz.build
 +++ b/third_party/libwebrtc/api/rtp_sender_setparameters_callback_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -974,7 +1447,7 @@ index 89f5c0fcc1184..46d09e7890da8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/rtp_transceiver_direction_gn/moz.build b/third_party/libwebrtc/api/rtp_transceiver_direction_gn/moz.build
-index c3b4e7f67e562..0c0233a8e64e4 100644
+index 154dc5391a..a5fe524d6b 100644
 --- a/third_party/libwebrtc/api/rtp_transceiver_direction_gn/moz.build
 +++ b/third_party/libwebrtc/api/rtp_transceiver_direction_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -989,7 +1462,7 @@ index c3b4e7f67e562..0c0233a8e64e4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/scoped_refptr_gn/moz.build b/third_party/libwebrtc/api/scoped_refptr_gn/moz.build
-index bd244c29b5cb2..10f1d42f76b2d 100644
+index 5dc69d00ee..a6f6302b48 100644
 --- a/third_party/libwebrtc/api/scoped_refptr_gn/moz.build
 +++ b/third_party/libwebrtc/api/scoped_refptr_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1004,7 +1477,7 @@ index bd244c29b5cb2..10f1d42f76b2d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/sequence_checker_gn/moz.build b/third_party/libwebrtc/api/sequence_checker_gn/moz.build
-index e129bf8a010e9..11c8e5391fa57 100644
+index 649a16507f..54be2add2b 100644
 --- a/third_party/libwebrtc/api/sequence_checker_gn/moz.build
 +++ b/third_party/libwebrtc/api/sequence_checker_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1019,7 +1492,7 @@ index e129bf8a010e9..11c8e5391fa57 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/simulated_network_api_gn/moz.build b/third_party/libwebrtc/api/simulated_network_api_gn/moz.build
-index 222193edde3f0..e627311ebbf09 100644
+index 654045dd91..a837cfd6b1 100644
 --- a/third_party/libwebrtc/api/simulated_network_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/simulated_network_api_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1034,7 +1507,7 @@ index 222193edde3f0..e627311ebbf09 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/task_queue/default_task_queue_factory_gn/moz.build b/third_party/libwebrtc/api/task_queue/default_task_queue_factory_gn/moz.build
-index 0d9947daa8ce4..77f07de263705 100644
+index a0b133fad7..1a315cbc8d 100644
 --- a/third_party/libwebrtc/api/task_queue/default_task_queue_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/task_queue/default_task_queue_factory_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1049,7 +1522,7 @@ index 0d9947daa8ce4..77f07de263705 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/task_queue/pending_task_safety_flag_gn/moz.build b/third_party/libwebrtc/api/task_queue/pending_task_safety_flag_gn/moz.build
-index e0e0b4688e62e..db1d874780dee 100644
+index 00c89a68d1..2e3e936102 100644
 --- a/third_party/libwebrtc/api/task_queue/pending_task_safety_flag_gn/moz.build
 +++ b/third_party/libwebrtc/api/task_queue/pending_task_safety_flag_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1064,7 +1537,7 @@ index e0e0b4688e62e..db1d874780dee 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/task_queue/task_queue_gn/moz.build b/third_party/libwebrtc/api/task_queue/task_queue_gn/moz.build
-index b3eb74837f201..80617f24dd39e 100644
+index fad8682ae7..a0b910a663 100644
 --- a/third_party/libwebrtc/api/task_queue/task_queue_gn/moz.build
 +++ b/third_party/libwebrtc/api/task_queue/task_queue_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1079,7 +1552,7 @@ index b3eb74837f201..80617f24dd39e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/bandwidth_estimation_settings_gn/moz.build b/third_party/libwebrtc/api/transport/bandwidth_estimation_settings_gn/moz.build
-index 0885f16a06553..5dd6c3a3c16e4 100644
+index 45a9e83269..921d0498e8 100644
 --- a/third_party/libwebrtc/api/transport/bandwidth_estimation_settings_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/bandwidth_estimation_settings_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1093,8 +1566,23 @@ index 0885f16a06553..5dd6c3a3c16e4 100644
  if CONFIG["TARGET_CPU"] == "mips32":
  
      DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/api/transport/bandwidth_usage_gn/moz.build b/third_party/libwebrtc/api/transport/bandwidth_usage_gn/moz.build
+index 0441698bcb..b86f6bb9e7 100644
+--- a/third_party/libwebrtc/api/transport/bandwidth_usage_gn/moz.build
++++ b/third_party/libwebrtc/api/transport/bandwidth_usage_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/bitrate_settings_gn/moz.build b/third_party/libwebrtc/api/transport/bitrate_settings_gn/moz.build
-index 42410686d0beb..5a3b31c1162c5 100644
+index b66b9044f1..e366191518 100644
 --- a/third_party/libwebrtc/api/transport/bitrate_settings_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/bitrate_settings_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1109,7 +1597,7 @@ index 42410686d0beb..5a3b31c1162c5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/datagram_transport_interface_gn/moz.build b/third_party/libwebrtc/api/transport/datagram_transport_interface_gn/moz.build
-index e0f8f023787b7..a4a27afce7db4 100644
+index 075109c58f..f27f5bcf72 100644
 --- a/third_party/libwebrtc/api/transport/datagram_transport_interface_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/datagram_transport_interface_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1124,7 +1612,7 @@ index e0f8f023787b7..a4a27afce7db4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/field_trial_based_config_gn/moz.build b/third_party/libwebrtc/api/transport/field_trial_based_config_gn/moz.build
-index 0b2e41f78c7bf..c89e0728c542a 100644
+index 3b970aee2e..b348065907 100644
 --- a/third_party/libwebrtc/api/transport/field_trial_based_config_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/field_trial_based_config_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1139,7 +1627,7 @@ index 0b2e41f78c7bf..c89e0728c542a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/goog_cc_gn/moz.build b/third_party/libwebrtc/api/transport/goog_cc_gn/moz.build
-index 70efa923b78f8..5d52ad1d36760 100644
+index 8255eb921f..79e78b8de8 100644
 --- a/third_party/libwebrtc/api/transport/goog_cc_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/goog_cc_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1154,7 +1642,7 @@ index 70efa923b78f8..5d52ad1d36760 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/network_control_gn/moz.build b/third_party/libwebrtc/api/transport/network_control_gn/moz.build
-index abbedfaee9af4..7dc37c636547f 100644
+index 561baff74f..6e86e24680 100644
 --- a/third_party/libwebrtc/api/transport/network_control_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/network_control_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1169,7 +1657,7 @@ index abbedfaee9af4..7dc37c636547f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/rtp/dependency_descriptor_gn/moz.build b/third_party/libwebrtc/api/transport/rtp/dependency_descriptor_gn/moz.build
-index 16ec75fa0170d..777afccd30656 100644
+index 5df8c9603a..f8f78e7f79 100644
 --- a/third_party/libwebrtc/api/transport/rtp/dependency_descriptor_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/rtp/dependency_descriptor_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1184,7 +1672,7 @@ index 16ec75fa0170d..777afccd30656 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/rtp/rtp_source_gn/moz.build b/third_party/libwebrtc/api/transport/rtp/rtp_source_gn/moz.build
-index 83c88e8037fe7..c171d5eaae727 100644
+index cd6ffae7d7..1ceeec366d 100644
 --- a/third_party/libwebrtc/api/transport/rtp/rtp_source_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/rtp/rtp_source_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1199,7 +1687,7 @@ index 83c88e8037fe7..c171d5eaae727 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport/stun_types_gn/moz.build b/third_party/libwebrtc/api/transport/stun_types_gn/moz.build
-index 51a16e295eef0..67f3481ac3f72 100644
+index 098eb72eb9..fca0939852 100644
 --- a/third_party/libwebrtc/api/transport/stun_types_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport/stun_types_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1214,7 +1702,7 @@ index 51a16e295eef0..67f3481ac3f72 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/transport_api_gn/moz.build b/third_party/libwebrtc/api/transport_api_gn/moz.build
-index a726caad2813e..1583c32e678d9 100644
+index 3f5d0852a5..efe0e7b0ee 100644
 --- a/third_party/libwebrtc/api/transport_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/transport_api_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1229,7 +1717,7 @@ index a726caad2813e..1583c32e678d9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/units/data_rate_gn/moz.build b/third_party/libwebrtc/api/units/data_rate_gn/moz.build
-index 398b03d0a231e..6e9d5a3220072 100644
+index 19e412ef71..47c62e9a70 100644
 --- a/third_party/libwebrtc/api/units/data_rate_gn/moz.build
 +++ b/third_party/libwebrtc/api/units/data_rate_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1244,7 +1732,7 @@ index 398b03d0a231e..6e9d5a3220072 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/units/data_size_gn/moz.build b/third_party/libwebrtc/api/units/data_size_gn/moz.build
-index 8f61d01314631..4be1545e6b243 100644
+index d78fda4aa5..1dd1600294 100644
 --- a/third_party/libwebrtc/api/units/data_size_gn/moz.build
 +++ b/third_party/libwebrtc/api/units/data_size_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1259,7 +1747,7 @@ index 8f61d01314631..4be1545e6b243 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/units/frequency_gn/moz.build b/third_party/libwebrtc/api/units/frequency_gn/moz.build
-index 40a6bf2617104..30b302563cdef 100644
+index ff1a8c5403..322cbb95be 100644
 --- a/third_party/libwebrtc/api/units/frequency_gn/moz.build
 +++ b/third_party/libwebrtc/api/units/frequency_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1274,7 +1762,7 @@ index 40a6bf2617104..30b302563cdef 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/units/time_delta_gn/moz.build b/third_party/libwebrtc/api/units/time_delta_gn/moz.build
-index d9ede8c812f23..fbc69252d87c0 100644
+index 43f43d80d8..5ca041b863 100644
 --- a/third_party/libwebrtc/api/units/time_delta_gn/moz.build
 +++ b/third_party/libwebrtc/api/units/time_delta_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1289,7 +1777,7 @@ index d9ede8c812f23..fbc69252d87c0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/units/timestamp_gn/moz.build b/third_party/libwebrtc/api/units/timestamp_gn/moz.build
-index 9e5ed8541e578..b1ac1b772c675 100644
+index d4a9959eae..d1580c1d19 100644
 --- a/third_party/libwebrtc/api/units/timestamp_gn/moz.build
 +++ b/third_party/libwebrtc/api/units/timestamp_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1304,7 +1792,7 @@ index 9e5ed8541e578..b1ac1b772c675 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/builtin_video_bitrate_allocator_factory_gn/moz.build b/third_party/libwebrtc/api/video/builtin_video_bitrate_allocator_factory_gn/moz.build
-index cafafadf4452d..a085a657952c8 100644
+index fb5c3b3250..d2776ddb28 100644
 --- a/third_party/libwebrtc/api/video/builtin_video_bitrate_allocator_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/builtin_video_bitrate_allocator_factory_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1319,7 +1807,7 @@ index cafafadf4452d..a085a657952c8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/encoded_frame_gn/moz.build b/third_party/libwebrtc/api/video/encoded_frame_gn/moz.build
-index d804e2fd36718..f21f8b55cf1c8 100644
+index c935e11284..5917570665 100644
 --- a/third_party/libwebrtc/api/video/encoded_frame_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/encoded_frame_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1334,7 +1822,7 @@ index d804e2fd36718..f21f8b55cf1c8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/encoded_image_gn/moz.build b/third_party/libwebrtc/api/video/encoded_image_gn/moz.build
-index a444a71189b96..a3ef10fcda796 100644
+index 4c2d4cd0cc..b8d5da1278 100644
 --- a/third_party/libwebrtc/api/video/encoded_image_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/encoded_image_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1349,7 +1837,7 @@ index a444a71189b96..a3ef10fcda796 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/frame_buffer_gn/moz.build b/third_party/libwebrtc/api/video/frame_buffer_gn/moz.build
-index 01a33c4b813fc..8a7e83234f242 100644
+index 8b0f073461..5aed8ca9b0 100644
 --- a/third_party/libwebrtc/api/video/frame_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/frame_buffer_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1364,7 +1852,7 @@ index 01a33c4b813fc..8a7e83234f242 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/recordable_encoded_frame_gn/moz.build b/third_party/libwebrtc/api/video/recordable_encoded_frame_gn/moz.build
-index 4d6199a71433e..b0203be91a91f 100644
+index e23a66634e..249341c559 100644
 --- a/third_party/libwebrtc/api/video/recordable_encoded_frame_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/recordable_encoded_frame_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1379,7 +1867,7 @@ index 4d6199a71433e..b0203be91a91f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/render_resolution_gn/moz.build b/third_party/libwebrtc/api/video/render_resolution_gn/moz.build
-index a0c4da6d58091..15ae70c2156ac 100644
+index 37131d1328..e2e2bdff11 100644
 --- a/third_party/libwebrtc/api/video/render_resolution_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/render_resolution_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1394,7 +1882,7 @@ index a0c4da6d58091..15ae70c2156ac 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/resolution_gn/moz.build b/third_party/libwebrtc/api/video/resolution_gn/moz.build
-index e55dfe7d2c222..fe470816b693e 100644
+index 2d00ea929f..6874770119 100644
 --- a/third_party/libwebrtc/api/video/resolution_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/resolution_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1409,7 +1897,7 @@ index e55dfe7d2c222..fe470816b693e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_adaptation_gn/moz.build b/third_party/libwebrtc/api/video/video_adaptation_gn/moz.build
-index c061e657ab8a0..4788ea5e553c9 100644
+index 8b89c69dc0..7723271dd7 100644
 --- a/third_party/libwebrtc/api/video/video_adaptation_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_adaptation_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1424,7 +1912,7 @@ index c061e657ab8a0..4788ea5e553c9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_bitrate_allocation_gn/moz.build b/third_party/libwebrtc/api/video/video_bitrate_allocation_gn/moz.build
-index 9581b4202af92..9c1413b14f181 100644
+index cd607967c4..8f95ec8b60 100644
 --- a/third_party/libwebrtc/api/video/video_bitrate_allocation_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_bitrate_allocation_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1439,7 +1927,7 @@ index 9581b4202af92..9c1413b14f181 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_bitrate_allocator_factory_gn/moz.build b/third_party/libwebrtc/api/video/video_bitrate_allocator_factory_gn/moz.build
-index 71a1a7f2dc3e5..fe3788112df32 100644
+index a0531d267a..eca087577e 100644
 --- a/third_party/libwebrtc/api/video/video_bitrate_allocator_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_bitrate_allocator_factory_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1454,7 +1942,7 @@ index 71a1a7f2dc3e5..fe3788112df32 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_bitrate_allocator_gn/moz.build b/third_party/libwebrtc/api/video/video_bitrate_allocator_gn/moz.build
-index aecab75d2eacd..fea9f428f2bef 100644
+index b731f61ae6..b1c3a02c5d 100644
 --- a/third_party/libwebrtc/api/video/video_bitrate_allocator_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_bitrate_allocator_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1469,7 +1957,7 @@ index aecab75d2eacd..fea9f428f2bef 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_codec_constants_gn/moz.build b/third_party/libwebrtc/api/video/video_codec_constants_gn/moz.build
-index 1ff8d8117fa60..9b78d2d8311fa 100644
+index 3ac5b9efc8..d9fcc8f447 100644
 --- a/third_party/libwebrtc/api/video/video_codec_constants_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_codec_constants_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1484,7 +1972,7 @@ index 1ff8d8117fa60..9b78d2d8311fa 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_frame_gn/moz.build b/third_party/libwebrtc/api/video/video_frame_gn/moz.build
-index 37f7adf1843d4..a44a5b3c64879 100644
+index 4704e8482b..eb84328e3c 100644
 --- a/third_party/libwebrtc/api/video/video_frame_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_frame_gn/moz.build
 @@ -161,6 +161,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1499,7 +1987,7 @@ index 37f7adf1843d4..a44a5b3c64879 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_frame_i010_gn/moz.build b/third_party/libwebrtc/api/video/video_frame_i010_gn/moz.build
-index 2b8bd493aff92..b2459fc0d73a4 100644
+index 5534a976cf..393567c949 100644
 --- a/third_party/libwebrtc/api/video/video_frame_i010_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_frame_i010_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1514,7 +2002,7 @@ index 2b8bd493aff92..b2459fc0d73a4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_frame_metadata_gn/moz.build b/third_party/libwebrtc/api/video/video_frame_metadata_gn/moz.build
-index 8b4bd96df2395..2cd46e22441c6 100644
+index e129b5b4f7..dc543a70d6 100644
 --- a/third_party/libwebrtc/api/video/video_frame_metadata_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_frame_metadata_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1529,7 +2017,7 @@ index 8b4bd96df2395..2cd46e22441c6 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_frame_type_gn/moz.build b/third_party/libwebrtc/api/video/video_frame_type_gn/moz.build
-index 3416d040b2eaa..f5951d6e30cd7 100644
+index d1402be61a..53c110f12f 100644
 --- a/third_party/libwebrtc/api/video/video_frame_type_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_frame_type_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1544,7 +2032,7 @@ index 3416d040b2eaa..f5951d6e30cd7 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_layers_allocation_gn/moz.build b/third_party/libwebrtc/api/video/video_layers_allocation_gn/moz.build
-index d9d7097f2f893..e6f9710eda5de 100644
+index d6bb07ec8c..f7be1268bf 100644
 --- a/third_party/libwebrtc/api/video/video_layers_allocation_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_layers_allocation_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1559,7 +2047,7 @@ index d9d7097f2f893..e6f9710eda5de 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_rtp_headers_gn/moz.build b/third_party/libwebrtc/api/video/video_rtp_headers_gn/moz.build
-index 7c696af228c61..609b8f3c2047b 100644
+index 3ce253a3e8..7756f9b710 100644
 --- a/third_party/libwebrtc/api/video/video_rtp_headers_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_rtp_headers_gn/moz.build
 @@ -153,6 +153,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1574,7 +2062,7 @@ index 7c696af228c61..609b8f3c2047b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video/video_stream_encoder_gn/moz.build b/third_party/libwebrtc/api/video/video_stream_encoder_gn/moz.build
-index f54c465004454..b7874ea832174 100644
+index d3ada0cf1d..3d5f054bf0 100644
 --- a/third_party/libwebrtc/api/video/video_stream_encoder_gn/moz.build
 +++ b/third_party/libwebrtc/api/video/video_stream_encoder_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1589,7 +2077,7 @@ index f54c465004454..b7874ea832174 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video_codecs/bitstream_parser_api_gn/moz.build b/third_party/libwebrtc/api/video_codecs/bitstream_parser_api_gn/moz.build
-index b1bb1e3323e8e..96630db641217 100644
+index 30278b672f..f47c3775ae 100644
 --- a/third_party/libwebrtc/api/video_codecs/bitstream_parser_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/video_codecs/bitstream_parser_api_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1604,7 +2092,7 @@ index b1bb1e3323e8e..96630db641217 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video_codecs/rtc_software_fallback_wrappers_gn/moz.build b/third_party/libwebrtc/api/video_codecs/rtc_software_fallback_wrappers_gn/moz.build
-index ca9c0f599a999..8b4f3c069f582 100644
+index 723ee880f3..0c6764c03a 100644
 --- a/third_party/libwebrtc/api/video_codecs/rtc_software_fallback_wrappers_gn/moz.build
 +++ b/third_party/libwebrtc/api/video_codecs/rtc_software_fallback_wrappers_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1619,7 +2107,7 @@ index ca9c0f599a999..8b4f3c069f582 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video_codecs/scalability_mode_gn/moz.build b/third_party/libwebrtc/api/video_codecs/scalability_mode_gn/moz.build
-index b0c90b8ad2eef..bcec657a2e8a4 100644
+index aca8affe68..a5c725642c 100644
 --- a/third_party/libwebrtc/api/video_codecs/scalability_mode_gn/moz.build
 +++ b/third_party/libwebrtc/api/video_codecs/scalability_mode_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1634,7 +2122,7 @@ index b0c90b8ad2eef..bcec657a2e8a4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video_codecs/video_codecs_api_gn/moz.build b/third_party/libwebrtc/api/video_codecs/video_codecs_api_gn/moz.build
-index f3060e020af9d..b06f0a61bb834 100644
+index df8d151dd4..4cd7c8debc 100644
 --- a/third_party/libwebrtc/api/video_codecs/video_codecs_api_gn/moz.build
 +++ b/third_party/libwebrtc/api/video_codecs/video_codecs_api_gn/moz.build
 @@ -160,6 +160,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1649,7 +2137,7 @@ index f3060e020af9d..b06f0a61bb834 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video_codecs/vp8_temporal_layers_factory_gn/moz.build b/third_party/libwebrtc/api/video_codecs/vp8_temporal_layers_factory_gn/moz.build
-index 3940914214498..f404af52ff917 100644
+index a197fc9fdc..7b87eb0347 100644
 --- a/third_party/libwebrtc/api/video_codecs/vp8_temporal_layers_factory_gn/moz.build
 +++ b/third_party/libwebrtc/api/video_codecs/vp8_temporal_layers_factory_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1664,7 +2152,7 @@ index 3940914214498..f404af52ff917 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/api/video_track_source_constraints_gn/moz.build b/third_party/libwebrtc/api/video_track_source_constraints_gn/moz.build
-index 636a3df69c9a7..6c8dc9ed7bf37 100644
+index f6456b10c9..c9afa81820 100644
 --- a/third_party/libwebrtc/api/video_track_source_constraints_gn/moz.build
 +++ b/third_party/libwebrtc/api/video_track_source_constraints_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1679,7 +2167,7 @@ index 636a3df69c9a7..6c8dc9ed7bf37 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/audio/audio_gn/moz.build b/third_party/libwebrtc/audio/audio_gn/moz.build
-index 2888ef09bd9b4..8cd43e9caa678 100644
+index 7e90715293..fd6e4c6c7c 100644
 --- a/third_party/libwebrtc/audio/audio_gn/moz.build
 +++ b/third_party/libwebrtc/audio/audio_gn/moz.build
 @@ -167,6 +167,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1694,7 +2182,7 @@ index 2888ef09bd9b4..8cd43e9caa678 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/audio/utility/audio_frame_operations_gn/moz.build b/third_party/libwebrtc/audio/utility/audio_frame_operations_gn/moz.build
-index 315f691f3e09f..46997a10da7aa 100644
+index 513ee2df29..e9155a44df 100644
 --- a/third_party/libwebrtc/audio/utility/audio_frame_operations_gn/moz.build
 +++ b/third_party/libwebrtc/audio/utility/audio_frame_operations_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1709,7 +2197,7 @@ index 315f691f3e09f..46997a10da7aa 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/adaptation/resource_adaptation_gn/moz.build b/third_party/libwebrtc/call/adaptation/resource_adaptation_gn/moz.build
-index 3dab96b5a3720..16d001bc0f420 100644
+index 9731da555b..e3d13b9a6e 100644
 --- a/third_party/libwebrtc/call/adaptation/resource_adaptation_gn/moz.build
 +++ b/third_party/libwebrtc/call/adaptation/resource_adaptation_gn/moz.build
 @@ -164,6 +164,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1724,7 +2212,7 @@ index 3dab96b5a3720..16d001bc0f420 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/audio_sender_interface_gn/moz.build b/third_party/libwebrtc/call/audio_sender_interface_gn/moz.build
-index 6ca0ee7739978..ba943f674bdf6 100644
+index af23788409..6d3568a6cc 100644
 --- a/third_party/libwebrtc/call/audio_sender_interface_gn/moz.build
 +++ b/third_party/libwebrtc/call/audio_sender_interface_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1739,7 +2227,7 @@ index 6ca0ee7739978..ba943f674bdf6 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/bitrate_allocator_gn/moz.build b/third_party/libwebrtc/call/bitrate_allocator_gn/moz.build
-index 57adb400db542..053203704dd3e 100644
+index eb39b9ced7..8795186ccb 100644
 --- a/third_party/libwebrtc/call/bitrate_allocator_gn/moz.build
 +++ b/third_party/libwebrtc/call/bitrate_allocator_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1754,7 +2242,7 @@ index 57adb400db542..053203704dd3e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/bitrate_configurator_gn/moz.build b/third_party/libwebrtc/call/bitrate_configurator_gn/moz.build
-index 59f87d2fdf4da..d3838013378c0 100644
+index e73d888976..9380581e2a 100644
 --- a/third_party/libwebrtc/call/bitrate_configurator_gn/moz.build
 +++ b/third_party/libwebrtc/call/bitrate_configurator_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1769,7 +2257,7 @@ index 59f87d2fdf4da..d3838013378c0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/call_gn/moz.build b/third_party/libwebrtc/call/call_gn/moz.build
-index da452122ce12a..db896312b03e7 100644
+index b00caf8581..eaaa870a25 100644
 --- a/third_party/libwebrtc/call/call_gn/moz.build
 +++ b/third_party/libwebrtc/call/call_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1784,7 +2272,7 @@ index da452122ce12a..db896312b03e7 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/call_interfaces_gn/moz.build b/third_party/libwebrtc/call/call_interfaces_gn/moz.build
-index 3c7b6a05d3ab3..a3f85dc6dc448 100644
+index c5d22abe42..6c077c707c 100644
 --- a/third_party/libwebrtc/call/call_interfaces_gn/moz.build
 +++ b/third_party/libwebrtc/call/call_interfaces_gn/moz.build
 @@ -161,6 +161,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1799,7 +2287,7 @@ index 3c7b6a05d3ab3..a3f85dc6dc448 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/receive_stream_interface_gn/moz.build b/third_party/libwebrtc/call/receive_stream_interface_gn/moz.build
-index 0b3511082a519..79a9228856cf8 100644
+index 15e5be29d3..0d6727403c 100644
 --- a/third_party/libwebrtc/call/receive_stream_interface_gn/moz.build
 +++ b/third_party/libwebrtc/call/receive_stream_interface_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1814,7 +2302,7 @@ index 0b3511082a519..79a9228856cf8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/rtp_interfaces_gn/moz.build b/third_party/libwebrtc/call/rtp_interfaces_gn/moz.build
-index f2fb2ab649bbc..d138865b6812e 100644
+index 29e7a8d996..e78d967af9 100644
 --- a/third_party/libwebrtc/call/rtp_interfaces_gn/moz.build
 +++ b/third_party/libwebrtc/call/rtp_interfaces_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1829,7 +2317,7 @@ index f2fb2ab649bbc..d138865b6812e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/rtp_receiver_gn/moz.build b/third_party/libwebrtc/call/rtp_receiver_gn/moz.build
-index 35c68ca3368d3..e1889430418c3 100644
+index b1a295a56a..5123b15aba 100644
 --- a/third_party/libwebrtc/call/rtp_receiver_gn/moz.build
 +++ b/third_party/libwebrtc/call/rtp_receiver_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1844,7 +2332,7 @@ index 35c68ca3368d3..e1889430418c3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/rtp_sender_gn/moz.build b/third_party/libwebrtc/call/rtp_sender_gn/moz.build
-index c99d9d8e8a667..d2ef2c26bf50d 100644
+index f488ad07c2..55a8afc7b6 100644
 --- a/third_party/libwebrtc/call/rtp_sender_gn/moz.build
 +++ b/third_party/libwebrtc/call/rtp_sender_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1859,7 +2347,7 @@ index c99d9d8e8a667..d2ef2c26bf50d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/version_gn/moz.build b/third_party/libwebrtc/call/version_gn/moz.build
-index 50ff0cff2e551..c048f48b9985a 100644
+index 485833ee2b..4a3e2689e1 100644
 --- a/third_party/libwebrtc/call/version_gn/moz.build
 +++ b/third_party/libwebrtc/call/version_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1874,7 +2362,7 @@ index 50ff0cff2e551..c048f48b9985a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/call/video_stream_api_gn/moz.build b/third_party/libwebrtc/call/video_stream_api_gn/moz.build
-index 9aa475a12fc68..2f75e5afadd55 100644
+index 3d0b6a488c..862981ef04 100644
 --- a/third_party/libwebrtc/call/video_stream_api_gn/moz.build
 +++ b/third_party/libwebrtc/call/video_stream_api_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1889,7 +2377,7 @@ index 9aa475a12fc68..2f75e5afadd55 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/common_audio_c_arm_asm_gn/moz.build b/third_party/libwebrtc/common_audio/common_audio_c_arm_asm_gn/moz.build
-index 0827bbf31a410..9c26089f8adee 100644
+index f87719576d..04ec6969a6 100644
 --- a/third_party/libwebrtc/common_audio/common_audio_c_arm_asm_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/common_audio_c_arm_asm_gn/moz.build
 @@ -136,6 +136,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1904,7 +2392,7 @@ index 0827bbf31a410..9c26089f8adee 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/common_audio_c_gn/moz.build b/third_party/libwebrtc/common_audio/common_audio_c_gn/moz.build
-index 99cceabf2989f..247ada76caf0e 100644
+index 07660c8bb5..8ab56c3f93 100644
 --- a/third_party/libwebrtc/common_audio/common_audio_c_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/common_audio_c_gn/moz.build
 @@ -213,6 +213,16 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1925,7 +2413,7 @@ index 99cceabf2989f..247ada76caf0e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/common_audio_cc_gn/moz.build b/third_party/libwebrtc/common_audio/common_audio_cc_gn/moz.build
-index 1ab56ac809181..7c54dfade59b7 100644
+index 63d72e183f..cf801998d0 100644
 --- a/third_party/libwebrtc/common_audio/common_audio_cc_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/common_audio_cc_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1940,7 +2428,7 @@ index 1ab56ac809181..7c54dfade59b7 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/common_audio_gn/moz.build b/third_party/libwebrtc/common_audio/common_audio_gn/moz.build
-index 79a78f7837942..c4e0d5b97304a 100644
+index 6ee6786018..f4ca343b13 100644
 --- a/third_party/libwebrtc/common_audio/common_audio_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/common_audio_gn/moz.build
 @@ -167,6 +167,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1955,7 +2443,7 @@ index 79a78f7837942..c4e0d5b97304a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/fir_filter_factory_gn/moz.build b/third_party/libwebrtc/common_audio/fir_filter_factory_gn/moz.build
-index 2faac2a93134b..8ce1283652b77 100644
+index 8e5b54e61d..9baa8739e8 100644
 --- a/third_party/libwebrtc/common_audio/fir_filter_factory_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/fir_filter_factory_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1970,7 +2458,7 @@ index 2faac2a93134b..8ce1283652b77 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/fir_filter_gn/moz.build b/third_party/libwebrtc/common_audio/fir_filter_gn/moz.build
-index af029033e761d..66ffa7f1c4d19 100644
+index 067128609c..cb503e5f11 100644
 --- a/third_party/libwebrtc/common_audio/fir_filter_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/fir_filter_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -1985,7 +2473,7 @@ index af029033e761d..66ffa7f1c4d19 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/sinc_resampler_gn/moz.build b/third_party/libwebrtc/common_audio/sinc_resampler_gn/moz.build
-index 962dbed44bf80..fbe78886f96fd 100644
+index 8649a26e7f..4c56c96b12 100644
 --- a/third_party/libwebrtc/common_audio/sinc_resampler_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/sinc_resampler_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2000,7 +2488,7 @@ index 962dbed44bf80..fbe78886f96fd 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_128_gn/moz.build b/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_128_gn/moz.build
-index 6245fdf7ef932..60598ae2b1089 100644
+index daeab1ffae..40968f7424 100644
 --- a/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_128_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_128_gn/moz.build
 @@ -162,6 +162,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2015,7 +2503,7 @@ index 6245fdf7ef932..60598ae2b1089 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_256_gn/moz.build b/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_256_gn/moz.build
-index 7c2503bc9ccd5..964be76261da5 100644
+index 157b77da74..30874d7c60 100644
 --- a/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_256_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/third_party/ooura/fft_size_256_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2030,7 +2518,7 @@ index 7c2503bc9ccd5..964be76261da5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_audio/third_party/spl_sqrt_floor/spl_sqrt_floor_gn/moz.build b/third_party/libwebrtc/common_audio/third_party/spl_sqrt_floor/spl_sqrt_floor_gn/moz.build
-index ec09e725fff76..424d4cd5b263f 100644
+index 3acc048e7b..66cbc4b934 100644
 --- a/third_party/libwebrtc/common_audio/third_party/spl_sqrt_floor/spl_sqrt_floor_gn/moz.build
 +++ b/third_party/libwebrtc/common_audio/third_party/spl_sqrt_floor/spl_sqrt_floor_gn/moz.build
 @@ -147,6 +147,14 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2049,7 +2537,7 @@ index ec09e725fff76..424d4cd5b263f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_video/common_video_gn/moz.build b/third_party/libwebrtc/common_video/common_video_gn/moz.build
-index fb64d190c30d1..02b32a6d4daaa 100644
+index e1d4464ae3..945cb852af 100644
 --- a/third_party/libwebrtc/common_video/common_video_gn/moz.build
 +++ b/third_party/libwebrtc/common_video/common_video_gn/moz.build
 @@ -162,6 +162,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2064,7 +2552,7 @@ index fb64d190c30d1..02b32a6d4daaa 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_video/frame_counts_gn/moz.build b/third_party/libwebrtc/common_video/frame_counts_gn/moz.build
-index 08c88c4702cf3..b23c38bd683c0 100644
+index f840eae902..42c2d2c5d4 100644
 --- a/third_party/libwebrtc/common_video/frame_counts_gn/moz.build
 +++ b/third_party/libwebrtc/common_video/frame_counts_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2079,7 +2567,7 @@ index 08c88c4702cf3..b23c38bd683c0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/common_video/generic_frame_descriptor/generic_frame_descriptor_gn/moz.build b/third_party/libwebrtc/common_video/generic_frame_descriptor/generic_frame_descriptor_gn/moz.build
-index b16531fbf8e27..4c983cdd33754 100644
+index a5877debe7..8a3bd5aecc 100644
 --- a/third_party/libwebrtc/common_video/generic_frame_descriptor/generic_frame_descriptor_gn/moz.build
 +++ b/third_party/libwebrtc/common_video/generic_frame_descriptor/generic_frame_descriptor_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2094,7 +2582,7 @@ index b16531fbf8e27..4c983cdd33754 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/experiments/registered_field_trials_gn/moz.build b/third_party/libwebrtc/experiments/registered_field_trials_gn/moz.build
-index 5e1ddc355d5b3..f54ba694b9795 100644
+index 9392f8ab7c..b87e5674d3 100644
 --- a/third_party/libwebrtc/experiments/registered_field_trials_gn/moz.build
 +++ b/third_party/libwebrtc/experiments/registered_field_trials_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2109,7 +2597,7 @@ index 5e1ddc355d5b3..f54ba694b9795 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_event_audio_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_audio_gn/moz.build
-index bf124013de2a6..5ccc734ffb632 100644
+index 10e20ecba0..cd337bdfa9 100644
 --- a/third_party/libwebrtc/logging/rtc_event_audio_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_event_audio_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2124,7 +2612,7 @@ index bf124013de2a6..5ccc734ffb632 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_event_bwe_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_bwe_gn/moz.build
-index c7c2a5f880332..2b655652cf267 100644
+index 8f8c1c86a1..1f99e652b2 100644
 --- a/third_party/libwebrtc/logging/rtc_event_bwe_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_event_bwe_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2139,7 +2627,7 @@ index c7c2a5f880332..2b655652cf267 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_event_field_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_field_gn/moz.build
-index 630358f349426..505d38c743e66 100644
+index db8a0c7723..0795e18b26 100644
 --- a/third_party/libwebrtc/logging/rtc_event_field_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_event_field_gn/moz.build
 @@ -153,6 +153,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2154,7 +2642,7 @@ index 630358f349426..505d38c743e66 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_event_log_parse_status_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_log_parse_status_gn/moz.build
-index 46e013a0d4d4c..67413d361af9b 100644
+index c5f090ad66..cfc2fd2c5f 100644
 --- a/third_party/libwebrtc/logging/rtc_event_log_parse_status_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_event_log_parse_status_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2169,7 +2657,7 @@ index 46e013a0d4d4c..67413d361af9b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_event_number_encodings_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_number_encodings_gn/moz.build
-index 4c491af3963ce..22760a576252e 100644
+index ae770cf7c7..0409fa399a 100644
 --- a/third_party/libwebrtc/logging/rtc_event_number_encodings_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_event_number_encodings_gn/moz.build
 @@ -145,6 +145,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2184,7 +2672,7 @@ index 4c491af3963ce..22760a576252e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_event_pacing_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_pacing_gn/moz.build
-index aec4465f8ac37..4c8b44223ce63 100644
+index 080549171c..f9d4e515ce 100644
 --- a/third_party/libwebrtc/logging/rtc_event_pacing_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_event_pacing_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2199,7 +2687,7 @@ index aec4465f8ac37..4c8b44223ce63 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_event_rtp_rtcp_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_rtp_rtcp_gn/moz.build
-index 3edc922b8f08f..bda2020ffebbb 100644
+index 953ae5151c..0eee91389f 100644
 --- a/third_party/libwebrtc/logging/rtc_event_rtp_rtcp_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_event_rtp_rtcp_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2214,7 +2702,7 @@ index 3edc922b8f08f..bda2020ffebbb 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_event_video_gn/moz.build b/third_party/libwebrtc/logging/rtc_event_video_gn/moz.build
-index 616e73dcf5ec0..bcbf391a109f4 100644
+index 0c31614317..9c6369a274 100644
 --- a/third_party/libwebrtc/logging/rtc_event_video_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_event_video_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2229,7 +2717,7 @@ index 616e73dcf5ec0..bcbf391a109f4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/logging/rtc_stream_config_gn/moz.build b/third_party/libwebrtc/logging/rtc_stream_config_gn/moz.build
-index 6fd95dde97d0e..fa2bb3837f814 100644
+index dbe85beeb1..2463070631 100644
 --- a/third_party/libwebrtc/logging/rtc_stream_config_gn/moz.build
 +++ b/third_party/libwebrtc/logging/rtc_stream_config_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2244,7 +2732,7 @@ index 6fd95dde97d0e..fa2bb3837f814 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/adapted_video_track_source_gn/moz.build b/third_party/libwebrtc/media/adapted_video_track_source_gn/moz.build
-index 1cb4f853abba1..bd46fcffc0b43 100644
+index 84ff989167..3bb517efb3 100644
 --- a/third_party/libwebrtc/media/adapted_video_track_source_gn/moz.build
 +++ b/third_party/libwebrtc/media/adapted_video_track_source_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2259,7 +2747,7 @@ index 1cb4f853abba1..bd46fcffc0b43 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/codec_gn/moz.build b/third_party/libwebrtc/media/codec_gn/moz.build
-index cf10ada0cf66b..b749cab4375c4 100644
+index 5e1a17cce7..267ab32141 100644
 --- a/third_party/libwebrtc/media/codec_gn/moz.build
 +++ b/third_party/libwebrtc/media/codec_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2274,7 +2762,7 @@ index cf10ada0cf66b..b749cab4375c4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/media_channel_gn/moz.build b/third_party/libwebrtc/media/media_channel_gn/moz.build
-index fc0c50aa726b4..9449c00102e37 100644
+index 9a8b4ded79..9bf393661b 100644
 --- a/third_party/libwebrtc/media/media_channel_gn/moz.build
 +++ b/third_party/libwebrtc/media/media_channel_gn/moz.build
 @@ -147,6 +147,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2289,7 +2777,7 @@ index fc0c50aa726b4..9449c00102e37 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/media_channel_impl_gn/moz.build b/third_party/libwebrtc/media/media_channel_impl_gn/moz.build
-index b7db93813a60b..5f0b214ebcd7a 100644
+index c42d7c6549..960a206c3e 100644
 --- a/third_party/libwebrtc/media/media_channel_impl_gn/moz.build
 +++ b/third_party/libwebrtc/media/media_channel_impl_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2304,7 +2792,7 @@ index b7db93813a60b..5f0b214ebcd7a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/media_constants_gn/moz.build b/third_party/libwebrtc/media/media_constants_gn/moz.build
-index fb7440ec4a070..08c077d93411f 100644
+index 9338f3c0f5..46fe45cd6e 100644
 --- a/third_party/libwebrtc/media/media_constants_gn/moz.build
 +++ b/third_party/libwebrtc/media/media_constants_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2319,7 +2807,7 @@ index fb7440ec4a070..08c077d93411f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/rid_description_gn/moz.build b/third_party/libwebrtc/media/rid_description_gn/moz.build
-index 22f56f08a780b..c604820208e3e 100644
+index c839981e68..c1db7f13b8 100644
 --- a/third_party/libwebrtc/media/rid_description_gn/moz.build
 +++ b/third_party/libwebrtc/media/rid_description_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2334,7 +2822,7 @@ index 22f56f08a780b..c604820208e3e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/rtc_media_base_gn/moz.build b/third_party/libwebrtc/media/rtc_media_base_gn/moz.build
-index eb9cb4e29d040..4f7284c512d5b 100644
+index 58997370b8..6410616606 100644
 --- a/third_party/libwebrtc/media/rtc_media_base_gn/moz.build
 +++ b/third_party/libwebrtc/media/rtc_media_base_gn/moz.build
 @@ -147,6 +147,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2349,7 +2837,7 @@ index eb9cb4e29d040..4f7284c512d5b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/rtc_media_config_gn/moz.build b/third_party/libwebrtc/media/rtc_media_config_gn/moz.build
-index 4b6ba11d76811..2c88fd713531c 100644
+index 2cfb8f9336..4fc6fb4895 100644
 --- a/third_party/libwebrtc/media/rtc_media_config_gn/moz.build
 +++ b/third_party/libwebrtc/media/rtc_media_config_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2364,7 +2852,7 @@ index 4b6ba11d76811..2c88fd713531c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/rtc_sdp_video_format_utils_gn/moz.build b/third_party/libwebrtc/media/rtc_sdp_video_format_utils_gn/moz.build
-index 10b08d64fbe20..e9691926eb785 100644
+index db2cc89a04..42df2d820c 100644
 --- a/third_party/libwebrtc/media/rtc_sdp_video_format_utils_gn/moz.build
 +++ b/third_party/libwebrtc/media/rtc_sdp_video_format_utils_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2379,7 +2867,7 @@ index 10b08d64fbe20..e9691926eb785 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/rtc_simulcast_encoder_adapter_gn/moz.build b/third_party/libwebrtc/media/rtc_simulcast_encoder_adapter_gn/moz.build
-index 1929dd6e9399b..21c90c720512f 100644
+index 4fe267a97b..b7d82e789e 100644
 --- a/third_party/libwebrtc/media/rtc_simulcast_encoder_adapter_gn/moz.build
 +++ b/third_party/libwebrtc/media/rtc_simulcast_encoder_adapter_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2394,7 +2882,7 @@ index 1929dd6e9399b..21c90c720512f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/rtp_utils_gn/moz.build b/third_party/libwebrtc/media/rtp_utils_gn/moz.build
-index 22b3cc9d64615..8bbe127ddbb5a 100644
+index 852af58608..931193ec46 100644
 --- a/third_party/libwebrtc/media/rtp_utils_gn/moz.build
 +++ b/third_party/libwebrtc/media/rtp_utils_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2409,7 +2897,7 @@ index 22b3cc9d64615..8bbe127ddbb5a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/stream_params_gn/moz.build b/third_party/libwebrtc/media/stream_params_gn/moz.build
-index 67ed8e9a461d0..389484ae5a68b 100644
+index 19a47f719a..e4f9ef46ed 100644
 --- a/third_party/libwebrtc/media/stream_params_gn/moz.build
 +++ b/third_party/libwebrtc/media/stream_params_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2424,7 +2912,7 @@ index 67ed8e9a461d0..389484ae5a68b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/video_adapter_gn/moz.build b/third_party/libwebrtc/media/video_adapter_gn/moz.build
-index 1ce6badaf84c0..8fbf5bde01ee7 100644
+index c64baa9d03..6a893dec65 100644
 --- a/third_party/libwebrtc/media/video_adapter_gn/moz.build
 +++ b/third_party/libwebrtc/media/video_adapter_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2439,7 +2927,7 @@ index 1ce6badaf84c0..8fbf5bde01ee7 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/video_broadcaster_gn/moz.build b/third_party/libwebrtc/media/video_broadcaster_gn/moz.build
-index c1ebd4508d5a5..0efea5fbdb49a 100644
+index 680eace514..2ff0461b9f 100644
 --- a/third_party/libwebrtc/media/video_broadcaster_gn/moz.build
 +++ b/third_party/libwebrtc/media/video_broadcaster_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2454,7 +2942,7 @@ index c1ebd4508d5a5..0efea5fbdb49a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/video_common_gn/moz.build b/third_party/libwebrtc/media/video_common_gn/moz.build
-index b99fdbd294469..f8eb593f9d784 100644
+index c25c1a0db3..7801a01ad3 100644
 --- a/third_party/libwebrtc/media/video_common_gn/moz.build
 +++ b/third_party/libwebrtc/media/video_common_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2469,7 +2957,7 @@ index b99fdbd294469..f8eb593f9d784 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/media/video_source_base_gn/moz.build b/third_party/libwebrtc/media/video_source_base_gn/moz.build
-index b74ce609e95fd..b5d0dba31c190 100644
+index cd9c32d0b0..3cddc2f507 100644
 --- a/third_party/libwebrtc/media/video_source_base_gn/moz.build
 +++ b/third_party/libwebrtc/media/video_source_base_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2484,7 +2972,7 @@ index b74ce609e95fd..b5d0dba31c190 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/async_audio_processing/async_audio_processing_gn/moz.build b/third_party/libwebrtc/modules/async_audio_processing/async_audio_processing_gn/moz.build
-index 495a5d8cac13f..fbaede458a8fc 100644
+index fb495956fb..5133c9ce45 100644
 --- a/third_party/libwebrtc/modules/async_audio_processing/async_audio_processing_gn/moz.build
 +++ b/third_party/libwebrtc/modules/async_audio_processing/async_audio_processing_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2499,7 +2987,7 @@ index 495a5d8cac13f..fbaede458a8fc 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/audio_coding_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/audio_coding_gn/moz.build
-index 995b2a2a3b312..6e189825b8932 100644
+index ae900ef8f8..d0609724c9 100644
 --- a/third_party/libwebrtc/modules/audio_coding/audio_coding_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/audio_coding_gn/moz.build
 @@ -158,6 +158,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2514,7 +3002,7 @@ index 995b2a2a3b312..6e189825b8932 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/audio_coding_module_typedefs_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/audio_coding_module_typedefs_gn/moz.build
-index 470578709e2fb..182b02b3ac5bf 100644
+index f907a73217..23468f4b7a 100644
 --- a/third_party/libwebrtc/modules/audio_coding/audio_coding_module_typedefs_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/audio_coding_module_typedefs_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2529,7 +3017,7 @@ index 470578709e2fb..182b02b3ac5bf 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/audio_coding_opus_common_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/audio_coding_opus_common_gn/moz.build
-index e484426fd2ab9..b6195f87e0fd3 100644
+index 0fba540a06..157cbb1588 100644
 --- a/third_party/libwebrtc/modules/audio_coding/audio_coding_opus_common_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/audio_coding_opus_common_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2544,7 +3032,7 @@ index e484426fd2ab9..b6195f87e0fd3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/audio_encoder_cng_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/audio_encoder_cng_gn/moz.build
-index 1e7e932b55da3..87d4e2c3a375e 100644
+index 1626d8cd6f..8ea5aa27be 100644
 --- a/third_party/libwebrtc/modules/audio_coding/audio_encoder_cng_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/audio_encoder_cng_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2559,7 +3047,7 @@ index 1e7e932b55da3..87d4e2c3a375e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_config_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_config_gn/moz.build
-index 92221fcca1a0c..5a2f9abe5853c 100644
+index cd665a5454..ff66a80909 100644
 --- a/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_config_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_config_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2574,7 +3062,7 @@ index 92221fcca1a0c..5a2f9abe5853c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_gn/moz.build
-index cb6c943d7c377..842e71ab1e052 100644
+index 735a5e0b91..4c77db9977 100644
 --- a/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/audio_network_adaptor_gn/moz.build
 @@ -164,6 +164,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2589,7 +3077,7 @@ index cb6c943d7c377..842e71ab1e052 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/default_neteq_factory_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/default_neteq_factory_gn/moz.build
-index a0d24b9a5d28d..5254b2ec5016e 100644
+index 9169caa940..ec12441036 100644
 --- a/third_party/libwebrtc/modules/audio_coding/default_neteq_factory_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/default_neteq_factory_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2604,7 +3092,7 @@ index a0d24b9a5d28d..5254b2ec5016e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/g711_c_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/g711_c_gn/moz.build
-index dcf3567d5c55e..81256b0baa340 100644
+index a207fdcb94..f90762825e 100644
 --- a/third_party/libwebrtc/modules/audio_coding/g711_c_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/g711_c_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2619,7 +3107,7 @@ index dcf3567d5c55e..81256b0baa340 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/g711_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/g711_gn/moz.build
-index b6962f1786abe..67ffd22812d3b 100644
+index f58ae04841..e042a788f9 100644
 --- a/third_party/libwebrtc/modules/audio_coding/g711_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/g711_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2634,7 +3122,7 @@ index b6962f1786abe..67ffd22812d3b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/g722_c_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/g722_c_gn/moz.build
-index 99188c0a58336..99f4403cfc64a 100644
+index aec0fb9b5e..928c466a23 100644
 --- a/third_party/libwebrtc/modules/audio_coding/g722_c_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/g722_c_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2649,7 +3137,7 @@ index 99188c0a58336..99f4403cfc64a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/g722_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/g722_gn/moz.build
-index 56ac627776c96..7c1e7e68d34c0 100644
+index 7e6c4fa154..dbdf83e603 100644
 --- a/third_party/libwebrtc/modules/audio_coding/g722_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/g722_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2664,7 +3152,7 @@ index 56ac627776c96..7c1e7e68d34c0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/ilbc_c_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/ilbc_c_gn/moz.build
-index 9c374405df33c..f4cd791e9f317 100644
+index f49ac18199..aa1ee79105 100644
 --- a/third_party/libwebrtc/modules/audio_coding/ilbc_c_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/ilbc_c_gn/moz.build
 @@ -222,6 +222,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2679,7 +3167,7 @@ index 9c374405df33c..f4cd791e9f317 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/ilbc_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/ilbc_gn/moz.build
-index f3546882a1a3a..93cd8f1d5ce9c 100644
+index 269e698268..1abc2cd087 100644
 --- a/third_party/libwebrtc/modules/audio_coding/ilbc_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/ilbc_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2694,7 +3182,7 @@ index f3546882a1a3a..93cd8f1d5ce9c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/isac_bwinfo_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/isac_bwinfo_gn/moz.build
-index c0b5ae4a7a4c4..8753166af0278 100644
+index de83c14d7e..6d475ff3f1 100644
 --- a/third_party/libwebrtc/modules/audio_coding/isac_bwinfo_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/isac_bwinfo_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2709,7 +3197,7 @@ index c0b5ae4a7a4c4..8753166af0278 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/isac_vad_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/isac_vad_gn/moz.build
-index 15040244a1180..fe5c0c394ec86 100644
+index 5fbc721158..b4efb1a545 100644
 --- a/third_party/libwebrtc/modules/audio_coding/isac_vad_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/isac_vad_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2724,7 +3212,7 @@ index 15040244a1180..fe5c0c394ec86 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/legacy_encoded_audio_frame_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/legacy_encoded_audio_frame_gn/moz.build
-index c03333a31981d..beadda7e8a919 100644
+index e4f0ed753e..1fdfb50fb0 100644
 --- a/third_party/libwebrtc/modules/audio_coding/legacy_encoded_audio_frame_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/legacy_encoded_audio_frame_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2739,7 +3227,7 @@ index c03333a31981d..beadda7e8a919 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/neteq_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/neteq_gn/moz.build
-index a017d70518e73..0f2809ec51ba9 100644
+index f656ea7d2d..8d85999f04 100644
 --- a/third_party/libwebrtc/modules/audio_coding/neteq_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/neteq_gn/moz.build
 @@ -188,6 +188,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2754,7 +3242,7 @@ index a017d70518e73..0f2809ec51ba9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/pcm16b_c_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/pcm16b_c_gn/moz.build
-index 1e7a8e8f65600..d9941475969b5 100644
+index 790032c65a..13a5239fee 100644
 --- a/third_party/libwebrtc/modules/audio_coding/pcm16b_c_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/pcm16b_c_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2769,7 +3257,7 @@ index 1e7a8e8f65600..d9941475969b5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/pcm16b_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/pcm16b_gn/moz.build
-index 2a2a2542335ba..2a25d447216c2 100644
+index 0bdd6ed6ba..e5e3555fd2 100644
 --- a/third_party/libwebrtc/modules/audio_coding/pcm16b_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/pcm16b_gn/moz.build
 @@ -152,6 +152,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2784,7 +3272,7 @@ index 2a2a2542335ba..2a25d447216c2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/red_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/red_gn/moz.build
-index 02ef2ce08e9c7..01928268a17a1 100644
+index d20eee8365..c9e35f8152 100644
 --- a/third_party/libwebrtc/modules/audio_coding/red_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/red_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2799,7 +3287,7 @@ index 02ef2ce08e9c7..01928268a17a1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/webrtc_cng_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/webrtc_cng_gn/moz.build
-index 02f3bf49e1c10..edb2870971b35 100644
+index 0e2616b2a0..886c185d10 100644
 --- a/third_party/libwebrtc/modules/audio_coding/webrtc_cng_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/webrtc_cng_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2814,7 +3302,7 @@ index 02f3bf49e1c10..edb2870971b35 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/webrtc_multiopus_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/webrtc_multiopus_gn/moz.build
-index 9665cd22c68e0..7e110948ffd57 100644
+index 34a982b762..23f6d5ab6b 100644
 --- a/third_party/libwebrtc/modules/audio_coding/webrtc_multiopus_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/webrtc_multiopus_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2829,7 +3317,7 @@ index 9665cd22c68e0..7e110948ffd57 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/webrtc_opus_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/webrtc_opus_gn/moz.build
-index 2d219b5cc091b..b432e58ff912a 100644
+index 33f8d93af1..31ae2e99a8 100644
 --- a/third_party/libwebrtc/modules/audio_coding/webrtc_opus_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/webrtc_opus_gn/moz.build
 @@ -159,6 +159,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2844,10 +3332,10 @@ index 2d219b5cc091b..b432e58ff912a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_coding/webrtc_opus_wrapper_gn/moz.build b/third_party/libwebrtc/modules/audio_coding/webrtc_opus_wrapper_gn/moz.build
-index 4c1faef881989..2dace42c235e3 100644
+index 45ce2083a1..241aead31d 100644
 --- a/third_party/libwebrtc/modules/audio_coding/webrtc_opus_wrapper_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_coding/webrtc_opus_wrapper_gn/moz.build
-@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+@@ -147,6 +147,10 @@ if CONFIG["TARGET_CPU"] == "arm":
      DEFINES["WEBRTC_ARCH_ARM_V7"] = True
      DEFINES["WEBRTC_HAS_NEON"] = True
  
@@ -2859,7 +3347,7 @@ index 4c1faef881989..2dace42c235e3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_device/audio_device_gn/moz.build b/third_party/libwebrtc/modules/audio_device/audio_device_gn/moz.build
-index acd3896de1055..c093add857353 100644
+index 6c2c91b004..5c71bac9a6 100644
 --- a/third_party/libwebrtc/modules/audio_device/audio_device_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_device/audio_device_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2874,7 +3362,7 @@ index acd3896de1055..c093add857353 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_mixer/audio_frame_manipulator_gn/moz.build b/third_party/libwebrtc/modules/audio_mixer/audio_frame_manipulator_gn/moz.build
-index 24bd59bd53567..eac3cf70bf93e 100644
+index f26b5858d6..e76879885d 100644
 --- a/third_party/libwebrtc/modules/audio_mixer/audio_frame_manipulator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_mixer/audio_frame_manipulator_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2889,7 +3377,7 @@ index 24bd59bd53567..eac3cf70bf93e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_mixer/audio_mixer_impl_gn/moz.build b/third_party/libwebrtc/modules/audio_mixer/audio_mixer_impl_gn/moz.build
-index c32088c064a8d..9dc3a5f0b7d83 100644
+index b998e5cf3e..cb38cdb20a 100644
 --- a/third_party/libwebrtc/modules/audio_mixer/audio_mixer_impl_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_mixer/audio_mixer_impl_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2904,7 +3392,7 @@ index c32088c064a8d..9dc3a5f0b7d83 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_erl_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_erl_gn/moz.build
-index f994d264fc0d0..b8abfc845a070 100644
+index 3643adf3d9..5d17a104ef 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_erl_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_erl_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2919,7 +3407,7 @@ index f994d264fc0d0..b8abfc845a070 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_gn/moz.build
-index bfab3391fd95a..5199751374e73 100644
+index cac619740b..052ea6e76d 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/adaptive_fir_filter_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2934,7 +3422,7 @@ index bfab3391fd95a..5199751374e73 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/aec3_common_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/aec3_common_gn/moz.build
-index 8c8af7ad0246e..44a5bc121e81f 100644
+index c5ec3c1cd9..3113f22bc4 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/aec3_common_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/aec3_common_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2949,7 +3437,7 @@ index 8c8af7ad0246e..44a5bc121e81f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/aec3_fft_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/aec3_fft_gn/moz.build
-index f29e375961679..af371904ec807 100644
+index a92b789398..3b67b401fe 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/aec3_fft_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/aec3_fft_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2964,7 +3452,7 @@ index f29e375961679..af371904ec807 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/aec3_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/aec3_gn/moz.build
-index b984c66872a14..1560ad3e8cf3c 100644
+index 76eb9b374a..312d3d8946 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/aec3_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/aec3_gn/moz.build
 @@ -211,6 +211,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2979,7 +3467,7 @@ index b984c66872a14..1560ad3e8cf3c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/fft_data_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/fft_data_gn/moz.build
-index 636d54205ecc3..e87539fa35259 100644
+index bf6f884d46..2be9f19d10 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/fft_data_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/fft_data_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -2994,7 +3482,7 @@ index 636d54205ecc3..e87539fa35259 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/matched_filter_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/matched_filter_gn/moz.build
-index 0399096915b44..4957767a97d1c 100644
+index 3e0c262d89..ab39555296 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/matched_filter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/matched_filter_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3009,7 +3497,7 @@ index 0399096915b44..4957767a97d1c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/render_buffer_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/render_buffer_gn/moz.build
-index 52ec8e5f7dfcc..59db026889b35 100644
+index 5cbc1135eb..f4f11f2778 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/render_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/render_buffer_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3024,7 +3512,7 @@ index 52ec8e5f7dfcc..59db026889b35 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec3/vector_math_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec3/vector_math_gn/moz.build
-index 712a4c3571722..84ab4122315b4 100644
+index c12496c562..7d6eb85525 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec3/vector_math_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec3/vector_math_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3039,10 +3527,10 @@ index 712a4c3571722..84ab4122315b4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec_dump/aec_dump_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec_dump/aec_dump_gn/moz.build
-index 9f186fec9c4bb..59469c1625caf 100644
+index 454823f408..4fb0e35a67 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec_dump/aec_dump_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec_dump/aec_dump_gn/moz.build
-@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+@@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
      DEFINES["WEBRTC_ARCH_ARM_V7"] = True
      DEFINES["WEBRTC_HAS_NEON"] = True
  
@@ -3054,10 +3542,10 @@ index 9f186fec9c4bb..59469c1625caf 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec_dump/null_aec_dump_factory_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec_dump/null_aec_dump_factory_gn/moz.build
-index f02e31ce448d3..7a8ef95b8b564 100644
+index 79c47a87bc..96f7ee36a0 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec_dump/null_aec_dump_factory_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec_dump/null_aec_dump_factory_gn/moz.build
-@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
      DEFINES["WEBRTC_ARCH_ARM_V7"] = True
      DEFINES["WEBRTC_HAS_NEON"] = True
  
@@ -3069,10 +3557,10 @@ index f02e31ce448d3..7a8ef95b8b564 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aec_dump_interface_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aec_dump_interface_gn/moz.build
-index db7c251ecd563..0c3d72a7dd5d0 100644
+index ba900c1f01..75e04f7478 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aec_dump_interface_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aec_dump_interface_gn/moz.build
-@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
      DEFINES["WEBRTC_ARCH_ARM_V7"] = True
      DEFINES["WEBRTC_HAS_NEON"] = True
  
@@ -3084,7 +3572,7 @@ index db7c251ecd563..0c3d72a7dd5d0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/aecm/aecm_core_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/aecm/aecm_core_gn/moz.build
-index fc1a743ada419..83fc157f7decd 100644
+index 576db07795..03c23f2594 100644
 --- a/third_party/libwebrtc/modules/audio_processing/aecm/aecm_core_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/aecm/aecm_core_gn/moz.build
 @@ -179,6 +179,14 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3103,7 +3591,7 @@ index fc1a743ada419..83fc157f7decd 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc/agc_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc/agc_gn/moz.build
-index c365d82510912..070881ded96b2 100644
+index e7becea289..6c81ae56ff 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc/agc_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc/agc_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3118,7 +3606,7 @@ index c365d82510912..070881ded96b2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc/gain_control_interface_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc/gain_control_interface_gn/moz.build
-index 7f018adae5f03..8506cfbd594b8 100644
+index 53e1886cef..e5c533f67e 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc/gain_control_interface_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc/gain_control_interface_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3133,7 +3621,7 @@ index 7f018adae5f03..8506cfbd594b8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc/legacy_agc_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc/legacy_agc_gn/moz.build
-index d129ca31f30f7..47ce5fd532fdc 100644
+index 887cc343cc..8cd05d6710 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc/legacy_agc_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc/legacy_agc_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3148,7 +3636,7 @@ index d129ca31f30f7..47ce5fd532fdc 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc/level_estimation_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc/level_estimation_gn/moz.build
-index 1b5ce0bb90583..c43e8fceb193b 100644
+index 068bd7f772..3943c01c83 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc/level_estimation_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc/level_estimation_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3163,7 +3651,7 @@ index 1b5ce0bb90583..c43e8fceb193b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/adaptive_digital_gain_controller_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/adaptive_digital_gain_controller_gn/moz.build
-index 3015020227107..aa570bdf4b9b6 100644
+index a9128bc171..a8ff8f1668 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/adaptive_digital_gain_controller_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/adaptive_digital_gain_controller_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3178,7 +3666,7 @@ index 3015020227107..aa570bdf4b9b6 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/biquad_filter_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/biquad_filter_gn/moz.build
-index fe132f5f694cd..da0e8c7f46395 100644
+index b414bac082..d21c4199a2 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/biquad_filter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/biquad_filter_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3193,7 +3681,7 @@ index fe132f5f694cd..da0e8c7f46395 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/clipping_predictor_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/clipping_predictor_gn/moz.build
-index ae1541ded6d8f..b3a96fea24c2a 100644
+index 14b87b5cac..cee655176d 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/clipping_predictor_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/clipping_predictor_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3208,7 +3696,7 @@ index ae1541ded6d8f..b3a96fea24c2a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/common_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/common_gn/moz.build
-index 64f1d62c2def1..9b5bddda30f94 100644
+index 79ab80ab68..ec0a458c3a 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/common_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/common_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3223,7 +3711,7 @@ index 64f1d62c2def1..9b5bddda30f94 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/cpu_features_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/cpu_features_gn/moz.build
-index bc5907abea356..ee5749e503637 100644
+index 15a4901cc9..d8cfb6c244 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/cpu_features_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/cpu_features_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3238,7 +3726,7 @@ index bc5907abea356..ee5749e503637 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/fixed_digital_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/fixed_digital_gn/moz.build
-index ed716566a46d6..03ed3a3a293b0 100644
+index dd306f3bb5..759c4158ac 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/fixed_digital_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/fixed_digital_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3253,10 +3741,10 @@ index ed716566a46d6..03ed3a3a293b0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/gain_applier_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/gain_applier_gn/moz.build
-index 3f2132cc91d8e..d589d866204ef 100644
+index 9f49e828dd..a6aa98540a 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/gain_applier_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/gain_applier_gn/moz.build
-@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
      DEFINES["WEBRTC_ARCH_ARM_V7"] = True
      DEFINES["WEBRTC_HAS_NEON"] = True
  
@@ -3268,7 +3756,7 @@ index 3f2132cc91d8e..d589d866204ef 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/gain_map_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/gain_map_gn/moz.build
-index 9736df45221e8..a7fb934a3473e 100644
+index fb4b57fed2..ee9c3b8c92 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/gain_map_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/gain_map_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3283,7 +3771,7 @@ index 9736df45221e8..a7fb934a3473e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_controller_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_controller_gn/moz.build
-index cd4bf219463d7..1d382745e827f 100644
+index 1d885a88ee..58f31d0989 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_controller_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_controller_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3298,7 +3786,7 @@ index cd4bf219463d7..1d382745e827f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_stats_reporter_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_stats_reporter_gn/moz.build
-index 59a2714924902..355c5856949ec 100644
+index 5825d2c670..d512de2491 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_stats_reporter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/input_volume_stats_reporter_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3313,7 +3801,7 @@ index 59a2714924902..355c5856949ec 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/noise_level_estimator_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/noise_level_estimator_gn/moz.build
-index bce906f682e90..93406719a2d0c 100644
+index c18a6769d7..f820a1cd12 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/noise_level_estimator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/noise_level_estimator_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3328,7 +3816,7 @@ index bce906f682e90..93406719a2d0c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_auto_correlation_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_auto_correlation_gn/moz.build
-index 06d77c98fdb89..07f0840a6fc57 100644
+index 81389ceafa..657c4a0f52 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_auto_correlation_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_auto_correlation_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3343,7 +3831,7 @@ index 06d77c98fdb89..07f0840a6fc57 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_common_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_common_gn/moz.build
-index 9c27c5284f733..89078be5920c8 100644
+index 97a069e402..ec4b5e15e1 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_common_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_common_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3358,7 +3846,7 @@ index 9c27c5284f733..89078be5920c8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_gn/moz.build
-index c06de8a64d6b8..5606c2a7f4e29 100644
+index 671e7abff2..2c3364ed9c 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3373,7 +3861,7 @@ index c06de8a64d6b8..5606c2a7f4e29 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_layers_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_layers_gn/moz.build
-index 68a10c5f8ca57..f982772114898 100644
+index 271469362f..1009d00b3a 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_layers_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_layers_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3388,7 +3876,7 @@ index 68a10c5f8ca57..f982772114898 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_lp_residual_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_lp_residual_gn/moz.build
-index 8d629f368af1d..5f78b7c60b0f2 100644
+index ca0bed615c..26796e36f7 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_lp_residual_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_lp_residual_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3403,7 +3891,7 @@ index 8d629f368af1d..5f78b7c60b0f2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_pitch_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_pitch_gn/moz.build
-index 89a8148e73b27..f255d2c3348c5 100644
+index 5820353de9..05df3aca36 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_pitch_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_pitch_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3418,7 +3906,7 @@ index 89a8148e73b27..f255d2c3348c5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_ring_buffer_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_ring_buffer_gn/moz.build
-index a650860e3ed12..34cb04366a07c 100644
+index 27fdd04949..786822725f 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_ring_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_ring_buffer_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3433,7 +3921,7 @@ index a650860e3ed12..34cb04366a07c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_sequence_buffer_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_sequence_buffer_gn/moz.build
-index 33988b17e143a..83d745b203600 100644
+index e42a389e6a..3bfa84c70c 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_sequence_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_sequence_buffer_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3448,7 +3936,7 @@ index 33988b17e143a..83d745b203600 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_spectral_features_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_spectral_features_gn/moz.build
-index 1e27faa5870dd..6be5b9b81526d 100644
+index 0ff9b98abd..8a20d231ae 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_spectral_features_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_spectral_features_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3463,7 +3951,7 @@ index 1e27faa5870dd..6be5b9b81526d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_symmetric_matrix_buffer_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_symmetric_matrix_buffer_gn/moz.build
-index 6ffad4636659e..f9fdb459564c3 100644
+index 9f5bb53ec0..efcc54b675 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_symmetric_matrix_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/rnn_vad_symmetric_matrix_buffer_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3478,7 +3966,7 @@ index 6ffad4636659e..f9fdb459564c3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/vector_math_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/vector_math_gn/moz.build
-index d3bb22b9a5254..08e88e9d82320 100644
+index 79d73bb0e3..d0b7d90908 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/vector_math_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/rnn_vad/vector_math_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3493,7 +3981,7 @@ index d3bb22b9a5254..08e88e9d82320 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/saturation_protector_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/saturation_protector_gn/moz.build
-index 271c46c540d72..b334441c85348 100644
+index fd27a27da1..0ff845f075 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/saturation_protector_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/saturation_protector_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3508,7 +3996,7 @@ index 271c46c540d72..b334441c85348 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/speech_level_estimator_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/speech_level_estimator_gn/moz.build
-index cfb4bb80840a1..0d452573df8c5 100644
+index aedae110fd..d92c979a76 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/speech_level_estimator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/speech_level_estimator_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3523,7 +4011,7 @@ index cfb4bb80840a1..0d452573df8c5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/agc2/vad_wrapper_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/agc2/vad_wrapper_gn/moz.build
-index 00e3216b4597f..b3e2fa8ad3953 100644
+index 9b40d9ff94..7316145c74 100644
 --- a/third_party/libwebrtc/modules/audio_processing/agc2/vad_wrapper_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/agc2/vad_wrapper_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3538,7 +4026,7 @@ index 00e3216b4597f..b3e2fa8ad3953 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/apm_logging_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/apm_logging_gn/moz.build
-index 9b5e11e947d92..f0ba4e3ff14ac 100644
+index 30453ba627..e202a50e9e 100644
 --- a/third_party/libwebrtc/modules/audio_processing/apm_logging_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/apm_logging_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3553,7 +4041,7 @@ index 9b5e11e947d92..f0ba4e3ff14ac 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/audio_buffer_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/audio_buffer_gn/moz.build
-index 986ecc61c766c..23f3f826ab1e9 100644
+index 2fce4639d9..3878d77df8 100644
 --- a/third_party/libwebrtc/modules/audio_processing/audio_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/audio_buffer_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3568,7 +4056,7 @@ index 986ecc61c766c..23f3f826ab1e9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/audio_frame_proxies_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/audio_frame_proxies_gn/moz.build
-index 894361b57458d..2bb4f4a1affcb 100644
+index 231bdb8f41..5dc4aa6c6a 100644
 --- a/third_party/libwebrtc/modules/audio_processing/audio_frame_proxies_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/audio_frame_proxies_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3583,10 +4071,10 @@ index 894361b57458d..2bb4f4a1affcb 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/audio_frame_view_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/audio_frame_view_gn/moz.build
-index 7a283f1e109a4..f718e0bebb47d 100644
+index 43ffbc502d..de06059f30 100644
 --- a/third_party/libwebrtc/modules/audio_processing/audio_frame_view_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/audio_frame_view_gn/moz.build
-@@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+@@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
      DEFINES["WEBRTC_ARCH_ARM_V7"] = True
      DEFINES["WEBRTC_HAS_NEON"] = True
  
@@ -3598,7 +4086,7 @@ index 7a283f1e109a4..f718e0bebb47d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/audio_processing_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/audio_processing_gn/moz.build
-index 4acaa7f014eb4..6856373c6aa8f 100644
+index c34635a347..f95e3976f2 100644
 --- a/third_party/libwebrtc/modules/audio_processing/audio_processing_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/audio_processing_gn/moz.build
 @@ -161,6 +161,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3613,7 +4101,7 @@ index 4acaa7f014eb4..6856373c6aa8f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/capture_levels_adjuster/capture_levels_adjuster_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/capture_levels_adjuster/capture_levels_adjuster_gn/moz.build
-index ba0901058580d..2a9087fbc8636 100644
+index bcc0e359d2..a1b73ba6a2 100644
 --- a/third_party/libwebrtc/modules/audio_processing/capture_levels_adjuster/capture_levels_adjuster_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/capture_levels_adjuster/capture_levels_adjuster_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3628,7 +4116,7 @@ index ba0901058580d..2a9087fbc8636 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/gain_controller2_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/gain_controller2_gn/moz.build
-index 2fd9b99a64dfd..840899c2bdc24 100644
+index 901a593d4e..2d453cc2e8 100644
 --- a/third_party/libwebrtc/modules/audio_processing/gain_controller2_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/gain_controller2_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3643,7 +4131,7 @@ index 2fd9b99a64dfd..840899c2bdc24 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/high_pass_filter_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/high_pass_filter_gn/moz.build
-index 09d5dc9882473..3a7c0d3e7ef91 100644
+index 767aac52bb..1c1124633f 100644
 --- a/third_party/libwebrtc/modules/audio_processing/high_pass_filter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/high_pass_filter_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3658,7 +4146,7 @@ index 09d5dc9882473..3a7c0d3e7ef91 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/ns/ns_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/ns/ns_gn/moz.build
-index 93c673ef17031..ca0192aff911f 100644
+index 2880f10c6d..033a97439c 100644
 --- a/third_party/libwebrtc/modules/audio_processing/ns/ns_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/ns/ns_gn/moz.build
 @@ -167,6 +167,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3672,23 +4160,8 @@ index 93c673ef17031..ca0192aff911f 100644
  if CONFIG["TARGET_CPU"] == "mips32":
  
      DEFINES["MIPS32_LE"] = True
-diff --git a/third_party/libwebrtc/modules/audio_processing/optionally_built_submodule_creators_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/optionally_built_submodule_creators_gn/moz.build
-index 0af06a9c3544b..b8e2e57e63dd2 100644
---- a/third_party/libwebrtc/modules/audio_processing/optionally_built_submodule_creators_gn/moz.build
-+++ b/third_party/libwebrtc/modules/audio_processing/optionally_built_submodule_creators_gn/moz.build
-@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
-     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
-     DEFINES["WEBRTC_HAS_NEON"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/rms_level_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/rms_level_gn/moz.build
-index 8b21dc34fd6c3..40e4d2abaddc4 100644
+index 6deed14b7f..f247004253 100644
 --- a/third_party/libwebrtc/modules/audio_processing/rms_level_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/rms_level_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3702,53 +4175,8 @@ index 8b21dc34fd6c3..40e4d2abaddc4 100644
  if CONFIG["TARGET_CPU"] == "mips32":
  
      DEFINES["MIPS32_LE"] = True
-diff --git a/third_party/libwebrtc/modules/audio_processing/transient/transient_suppressor_api_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/transient/transient_suppressor_api_gn/moz.build
-index f3ccbefcdb8e2..c60ead6c16a15 100644
---- a/third_party/libwebrtc/modules/audio_processing/transient/transient_suppressor_api_gn/moz.build
-+++ b/third_party/libwebrtc/modules/audio_processing/transient/transient_suppressor_api_gn/moz.build
-@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
-     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
-     DEFINES["WEBRTC_HAS_NEON"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["MIPS32_LE"] = True
-diff --git a/third_party/libwebrtc/modules/audio_processing/transient/transient_suppressor_impl_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/transient/transient_suppressor_impl_gn/moz.build
-index 0ec5dcb6c535a..1d397b8332717 100644
---- a/third_party/libwebrtc/modules/audio_processing/transient/transient_suppressor_impl_gn/moz.build
-+++ b/third_party/libwebrtc/modules/audio_processing/transient/transient_suppressor_impl_gn/moz.build
-@@ -158,6 +158,10 @@ if CONFIG["TARGET_CPU"] == "arm":
-     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
-     DEFINES["WEBRTC_HAS_NEON"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["MIPS32_LE"] = True
-diff --git a/third_party/libwebrtc/modules/audio_processing/transient/voice_probability_delay_unit_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/transient/voice_probability_delay_unit_gn/moz.build
-index 50a6a9d55ce52..8125425cc94f1 100644
---- a/third_party/libwebrtc/modules/audio_processing/transient/voice_probability_delay_unit_gn/moz.build
-+++ b/third_party/libwebrtc/modules/audio_processing/transient/voice_probability_delay_unit_gn/moz.build
-@@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
-     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
-     DEFINES["WEBRTC_HAS_NEON"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/utility/cascaded_biquad_filter_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/utility/cascaded_biquad_filter_gn/moz.build
-index f1b3493b7a961..362afb2cd88cc 100644
+index ec295a9840..4975d07199 100644
 --- a/third_party/libwebrtc/modules/audio_processing/utility/cascaded_biquad_filter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/utility/cascaded_biquad_filter_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3763,7 +4191,7 @@ index f1b3493b7a961..362afb2cd88cc 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/utility/legacy_delay_estimator_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/utility/legacy_delay_estimator_gn/moz.build
-index 12b385e2e9056..161fa3204ef51 100644
+index beca78d134..ac1f1b2737 100644
 --- a/third_party/libwebrtc/modules/audio_processing/utility/legacy_delay_estimator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/utility/legacy_delay_estimator_gn/moz.build
 @@ -144,6 +144,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3778,7 +4206,7 @@ index 12b385e2e9056..161fa3204ef51 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/utility/pffft_wrapper_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/utility/pffft_wrapper_gn/moz.build
-index f1e1bc555af42..ebad818492f3b 100644
+index d118284e2c..1d80d18544 100644
 --- a/third_party/libwebrtc/modules/audio_processing/utility/pffft_wrapper_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/utility/pffft_wrapper_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3793,7 +4221,7 @@ index f1e1bc555af42..ebad818492f3b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/audio_processing/vad/vad_gn/moz.build b/third_party/libwebrtc/modules/audio_processing/vad/vad_gn/moz.build
-index 4794a478e8a07..9832d3f2206cd 100644
+index b2ff5b4798..30a54c7870 100644
 --- a/third_party/libwebrtc/modules/audio_processing/vad/vad_gn/moz.build
 +++ b/third_party/libwebrtc/modules/audio_processing/vad/vad_gn/moz.build
 @@ -161,6 +161,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3808,10 +4236,10 @@ index 4794a478e8a07..9832d3f2206cd 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/congestion_controller_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/congestion_controller_gn/moz.build
-index 59d06c939618e..52e2ba8782453 100644
+index 1f355f493b..c8956b1040 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/congestion_controller_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/congestion_controller_gn/moz.build
-@@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+@@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
      DEFINES["WEBRTC_ARCH_ARM_V7"] = True
      DEFINES["WEBRTC_HAS_NEON"] = True
  
@@ -3823,7 +4251,7 @@ index 59d06c939618e..52e2ba8782453 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/alr_detector_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/alr_detector_gn/moz.build
-index 2a3d216e40c07..9ebbf45b41e0a 100644
+index d846e19c0b..4c15cdcf2f 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/alr_detector_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/alr_detector_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3838,39 +4266,9 @@ index 2a3d216e40c07..9ebbf45b41e0a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/delay_based_bwe_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/delay_based_bwe_gn/moz.build
-index b138b59fc6564..50f1b151b8a1f 100644
+index 7668240917..aa3081fabc 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/delay_based_bwe_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/delay_based_bwe_gn/moz.build
-@@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
-     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
-     DEFINES["WEBRTC_HAS_NEON"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["MIPS32_LE"] = True
-diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/estimators_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/estimators_gn/moz.build
-index 47ee346c89e83..5ea300d6f1487 100644
---- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/estimators_gn/moz.build
-+++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/estimators_gn/moz.build
-@@ -160,6 +160,10 @@ if CONFIG["TARGET_CPU"] == "arm":
-     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
-     DEFINES["WEBRTC_HAS_NEON"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["MIPS32_LE"] = True
-diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/goog_cc_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/goog_cc_gn/moz.build
-index fa641fccfe187..cc591aeee423c 100644
---- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/goog_cc_gn/moz.build
-+++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/goog_cc_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
      DEFINES["WEBRTC_ARCH_ARM_V7"] = True
      DEFINES["WEBRTC_HAS_NEON"] = True
@@ -3882,8 +4280,38 @@ index fa641fccfe187..cc591aeee423c 100644
  if CONFIG["TARGET_CPU"] == "mips32":
  
      DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/estimators_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/estimators_gn/moz.build
+index 8c9acee029..400cb61311 100644
+--- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/estimators_gn/moz.build
++++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/estimators_gn/moz.build
+@@ -159,6 +159,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/goog_cc_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/goog_cc_gn/moz.build
+index b63d8b6e6f..74ddfeaeb0 100644
+--- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/goog_cc_gn/moz.build
++++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/goog_cc_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/link_capacity_estimator_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/link_capacity_estimator_gn/moz.build
-index d229d732df781..9c497d39ff31c 100644
+index 6480b5f786..45ff2eb655 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/link_capacity_estimator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/link_capacity_estimator_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3898,10 +4326,10 @@ index d229d732df781..9c497d39ff31c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v1_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v1_gn/moz.build
-index 8065861f7854c..e3130fd38e809 100644
+index a1dae5bfec..35bcbd0bc6 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v1_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v1_gn/moz.build
-@@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+@@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
      DEFINES["WEBRTC_ARCH_ARM_V7"] = True
      DEFINES["WEBRTC_HAS_NEON"] = True
  
@@ -3913,7 +4341,7 @@ index 8065861f7854c..e3130fd38e809 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v2_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v2_gn/moz.build
-index 72c625902ca3e..17370f74758c8 100644
+index fb157ec2ad..51ae00ed2a 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v2_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/loss_based_bwe_v2_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3928,7 +4356,7 @@ index 72c625902ca3e..17370f74758c8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/probe_controller_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/probe_controller_gn/moz.build
-index cb2bc83d2850c..33ec90a9bf5e3 100644
+index c098912b76..fe1adb7445 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/probe_controller_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/probe_controller_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3943,7 +4371,7 @@ index cb2bc83d2850c..33ec90a9bf5e3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/pushback_controller_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/pushback_controller_gn/moz.build
-index af00c01323020..445de1ab79391 100644
+index 46255c3242..9e81111fa3 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/pushback_controller_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/pushback_controller_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3958,10 +4386,10 @@ index af00c01323020..445de1ab79391 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/goog_cc/send_side_bwe_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/goog_cc/send_side_bwe_gn/moz.build
-index 52323451eb320..0337cbd03c3bb 100644
+index 3c3f10e984..5a70f16f73 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/goog_cc/send_side_bwe_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/goog_cc/send_side_bwe_gn/moz.build
-@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
      DEFINES["WEBRTC_ARCH_ARM_V7"] = True
      DEFINES["WEBRTC_HAS_NEON"] = True
  
@@ -3973,7 +4401,7 @@ index 52323451eb320..0337cbd03c3bb 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/rtp/control_handler_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/rtp/control_handler_gn/moz.build
-index 9226c07dda237..81fa66ddf6428 100644
+index 51a296016a..8795241631 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/rtp/control_handler_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/rtp/control_handler_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -3988,7 +4416,7 @@ index 9226c07dda237..81fa66ddf6428 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/congestion_controller/rtp/transport_feedback_gn/moz.build b/third_party/libwebrtc/modules/congestion_controller/rtp/transport_feedback_gn/moz.build
-index c2b8fead8d154..a82b18fa5cd42 100644
+index f1c4138f12..2740485a4c 100644
 --- a/third_party/libwebrtc/modules/congestion_controller/rtp/transport_feedback_gn/moz.build
 +++ b/third_party/libwebrtc/modules/congestion_controller/rtp/transport_feedback_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4003,7 +4431,7 @@ index c2b8fead8d154..a82b18fa5cd42 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/desktop_capture/desktop_capture_gn/moz.build b/third_party/libwebrtc/modules/desktop_capture/desktop_capture_gn/moz.build
-index a4fb8b3162bd8..ee039ce2e38a8 100644
+index 442f60843d..ca72431d9e 100644
 --- a/third_party/libwebrtc/modules/desktop_capture/desktop_capture_gn/moz.build
 +++ b/third_party/libwebrtc/modules/desktop_capture/desktop_capture_gn/moz.build
 @@ -277,6 +277,35 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4043,7 +4471,7 @@ index a4fb8b3162bd8..ee039ce2e38a8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/desktop_capture/primitives_gn/moz.build b/third_party/libwebrtc/modules/desktop_capture/primitives_gn/moz.build
-index 927926f3e987a..e60f2879d7180 100644
+index 4414259d7e..ca1a4b681e 100644
 --- a/third_party/libwebrtc/modules/desktop_capture/primitives_gn/moz.build
 +++ b/third_party/libwebrtc/modules/desktop_capture/primitives_gn/moz.build
 @@ -132,6 +132,11 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4059,7 +4487,7 @@ index 927926f3e987a..e60f2879d7180 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/module_api_gn/moz.build b/third_party/libwebrtc/modules/module_api_gn/moz.build
-index 9b77a009fa9ec..80236e4efbbf7 100644
+index 5d16a3e7e5..035a1f304c 100644
 --- a/third_party/libwebrtc/modules/module_api_gn/moz.build
 +++ b/third_party/libwebrtc/modules/module_api_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4074,7 +4502,7 @@ index 9b77a009fa9ec..80236e4efbbf7 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/module_api_public_gn/moz.build b/third_party/libwebrtc/modules/module_api_public_gn/moz.build
-index 474dec612359e..634cf27e15f0a 100644
+index 38f4c929eb..2413fd7f27 100644
 --- a/third_party/libwebrtc/modules/module_api_public_gn/moz.build
 +++ b/third_party/libwebrtc/modules/module_api_public_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4089,7 +4517,7 @@ index 474dec612359e..634cf27e15f0a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/module_fec_api_gn/moz.build b/third_party/libwebrtc/modules/module_fec_api_gn/moz.build
-index b69c69c3118c0..3b3b0dbc5cb31 100644
+index 2c8d429c92..41cab323bd 100644
 --- a/third_party/libwebrtc/modules/module_fec_api_gn/moz.build
 +++ b/third_party/libwebrtc/modules/module_fec_api_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4104,7 +4532,7 @@ index b69c69c3118c0..3b3b0dbc5cb31 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/pacing/interval_budget_gn/moz.build b/third_party/libwebrtc/modules/pacing/interval_budget_gn/moz.build
-index 2e3ab3d9878e0..9af23bc939192 100644
+index 4b4e2e1bf4..fbc98f8eb0 100644
 --- a/third_party/libwebrtc/modules/pacing/interval_budget_gn/moz.build
 +++ b/third_party/libwebrtc/modules/pacing/interval_budget_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4119,7 +4547,7 @@ index 2e3ab3d9878e0..9af23bc939192 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/pacing/pacing_gn/moz.build b/third_party/libwebrtc/modules/pacing/pacing_gn/moz.build
-index d7aa189ef37b1..bf250e4433187 100644
+index f713d0737f..3d820032b1 100644
 --- a/third_party/libwebrtc/modules/pacing/pacing_gn/moz.build
 +++ b/third_party/libwebrtc/modules/pacing/pacing_gn/moz.build
 @@ -162,6 +162,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4133,11 +4561,56 @@ index d7aa189ef37b1..bf250e4433187 100644
  if CONFIG["TARGET_CPU"] == "mips32":
  
      DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/remote_bitrate_estimator/congestion_control_feedback_generator_gn/moz.build b/third_party/libwebrtc/modules/remote_bitrate_estimator/congestion_control_feedback_generator_gn/moz.build
+index 2f721caab1..d7f19e195c 100644
+--- a/third_party/libwebrtc/modules/remote_bitrate_estimator/congestion_control_feedback_generator_gn/moz.build
++++ b/third_party/libwebrtc/modules/remote_bitrate_estimator/congestion_control_feedback_generator_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_gn/moz.build b/third_party/libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_gn/moz.build
-index eab6f3f9d0fca..02e5a63adbfba 100644
+index 70b2e3fe35..77996721f4 100644
 --- a/third_party/libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_gn/moz.build
-@@ -166,6 +166,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+@@ -163,6 +163,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/remote_bitrate_estimator/rtp_transport_feedback_generator_gn/moz.build b/third_party/libwebrtc/modules/remote_bitrate_estimator/rtp_transport_feedback_generator_gn/moz.build
+index a0d7d7e0ac..4198059909 100644
+--- a/third_party/libwebrtc/modules/remote_bitrate_estimator/rtp_transport_feedback_generator_gn/moz.build
++++ b/third_party/libwebrtc/modules/remote_bitrate_estimator/rtp_transport_feedback_generator_gn/moz.build
+@@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/remote_bitrate_estimator/transport_sequence_number_feedback_generator_gn/moz.build b/third_party/libwebrtc/modules/remote_bitrate_estimator/transport_sequence_number_feedback_generator_gn/moz.build
+index 3cdc29623f..9a052a61c0 100644
+--- a/third_party/libwebrtc/modules/remote_bitrate_estimator/transport_sequence_number_feedback_generator_gn/moz.build
++++ b/third_party/libwebrtc/modules/remote_bitrate_estimator/transport_sequence_number_feedback_generator_gn/moz.build
+@@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
      DEFINES["WEBRTC_ARCH_ARM_V7"] = True
      DEFINES["WEBRTC_HAS_NEON"] = True
  
@@ -4149,7 +4622,7 @@ index eab6f3f9d0fca..02e5a63adbfba 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/rtp_rtcp/leb128_gn/moz.build b/third_party/libwebrtc/modules/rtp_rtcp/leb128_gn/moz.build
-index 6e1dfd18c099e..f1eb5b14cde17 100644
+index db194c628d..9cc6ca303f 100644
 --- a/third_party/libwebrtc/modules/rtp_rtcp/leb128_gn/moz.build
 +++ b/third_party/libwebrtc/modules/rtp_rtcp/leb128_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4163,8 +4636,23 @@ index 6e1dfd18c099e..f1eb5b14cde17 100644
  if CONFIG["TARGET_CPU"] == "mips32":
  
      DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/modules/rtp_rtcp/ntp_time_util_gn/moz.build b/third_party/libwebrtc/modules/rtp_rtcp/ntp_time_util_gn/moz.build
+index 82edd94526..16184b2eb9 100644
+--- a/third_party/libwebrtc/modules/rtp_rtcp/ntp_time_util_gn/moz.build
++++ b/third_party/libwebrtc/modules/rtp_rtcp/ntp_time_util_gn/moz.build
+@@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_format_gn/moz.build b/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_format_gn/moz.build
-index ef123804746ac..932c1ce369ee5 100644
+index ffa92866f6..8ac155649b 100644
 --- a/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_format_gn/moz.build
 +++ b/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_format_gn/moz.build
 @@ -197,6 +197,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4179,10 +4667,10 @@ index ef123804746ac..932c1ce369ee5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_gn/moz.build b/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_gn/moz.build
-index 31789273913d5..90e87e42cb182 100644
+index 91531e0c5f..cb01601a3d 100644
 --- a/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_gn/moz.build
 +++ b/third_party/libwebrtc/modules/rtp_rtcp/rtp_rtcp_gn/moz.build
-@@ -211,6 +211,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+@@ -209,6 +209,10 @@ if CONFIG["TARGET_CPU"] == "arm":
      DEFINES["WEBRTC_ARCH_ARM_V7"] = True
      DEFINES["WEBRTC_HAS_NEON"] = True
  
@@ -4194,7 +4682,7 @@ index 31789273913d5..90e87e42cb182 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/rtp_rtcp/rtp_video_header_gn/moz.build b/third_party/libwebrtc/modules/rtp_rtcp/rtp_video_header_gn/moz.build
-index bdee5bedc6dba..a78ffabadd3e0 100644
+index 2c4f895923..ac96b1909b 100644
 --- a/third_party/libwebrtc/modules/rtp_rtcp/rtp_video_header_gn/moz.build
 +++ b/third_party/libwebrtc/modules/rtp_rtcp/rtp_video_header_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4209,7 +4697,7 @@ index bdee5bedc6dba..a78ffabadd3e0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/third_party/fft/fft_gn/moz.build b/third_party/libwebrtc/modules/third_party/fft/fft_gn/moz.build
-index 9afa4154ee379..fc523a328e9fc 100644
+index 855a7c640e..2b15d9f143 100644
 --- a/third_party/libwebrtc/modules/third_party/fft/fft_gn/moz.build
 +++ b/third_party/libwebrtc/modules/third_party/fft/fft_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4224,7 +4712,7 @@ index 9afa4154ee379..fc523a328e9fc 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/third_party/g711/g711_3p_gn/moz.build b/third_party/libwebrtc/modules/third_party/g711/g711_3p_gn/moz.build
-index 2fa1910cc8443..6c2d50e960272 100644
+index e49c5be296..4dd04f1c15 100644
 --- a/third_party/libwebrtc/modules/third_party/g711/g711_3p_gn/moz.build
 +++ b/third_party/libwebrtc/modules/third_party/g711/g711_3p_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4239,7 +4727,7 @@ index 2fa1910cc8443..6c2d50e960272 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/third_party/g722/g722_3p_gn/moz.build b/third_party/libwebrtc/modules/third_party/g722/g722_3p_gn/moz.build
-index d1ff3aaad3489..57fc6a12afa5d 100644
+index 35318f094a..e365ac87b4 100644
 --- a/third_party/libwebrtc/modules/third_party/g722/g722_3p_gn/moz.build
 +++ b/third_party/libwebrtc/modules/third_party/g722/g722_3p_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4254,7 +4742,7 @@ index d1ff3aaad3489..57fc6a12afa5d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/utility/utility_gn/moz.build b/third_party/libwebrtc/modules/utility/utility_gn/moz.build
-index 97d828d64fc18..dafae21d5fbd1 100644
+index 08951c311a..2ed1f7e7aa 100644
 --- a/third_party/libwebrtc/modules/utility/utility_gn/moz.build
 +++ b/third_party/libwebrtc/modules/utility/utility_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4269,7 +4757,7 @@ index 97d828d64fc18..dafae21d5fbd1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_capture/video_capture_internal_impl_gn/moz.build b/third_party/libwebrtc/modules/video_capture/video_capture_internal_impl_gn/moz.build
-index 6af27f618bcde..68ef46df66f24 100644
+index ce9b51191c..7e2ff67942 100644
 --- a/third_party/libwebrtc/modules/video_capture/video_capture_internal_impl_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_capture/video_capture_internal_impl_gn/moz.build
 @@ -185,6 +185,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4284,7 +4772,7 @@ index 6af27f618bcde..68ef46df66f24 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_capture/video_capture_module_gn/moz.build b/third_party/libwebrtc/modules/video_capture/video_capture_module_gn/moz.build
-index 145e549286443..b5c52722f7500 100644
+index c0bac40647..f85896a2dd 100644
 --- a/third_party/libwebrtc/modules/video_capture/video_capture_module_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_capture/video_capture_module_gn/moz.build
 @@ -158,6 +158,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4299,7 +4787,7 @@ index 145e549286443..b5c52722f7500 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/chain_diff_calculator_gn/moz.build b/third_party/libwebrtc/modules/video_coding/chain_diff_calculator_gn/moz.build
-index 065cf604b5d31..f2e93630b268e 100644
+index 4d13e69f7b..61ffeec4a9 100644
 --- a/third_party/libwebrtc/modules/video_coding/chain_diff_calculator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/chain_diff_calculator_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4314,7 +4802,7 @@ index 065cf604b5d31..f2e93630b268e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/codec_globals_headers_gn/moz.build b/third_party/libwebrtc/modules/video_coding/codec_globals_headers_gn/moz.build
-index 53a7fc384c3d8..9bb894a49e459 100644
+index 7fd4ec68f2..bc8152852e 100644
 --- a/third_party/libwebrtc/modules/video_coding/codec_globals_headers_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/codec_globals_headers_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4329,7 +4817,7 @@ index 53a7fc384c3d8..9bb894a49e459 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/codecs/av1/av1_svc_config_gn/moz.build b/third_party/libwebrtc/modules/video_coding/codecs/av1/av1_svc_config_gn/moz.build
-index b9784482e9bd3..674553fda2f86 100644
+index 68e07db4ea..77632d3579 100644
 --- a/third_party/libwebrtc/modules/video_coding/codecs/av1/av1_svc_config_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/codecs/av1/av1_svc_config_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4344,7 +4832,7 @@ index b9784482e9bd3..674553fda2f86 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/encoded_frame_gn/moz.build b/third_party/libwebrtc/modules/video_coding/encoded_frame_gn/moz.build
-index a086f7cb0b6f8..c8c63c182bc7a 100644
+index ff8f03e990..b73fff4fd1 100644
 --- a/third_party/libwebrtc/modules/video_coding/encoded_frame_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/encoded_frame_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4359,7 +4847,7 @@ index a086f7cb0b6f8..c8c63c182bc7a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/frame_dependencies_calculator_gn/moz.build b/third_party/libwebrtc/modules/video_coding/frame_dependencies_calculator_gn/moz.build
-index e8fdf3750a0c8..78f33ae389f0d 100644
+index a353fa0c1a..ecad283906 100644
 --- a/third_party/libwebrtc/modules/video_coding/frame_dependencies_calculator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/frame_dependencies_calculator_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4374,7 +4862,7 @@ index e8fdf3750a0c8..78f33ae389f0d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/frame_helpers_gn/moz.build b/third_party/libwebrtc/modules/video_coding/frame_helpers_gn/moz.build
-index ecd9c1dd8d376..f0fde86029d8a 100644
+index 23f3426af9..3901cf74ce 100644
 --- a/third_party/libwebrtc/modules/video_coding/frame_helpers_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/frame_helpers_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4389,7 +4877,7 @@ index ecd9c1dd8d376..f0fde86029d8a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/h264_sprop_parameter_sets_gn/moz.build b/third_party/libwebrtc/modules/video_coding/h264_sprop_parameter_sets_gn/moz.build
-index b92c2ed52823f..03978f5726371 100644
+index 293c5a9447..29bef5e131 100644
 --- a/third_party/libwebrtc/modules/video_coding/h264_sprop_parameter_sets_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/h264_sprop_parameter_sets_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4404,7 +4892,7 @@ index b92c2ed52823f..03978f5726371 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/h26x_packet_buffer_gn/moz.build b/third_party/libwebrtc/modules/video_coding/h26x_packet_buffer_gn/moz.build
-index 92267a7c583f2..385ac6b02c51b 100644
+index 61b529cd9a..1d12163a99 100644
 --- a/third_party/libwebrtc/modules/video_coding/h26x_packet_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/h26x_packet_buffer_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4419,7 +4907,7 @@ index 92267a7c583f2..385ac6b02c51b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/nack_requester_gn/moz.build b/third_party/libwebrtc/modules/video_coding/nack_requester_gn/moz.build
-index 187cf6089c53f..8d44f9aa21772 100644
+index 81bf962b05..98188de263 100644
 --- a/third_party/libwebrtc/modules/video_coding/nack_requester_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/nack_requester_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4434,7 +4922,7 @@ index 187cf6089c53f..8d44f9aa21772 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/packet_buffer_gn/moz.build b/third_party/libwebrtc/modules/video_coding/packet_buffer_gn/moz.build
-index 09929b1d482a1..65658185219d7 100644
+index deb0e75d02..435cf6cacc 100644
 --- a/third_party/libwebrtc/modules/video_coding/packet_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/packet_buffer_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4449,7 +4937,7 @@ index 09929b1d482a1..65658185219d7 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/svc/scalability_mode_util_gn/moz.build b/third_party/libwebrtc/modules/video_coding/svc/scalability_mode_util_gn/moz.build
-index 6986843464121..3699238b44926 100644
+index a927c85233..6a5f242d15 100644
 --- a/third_party/libwebrtc/modules/video_coding/svc/scalability_mode_util_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/svc/scalability_mode_util_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4464,7 +4952,7 @@ index 6986843464121..3699238b44926 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/svc/scalability_structures_gn/moz.build b/third_party/libwebrtc/modules/video_coding/svc/scalability_structures_gn/moz.build
-index 88f469760f7f5..40515fd26fcd5 100644
+index 7d99ca631f..44fbc39c93 100644
 --- a/third_party/libwebrtc/modules/video_coding/svc/scalability_structures_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/svc/scalability_structures_gn/moz.build
 @@ -157,6 +157,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4479,7 +4967,7 @@ index 88f469760f7f5..40515fd26fcd5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/svc/scalable_video_controller_gn/moz.build b/third_party/libwebrtc/modules/video_coding/svc/scalable_video_controller_gn/moz.build
-index d09a4aed3ab50..bd11fa819a394 100644
+index de65ae6081..04823c62b7 100644
 --- a/third_party/libwebrtc/modules/video_coding/svc/scalable_video_controller_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/svc/scalable_video_controller_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4494,7 +4982,7 @@ index d09a4aed3ab50..bd11fa819a394 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/svc/svc_rate_allocator_gn/moz.build b/third_party/libwebrtc/modules/video_coding/svc/svc_rate_allocator_gn/moz.build
-index 2bd3634ba957d..cc86bd52980d2 100644
+index 9ac42accf0..90d351fca9 100644
 --- a/third_party/libwebrtc/modules/video_coding/svc/svc_rate_allocator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/svc/svc_rate_allocator_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4509,7 +4997,7 @@ index 2bd3634ba957d..cc86bd52980d2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/timing/decode_time_percentile_filter_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/decode_time_percentile_filter_gn/moz.build
-index 9c48932149b90..b177a6c6af3cc 100644
+index edf94ba576..dfd85219b4 100644
 --- a/third_party/libwebrtc/modules/video_coding/timing/decode_time_percentile_filter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/timing/decode_time_percentile_filter_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4524,7 +5012,7 @@ index 9c48932149b90..b177a6c6af3cc 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/timing/frame_delay_variation_kalman_filter_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/frame_delay_variation_kalman_filter_gn/moz.build
-index 0e5991cffd44d..a1eda8e0e10d3 100644
+index 33b768c83d..a0b90bed32 100644
 --- a/third_party/libwebrtc/modules/video_coding/timing/frame_delay_variation_kalman_filter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/timing/frame_delay_variation_kalman_filter_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4539,7 +5027,7 @@ index 0e5991cffd44d..a1eda8e0e10d3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/timing/inter_frame_delay_variation_calculator_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/inter_frame_delay_variation_calculator_gn/moz.build
-index a311c4a8024c1..8c81383d449b6 100644
+index 2e60885cc8..79e7354ba8 100644
 --- a/third_party/libwebrtc/modules/video_coding/timing/inter_frame_delay_variation_calculator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/timing/inter_frame_delay_variation_calculator_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4554,7 +5042,7 @@ index a311c4a8024c1..8c81383d449b6 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/timing/jitter_estimator_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/jitter_estimator_gn/moz.build
-index 6d87c74bd732f..02fc5944f0d66 100644
+index 93e4dc45ce..ee28702d27 100644
 --- a/third_party/libwebrtc/modules/video_coding/timing/jitter_estimator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/timing/jitter_estimator_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4569,7 +5057,7 @@ index 6d87c74bd732f..02fc5944f0d66 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/timing/rtt_filter_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/rtt_filter_gn/moz.build
-index e05eebc11f52e..188f88c23cf81 100644
+index 38d5005afb..e207c3091a 100644
 --- a/third_party/libwebrtc/modules/video_coding/timing/rtt_filter_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/timing/rtt_filter_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4584,7 +5072,7 @@ index e05eebc11f52e..188f88c23cf81 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/timing/timestamp_extrapolator_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/timestamp_extrapolator_gn/moz.build
-index 10e36ea24cf2c..033dfbfbe578e 100644
+index f8c4616bcd..a438c56d5b 100644
 --- a/third_party/libwebrtc/modules/video_coding/timing/timestamp_extrapolator_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/timing/timestamp_extrapolator_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4599,7 +5087,7 @@ index 10e36ea24cf2c..033dfbfbe578e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/timing/timing_module_gn/moz.build b/third_party/libwebrtc/modules/video_coding/timing/timing_module_gn/moz.build
-index 2ab95ef629911..cd036f90bb3b5 100644
+index d517c26f4e..a14bd99b05 100644
 --- a/third_party/libwebrtc/modules/video_coding/timing/timing_module_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/timing/timing_module_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4614,7 +5102,7 @@ index 2ab95ef629911..cd036f90bb3b5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/video_codec_interface_gn/moz.build b/third_party/libwebrtc/modules/video_coding/video_codec_interface_gn/moz.build
-index 0e18b1aecaed9..3c0c4d1b83721 100644
+index dfd036b770..ce06b2f9a3 100644
 --- a/third_party/libwebrtc/modules/video_coding/video_codec_interface_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/video_codec_interface_gn/moz.build
 @@ -152,6 +152,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4629,7 +5117,7 @@ index 0e18b1aecaed9..3c0c4d1b83721 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/video_coding_gn/moz.build b/third_party/libwebrtc/modules/video_coding/video_coding_gn/moz.build
-index 01a6429d0cdf8..813a0d673454a 100644
+index 35788afdc0..5fec3c4088 100644
 --- a/third_party/libwebrtc/modules/video_coding/video_coding_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/video_coding_gn/moz.build
 @@ -168,6 +168,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4644,7 +5132,7 @@ index 01a6429d0cdf8..813a0d673454a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/video_coding_utility_gn/moz.build b/third_party/libwebrtc/modules/video_coding/video_coding_utility_gn/moz.build
-index 75698c304f785..143d8016cc7ac 100644
+index 73901879e7..373ab4f712 100644
 --- a/third_party/libwebrtc/modules/video_coding/video_coding_utility_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/video_coding_utility_gn/moz.build
 @@ -166,6 +166,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4659,7 +5147,7 @@ index 75698c304f785..143d8016cc7ac 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_libvpx_interface_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_libvpx_interface_gn/moz.build
-index ce59cc861c99b..fbdbc2bcf8f56 100644
+index e94a117cf5..e9707b69d0 100644
 --- a/third_party/libwebrtc/modules/video_coding/webrtc_libvpx_interface_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/webrtc_libvpx_interface_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4674,7 +5162,7 @@ index ce59cc861c99b..fbdbc2bcf8f56 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_gn/moz.build
-index 352458cf8e21a..72e24edaa1e77 100644
+index a0a827f8c6..af7259688c 100644
 --- a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_gn/moz.build
 @@ -161,6 +161,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4689,7 +5177,7 @@ index 352458cf8e21a..72e24edaa1e77 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_scalability_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_scalability_gn/moz.build
-index 0338ba659e01e..b1519e2f179ac 100644
+index c6c24c5e66..98d44aed76 100644
 --- a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_scalability_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_scalability_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4704,7 +5192,7 @@ index 0338ba659e01e..b1519e2f179ac 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_temporal_layers_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_temporal_layers_gn/moz.build
-index d7ae0d5805b37..6a4d3fcf8fcb2 100644
+index 9e4b59514b..91f6e07538 100644
 --- a/third_party/libwebrtc/modules/video_coding/webrtc_vp8_temporal_layers_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/webrtc_vp8_temporal_layers_gn/moz.build
 @@ -160,6 +160,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4719,7 +5207,7 @@ index d7ae0d5805b37..6a4d3fcf8fcb2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_vp9_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_vp9_gn/moz.build
-index c0d16a8e5163e..9fab25c590706 100644
+index 79230cbf34..542704a7ea 100644
 --- a/third_party/libwebrtc/modules/video_coding/webrtc_vp9_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/webrtc_vp9_gn/moz.build
 @@ -163,6 +163,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4734,7 +5222,7 @@ index c0d16a8e5163e..9fab25c590706 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/modules/video_coding/webrtc_vp9_helpers_gn/moz.build b/third_party/libwebrtc/modules/video_coding/webrtc_vp9_helpers_gn/moz.build
-index 6abd453136c93..dd71c3be6b357 100644
+index 2c74ca51d9..58084a8ab9 100644
 --- a/third_party/libwebrtc/modules/video_coding/webrtc_vp9_helpers_gn/moz.build
 +++ b/third_party/libwebrtc/modules/video_coding/webrtc_vp9_helpers_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4749,10 +5237,10 @@ index 6abd453136c93..dd71c3be6b357 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/moz.build b/third_party/libwebrtc/moz.build
-index 58c3c3520bc36..806f8caa65a6b 100644
+index 8e02964e73..fcf5f3623b 100644
 --- a/third_party/libwebrtc/moz.build
 +++ b/third_party/libwebrtc/moz.build
-@@ -692,6 +692,13 @@ if CONFIG["OS_TARGET"] == "WINNT" and CONFIG["TARGET_CPU"] == "x86_64":
+@@ -666,6 +666,13 @@ if CONFIG["OS_TARGET"] == "WINNT" and CONFIG["TARGET_CPU"] == "x86_64":
          "/third_party/libwebrtc/modules/desktop_capture/desktop_capture_differ_sse2_gn"
      ]
  
@@ -4767,7 +5255,7 @@ index 58c3c3520bc36..806f8caa65a6b 100644
  
      DIRS += [
 diff --git a/third_party/libwebrtc/rtc_base/async_dns_resolver_gn/moz.build b/third_party/libwebrtc/rtc_base/async_dns_resolver_gn/moz.build
-index 415f09cfd1fec..8e39a6815b5c2 100644
+index 04a6adf963..e851085ec9 100644
 --- a/third_party/libwebrtc/rtc_base/async_dns_resolver_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/async_dns_resolver_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4782,7 +5270,7 @@ index 415f09cfd1fec..8e39a6815b5c2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/async_packet_socket_gn/moz.build b/third_party/libwebrtc/rtc_base/async_packet_socket_gn/moz.build
-index 9f3ce4d4b6004..7d05708ab2f34 100644
+index 9337d72a6b..9c67d5f615 100644
 --- a/third_party/libwebrtc/rtc_base/async_packet_socket_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/async_packet_socket_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4797,7 +5285,7 @@ index 9f3ce4d4b6004..7d05708ab2f34 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/audio_format_to_string_gn/moz.build b/third_party/libwebrtc/rtc_base/audio_format_to_string_gn/moz.build
-index 70a2aa730b192..5a18fc497148b 100644
+index 6d057c77d7..60baff9d29 100644
 --- a/third_party/libwebrtc/rtc_base/audio_format_to_string_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/audio_format_to_string_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4812,7 +5300,7 @@ index 70a2aa730b192..5a18fc497148b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/bit_buffer_gn/moz.build b/third_party/libwebrtc/rtc_base/bit_buffer_gn/moz.build
-index 3dfd3b19d24b3..a269686bc379e 100644
+index b9848a2879..bfe0141e97 100644
 --- a/third_party/libwebrtc/rtc_base/bit_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/bit_buffer_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4827,7 +5315,7 @@ index 3dfd3b19d24b3..a269686bc379e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/bitrate_tracker_gn/moz.build b/third_party/libwebrtc/rtc_base/bitrate_tracker_gn/moz.build
-index 7b1ba50f99cfe..13166faba84ff 100644
+index 3019986ef2..8f182a59a6 100644
 --- a/third_party/libwebrtc/rtc_base/bitrate_tracker_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/bitrate_tracker_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4842,7 +5330,7 @@ index 7b1ba50f99cfe..13166faba84ff 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/bitstream_reader_gn/moz.build b/third_party/libwebrtc/rtc_base/bitstream_reader_gn/moz.build
-index c82c4c9965bf7..48329129ba165 100644
+index 08b85e88db..d7d7e3f8ee 100644
 --- a/third_party/libwebrtc/rtc_base/bitstream_reader_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/bitstream_reader_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4857,7 +5345,7 @@ index c82c4c9965bf7..48329129ba165 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/buffer_gn/moz.build b/third_party/libwebrtc/rtc_base/buffer_gn/moz.build
-index 5e5d11ff6f7e2..23fccce8d58a0 100644
+index ca6f8408cd..cf5f724f48 100644
 --- a/third_party/libwebrtc/rtc_base/buffer_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/buffer_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4872,7 +5360,7 @@ index 5e5d11ff6f7e2..23fccce8d58a0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/byte_buffer_gn/moz.build b/third_party/libwebrtc/rtc_base/byte_buffer_gn/moz.build
-index 89a2c9e84e1c7..fa6463f7dc2eb 100644
+index 925b6e4218..8d92cec39f 100644
 --- a/third_party/libwebrtc/rtc_base/byte_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/byte_buffer_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4887,7 +5375,7 @@ index 89a2c9e84e1c7..fa6463f7dc2eb 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/byte_order_gn/moz.build b/third_party/libwebrtc/rtc_base/byte_order_gn/moz.build
-index b95d149625ed0..edb05a89f393b 100644
+index 44c220a2f7..0d19631abd 100644
 --- a/third_party/libwebrtc/rtc_base/byte_order_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/byte_order_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4902,7 +5390,7 @@ index b95d149625ed0..edb05a89f393b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/checks_gn/moz.build b/third_party/libwebrtc/rtc_base/checks_gn/moz.build
-index f147bdc64bd97..ade028b3e1240 100644
+index ea191d0a16..9137c22c68 100644
 --- a/third_party/libwebrtc/rtc_base/checks_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/checks_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4917,7 +5405,7 @@ index f147bdc64bd97..ade028b3e1240 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/compile_assert_c_gn/moz.build b/third_party/libwebrtc/rtc_base/compile_assert_c_gn/moz.build
-index 711466336e156..15d74c507a3e0 100644
+index 29b7e50f59..a530128302 100644
 --- a/third_party/libwebrtc/rtc_base/compile_assert_c_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/compile_assert_c_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4932,7 +5420,7 @@ index 711466336e156..15d74c507a3e0 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/containers/flat_containers_internal_gn/moz.build b/third_party/libwebrtc/rtc_base/containers/flat_containers_internal_gn/moz.build
-index fa4fdc873993e..fbb9672971b5b 100644
+index 3cf4d58b70..265d36f3cb 100644
 --- a/third_party/libwebrtc/rtc_base/containers/flat_containers_internal_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/containers/flat_containers_internal_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4947,7 +5435,7 @@ index fa4fdc873993e..fbb9672971b5b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/containers/flat_map_gn/moz.build b/third_party/libwebrtc/rtc_base/containers/flat_map_gn/moz.build
-index 7c9b3edd16767..b96ccfa67d805 100644
+index 7dbec67793..3204d866a8 100644
 --- a/third_party/libwebrtc/rtc_base/containers/flat_map_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/containers/flat_map_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4962,7 +5450,7 @@ index 7c9b3edd16767..b96ccfa67d805 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/containers/flat_set_gn/moz.build b/third_party/libwebrtc/rtc_base/containers/flat_set_gn/moz.build
-index 02d364fe30a5d..d4c7825e81319 100644
+index ad3fa67255..e8d551e985 100644
 --- a/third_party/libwebrtc/rtc_base/containers/flat_set_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/containers/flat_set_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4977,7 +5465,7 @@ index 02d364fe30a5d..d4c7825e81319 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/copy_on_write_buffer_gn/moz.build b/third_party/libwebrtc/rtc_base/copy_on_write_buffer_gn/moz.build
-index dd687b90f3ff9..2fdd6c24f6dbf 100644
+index 9e422ff63e..512ee957bd 100644
 --- a/third_party/libwebrtc/rtc_base/copy_on_write_buffer_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/copy_on_write_buffer_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -4992,7 +5480,7 @@ index dd687b90f3ff9..2fdd6c24f6dbf 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/criticalsection_gn/moz.build b/third_party/libwebrtc/rtc_base/criticalsection_gn/moz.build
-index d860667eb5919..ee5683a29711c 100644
+index 82b4602953..581ea5572e 100644
 --- a/third_party/libwebrtc/rtc_base/criticalsection_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/criticalsection_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5007,7 +5495,7 @@ index d860667eb5919..ee5683a29711c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/divide_round_gn/moz.build b/third_party/libwebrtc/rtc_base/divide_round_gn/moz.build
-index 5946a30db45f2..cd02618cca9b3 100644
+index bcbc3682ad..2cb742076e 100644
 --- a/third_party/libwebrtc/rtc_base/divide_round_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/divide_round_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5022,7 +5510,7 @@ index 5946a30db45f2..cd02618cca9b3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/dscp_gn/moz.build b/third_party/libwebrtc/rtc_base/dscp_gn/moz.build
-index fd82b23b98e3d..89e4a04d02e56 100644
+index 9011068358..19ed013eff 100644
 --- a/third_party/libwebrtc/rtc_base/dscp_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/dscp_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5037,7 +5525,7 @@ index fd82b23b98e3d..89e4a04d02e56 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/event_tracer_gn/moz.build b/third_party/libwebrtc/rtc_base/event_tracer_gn/moz.build
-index 2ea470772f4b1..0632f47c6f3ff 100644
+index 4c41814829..0bfaae99bf 100644
 --- a/third_party/libwebrtc/rtc_base/event_tracer_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/event_tracer_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5052,7 +5540,7 @@ index 2ea470772f4b1..0632f47c6f3ff 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/alr_experiment_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/alr_experiment_gn/moz.build
-index 09174a3a20ab9..0223129834085 100644
+index 4e53a89a05..9a7fd22f7e 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/alr_experiment_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/alr_experiment_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5067,7 +5555,7 @@ index 09174a3a20ab9..0223129834085 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/balanced_degradation_settings_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/balanced_degradation_settings_gn/moz.build
-index 233c203847c47..1bbb729d23bc9 100644
+index 3ddc28da45..bf3ea6d012 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/balanced_degradation_settings_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/balanced_degradation_settings_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5082,7 +5570,7 @@ index 233c203847c47..1bbb729d23bc9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/encoder_info_settings_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/encoder_info_settings_gn/moz.build
-index 9866a74964c7a..892b9d5894825 100644
+index 8ab7b59f9a..a35f9a80f8 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/encoder_info_settings_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/encoder_info_settings_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5097,7 +5585,7 @@ index 9866a74964c7a..892b9d5894825 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/field_trial_parser_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/field_trial_parser_gn/moz.build
-index 520c4db65a2b2..63192262a02f8 100644
+index 7c2115ee42..c0b6ba9ada 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/field_trial_parser_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/field_trial_parser_gn/moz.build
 @@ -153,6 +153,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5112,7 +5600,7 @@ index 520c4db65a2b2..63192262a02f8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/keyframe_interval_settings_experiment_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/keyframe_interval_settings_experiment_gn/moz.build
-index 397f0dd3ce6fa..c3778a2228961 100644
+index 80ee96a366..bf1a1b0a58 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/keyframe_interval_settings_experiment_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/keyframe_interval_settings_experiment_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5127,7 +5615,7 @@ index 397f0dd3ce6fa..c3778a2228961 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/min_video_bitrate_experiment_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/min_video_bitrate_experiment_gn/moz.build
-index 5cd3bb4a2bf0e..0d11a128d3591 100644
+index 237ee94c87..da3e4a9f15 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/min_video_bitrate_experiment_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/min_video_bitrate_experiment_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5142,7 +5630,7 @@ index 5cd3bb4a2bf0e..0d11a128d3591 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/normalize_simulcast_size_experiment_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/normalize_simulcast_size_experiment_gn/moz.build
-index 9c3e585bf9727..9f41518b202de 100644
+index 4f2adbf257..b299002d74 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/normalize_simulcast_size_experiment_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/normalize_simulcast_size_experiment_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5157,7 +5645,7 @@ index 9c3e585bf9727..9f41518b202de 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/quality_scaler_settings_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/quality_scaler_settings_gn/moz.build
-index d1b4330a18db7..9c69480dda61f 100644
+index 0d309eb7e4..4ab9dc0a1b 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/quality_scaler_settings_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/quality_scaler_settings_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5172,7 +5660,7 @@ index d1b4330a18db7..9c69480dda61f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/quality_scaling_experiment_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/quality_scaling_experiment_gn/moz.build
-index 8e75fbc3b0323..411e1effc53ad 100644
+index 59d541e6a0..6bd59f95b8 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/quality_scaling_experiment_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/quality_scaling_experiment_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5187,7 +5675,7 @@ index 8e75fbc3b0323..411e1effc53ad 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/rate_control_settings_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/rate_control_settings_gn/moz.build
-index 0051ac37f9e8d..f7be521b76bfd 100644
+index 34a32a0e0d..9c1bcac1ad 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/rate_control_settings_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/rate_control_settings_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5202,7 +5690,7 @@ index 0051ac37f9e8d..f7be521b76bfd 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/experiments/stable_target_rate_experiment_gn/moz.build b/third_party/libwebrtc/rtc_base/experiments/stable_target_rate_experiment_gn/moz.build
-index 2c239310fc087..5724d0c3a2c0f 100644
+index 90de4c0afe..1a5108c256 100644
 --- a/third_party/libwebrtc/rtc_base/experiments/stable_target_rate_experiment_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/experiments/stable_target_rate_experiment_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5217,7 +5705,7 @@ index 2c239310fc087..5724d0c3a2c0f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/frequency_tracker_gn/moz.build b/third_party/libwebrtc/rtc_base/frequency_tracker_gn/moz.build
-index 87a5e335eb061..eb2b13a9d5447 100644
+index d73e4f6d7f..418cf67071 100644
 --- a/third_party/libwebrtc/rtc_base/frequency_tracker_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/frequency_tracker_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5232,7 +5720,7 @@ index 87a5e335eb061..eb2b13a9d5447 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/gtest_prod_gn/moz.build b/third_party/libwebrtc/rtc_base/gtest_prod_gn/moz.build
-index 03bb1071f60c2..863c831e74a00 100644
+index 39f95b2ec8..736f4a0a5d 100644
 --- a/third_party/libwebrtc/rtc_base/gtest_prod_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/gtest_prod_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5247,7 +5735,7 @@ index 03bb1071f60c2..863c831e74a00 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/histogram_percentile_counter_gn/moz.build b/third_party/libwebrtc/rtc_base/histogram_percentile_counter_gn/moz.build
-index 3f7a2c1ffa1f0..c8feb06ebe2ae 100644
+index a9e54dfe82..4cd5b3b5e7 100644
 --- a/third_party/libwebrtc/rtc_base/histogram_percentile_counter_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/histogram_percentile_counter_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5262,7 +5750,7 @@ index 3f7a2c1ffa1f0..c8feb06ebe2ae 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/ignore_wundef_gn/moz.build b/third_party/libwebrtc/rtc_base/ignore_wundef_gn/moz.build
-index 06009fc8668e3..6928e5a8d0e3d 100644
+index c50706007b..1b0a2ad769 100644
 --- a/third_party/libwebrtc/rtc_base/ignore_wundef_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/ignore_wundef_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5277,7 +5765,7 @@ index 06009fc8668e3..6928e5a8d0e3d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/ip_address_gn/moz.build b/third_party/libwebrtc/rtc_base/ip_address_gn/moz.build
-index c2f9eb412bcaa..9be9bef95fc2a 100644
+index d7e6c9f293..646246bdb1 100644
 --- a/third_party/libwebrtc/rtc_base/ip_address_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/ip_address_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5292,7 +5780,7 @@ index c2f9eb412bcaa..9be9bef95fc2a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/logging_gn/moz.build b/third_party/libwebrtc/rtc_base/logging_gn/moz.build
-index 2b47ed986c72c..3caf6f16444e4 100644
+index 56ed104e20..4c6d7abac6 100644
 --- a/third_party/libwebrtc/rtc_base/logging_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/logging_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5307,7 +5795,7 @@ index 2b47ed986c72c..3caf6f16444e4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/macromagic_gn/moz.build b/third_party/libwebrtc/rtc_base/macromagic_gn/moz.build
-index 7a54f63695680..f0797ee8f7d2c 100644
+index 359df288f2..63870be4cb 100644
 --- a/third_party/libwebrtc/rtc_base/macromagic_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/macromagic_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5322,7 +5810,7 @@ index 7a54f63695680..f0797ee8f7d2c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/memory/aligned_malloc_gn/moz.build b/third_party/libwebrtc/rtc_base/memory/aligned_malloc_gn/moz.build
-index 06a17077bb825..21579b6836f3a 100644
+index d09905b698..42a562cd6e 100644
 --- a/third_party/libwebrtc/rtc_base/memory/aligned_malloc_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/memory/aligned_malloc_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5337,7 +5825,7 @@ index 06a17077bb825..21579b6836f3a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/mod_ops_gn/moz.build b/third_party/libwebrtc/rtc_base/mod_ops_gn/moz.build
-index ea25143a15aa4..bc55301f35567 100644
+index b65e15c66b..745e908c26 100644
 --- a/third_party/libwebrtc/rtc_base/mod_ops_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/mod_ops_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5352,7 +5840,7 @@ index ea25143a15aa4..bc55301f35567 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/moving_max_counter_gn/moz.build b/third_party/libwebrtc/rtc_base/moving_max_counter_gn/moz.build
-index 967e6e28ba29b..ee61c961c6efc 100644
+index f04b67d19d..e6cab14863 100644
 --- a/third_party/libwebrtc/rtc_base/moving_max_counter_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/moving_max_counter_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5367,7 +5855,7 @@ index 967e6e28ba29b..ee61c961c6efc 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/net_helpers_gn/moz.build b/third_party/libwebrtc/rtc_base/net_helpers_gn/moz.build
-index 7c0cfcf806a71..afcce9669ea0a 100644
+index db5cf7eda3..7d6a0c1eea 100644
 --- a/third_party/libwebrtc/rtc_base/net_helpers_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/net_helpers_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5382,7 +5870,7 @@ index 7c0cfcf806a71..afcce9669ea0a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/network/ecn_marking_gn/moz.build b/third_party/libwebrtc/rtc_base/network/ecn_marking_gn/moz.build
-index 9fb05f529e15e..fd974325cd73a 100644
+index 51dafd65f7..ff6d63a302 100644
 --- a/third_party/libwebrtc/rtc_base/network/ecn_marking_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/network/ecn_marking_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5397,7 +5885,7 @@ index 9fb05f529e15e..fd974325cd73a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/network/sent_packet_gn/moz.build b/third_party/libwebrtc/rtc_base/network/sent_packet_gn/moz.build
-index 604cb9a5e8c83..9720569e9f45c 100644
+index 3871a5742f..fa37216051 100644
 --- a/third_party/libwebrtc/rtc_base/network/sent_packet_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/network/sent_packet_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5412,7 +5900,7 @@ index 604cb9a5e8c83..9720569e9f45c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/network_constants_gn/moz.build b/third_party/libwebrtc/rtc_base/network_constants_gn/moz.build
-index eacf185197862..d86cc1dfdd322 100644
+index e016c6ebf3..fab30aea18 100644
 --- a/third_party/libwebrtc/rtc_base/network_constants_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/network_constants_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5427,7 +5915,7 @@ index eacf185197862..d86cc1dfdd322 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/network_route_gn/moz.build b/third_party/libwebrtc/rtc_base/network_route_gn/moz.build
-index 2ae8cf3c3837a..29577a4ef1019 100644
+index d36384ccc5..0632f66dd1 100644
 --- a/third_party/libwebrtc/rtc_base/network_route_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/network_route_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5442,7 +5930,7 @@ index 2ae8cf3c3837a..29577a4ef1019 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/null_socket_server_gn/moz.build b/third_party/libwebrtc/rtc_base/null_socket_server_gn/moz.build
-index da5eb5b49753a..0115b8aa67a4b 100644
+index 2d37973247..76935767b3 100644
 --- a/third_party/libwebrtc/rtc_base/null_socket_server_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/null_socket_server_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5457,7 +5945,7 @@ index da5eb5b49753a..0115b8aa67a4b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/one_time_event_gn/moz.build b/third_party/libwebrtc/rtc_base/one_time_event_gn/moz.build
-index 4de80444bef47..ba09c026e1a69 100644
+index e12f306d61..f8299c7070 100644
 --- a/third_party/libwebrtc/rtc_base/one_time_event_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/one_time_event_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5472,7 +5960,7 @@ index 4de80444bef47..ba09c026e1a69 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/platform_thread_gn/moz.build b/third_party/libwebrtc/rtc_base/platform_thread_gn/moz.build
-index 8c259b6765c4f..702a66b0487c7 100644
+index de9df4d78a..f14d554708 100644
 --- a/third_party/libwebrtc/rtc_base/platform_thread_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/platform_thread_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5487,7 +5975,7 @@ index 8c259b6765c4f..702a66b0487c7 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/platform_thread_types_gn/moz.build b/third_party/libwebrtc/rtc_base/platform_thread_types_gn/moz.build
-index 09d6147ce17dd..044a2a040a923 100644
+index fa305fd318..4267bc8917 100644
 --- a/third_party/libwebrtc/rtc_base/platform_thread_types_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/platform_thread_types_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5502,7 +5990,7 @@ index 09d6147ce17dd..044a2a040a923 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/protobuf_utils_gn/moz.build b/third_party/libwebrtc/rtc_base/protobuf_utils_gn/moz.build
-index c2b0d4ce2f3a7..77ed1ccd5d15a 100644
+index 89ac56a987..a2f9b43c7b 100644
 --- a/third_party/libwebrtc/rtc_base/protobuf_utils_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/protobuf_utils_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5517,7 +6005,7 @@ index c2b0d4ce2f3a7..77ed1ccd5d15a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/race_checker_gn/moz.build b/third_party/libwebrtc/rtc_base/race_checker_gn/moz.build
-index 1fef37a2babc7..646c506f7bda3 100644
+index 8fe24e9ea3..1fd412a127 100644
 --- a/third_party/libwebrtc/rtc_base/race_checker_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/race_checker_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5532,7 +6020,7 @@ index 1fef37a2babc7..646c506f7bda3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/random_gn/moz.build b/third_party/libwebrtc/rtc_base/random_gn/moz.build
-index 6c9b369317a56..b244cf3c63f95 100644
+index 3790744893..5eb27b7c0c 100644
 --- a/third_party/libwebrtc/rtc_base/random_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/random_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5547,7 +6035,7 @@ index 6c9b369317a56..b244cf3c63f95 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/rate_limiter_gn/moz.build b/third_party/libwebrtc/rtc_base/rate_limiter_gn/moz.build
-index 586fc513dc7e5..2383278249423 100644
+index 5329a3ecff..4cd2b1b74c 100644
 --- a/third_party/libwebrtc/rtc_base/rate_limiter_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/rate_limiter_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5562,7 +6050,7 @@ index 586fc513dc7e5..2383278249423 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/rate_statistics_gn/moz.build b/third_party/libwebrtc/rtc_base/rate_statistics_gn/moz.build
-index 76d4f9d980aee..89fc7b6c88d80 100644
+index dcf729ffe8..d3023fa86a 100644
 --- a/third_party/libwebrtc/rtc_base/rate_statistics_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/rate_statistics_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5577,7 +6065,7 @@ index 76d4f9d980aee..89fc7b6c88d80 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/rate_tracker_gn/moz.build b/third_party/libwebrtc/rtc_base/rate_tracker_gn/moz.build
-index c381e91cdc554..93793d6d9d69b 100644
+index 0c54b37a13..f705ec197f 100644
 --- a/third_party/libwebrtc/rtc_base/rate_tracker_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/rate_tracker_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5592,7 +6080,7 @@ index c381e91cdc554..93793d6d9d69b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/refcount_gn/moz.build b/third_party/libwebrtc/rtc_base/refcount_gn/moz.build
-index 4059c66e7135d..1d99acfc987a4 100644
+index 9f5c572f20..2f03f163cb 100644
 --- a/third_party/libwebrtc/rtc_base/refcount_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/refcount_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5607,7 +6095,7 @@ index 4059c66e7135d..1d99acfc987a4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/rolling_accumulator_gn/moz.build b/third_party/libwebrtc/rtc_base/rolling_accumulator_gn/moz.build
-index c8e14d5996e0c..624ceec102534 100644
+index 879a61c336..9be5da4aa9 100644
 --- a/third_party/libwebrtc/rtc_base/rolling_accumulator_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/rolling_accumulator_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5622,7 +6110,7 @@ index c8e14d5996e0c..624ceec102534 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/rtc_event_gn/moz.build b/third_party/libwebrtc/rtc_base/rtc_event_gn/moz.build
-index a1b2840da3ea2..8dd1830b2cccb 100644
+index 28da0c6981..af467cb246 100644
 --- a/third_party/libwebrtc/rtc_base/rtc_event_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/rtc_event_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5637,7 +6125,7 @@ index a1b2840da3ea2..8dd1830b2cccb 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/rtc_numerics_gn/moz.build b/third_party/libwebrtc/rtc_base/rtc_numerics_gn/moz.build
-index 6bcce7ecf591d..fab2c2acf14b1 100644
+index dc606f8e63..570d06207f 100644
 --- a/third_party/libwebrtc/rtc_base/rtc_numerics_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/rtc_numerics_gn/moz.build
 @@ -145,6 +145,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5652,7 +6140,7 @@ index 6bcce7ecf591d..fab2c2acf14b1 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/safe_compare_gn/moz.build b/third_party/libwebrtc/rtc_base/safe_compare_gn/moz.build
-index 1e381892f367d..1d20d4b9a8832 100644
+index 6bd90aff9d..4c5fd40a3d 100644
 --- a/third_party/libwebrtc/rtc_base/safe_compare_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/safe_compare_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5667,7 +6155,7 @@ index 1e381892f367d..1d20d4b9a8832 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/safe_conversions_gn/moz.build b/third_party/libwebrtc/rtc_base/safe_conversions_gn/moz.build
-index f409a3834780c..5de066b506b92 100644
+index 728f9986f5..3ad4ce1611 100644
 --- a/third_party/libwebrtc/rtc_base/safe_conversions_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/safe_conversions_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5682,7 +6170,7 @@ index f409a3834780c..5de066b506b92 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/safe_minmax_gn/moz.build b/third_party/libwebrtc/rtc_base/safe_minmax_gn/moz.build
-index 31299792ebebf..a702ead45989d 100644
+index 08d6ed5a08..ccb12cde91 100644
 --- a/third_party/libwebrtc/rtc_base/safe_minmax_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/safe_minmax_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5697,7 +6185,7 @@ index 31299792ebebf..a702ead45989d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/sample_counter_gn/moz.build b/third_party/libwebrtc/rtc_base/sample_counter_gn/moz.build
-index 0657de77c15bc..7387bc5630993 100644
+index bf6a8ed2ea..9b326e883f 100644
 --- a/third_party/libwebrtc/rtc_base/sample_counter_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/sample_counter_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5712,7 +6200,7 @@ index 0657de77c15bc..7387bc5630993 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/sanitizer_gn/moz.build b/third_party/libwebrtc/rtc_base/sanitizer_gn/moz.build
-index dcdcffdd8ef45..81c8160cff54f 100644
+index 10412ea91e..b00a4f1ce8 100644
 --- a/third_party/libwebrtc/rtc_base/sanitizer_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/sanitizer_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5727,7 +6215,7 @@ index dcdcffdd8ef45..81c8160cff54f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/socket_address_gn/moz.build b/third_party/libwebrtc/rtc_base/socket_address_gn/moz.build
-index 2e5c00378acd6..61b9d40f4d365 100644
+index a519752955..a5c5910e37 100644
 --- a/third_party/libwebrtc/rtc_base/socket_address_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/socket_address_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5742,7 +6230,7 @@ index 2e5c00378acd6..61b9d40f4d365 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/socket_factory_gn/moz.build b/third_party/libwebrtc/rtc_base/socket_factory_gn/moz.build
-index 572b2f62b08cc..65a197c45742a 100644
+index a7ffe7659d..5985c59599 100644
 --- a/third_party/libwebrtc/rtc_base/socket_factory_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/socket_factory_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5757,7 +6245,7 @@ index 572b2f62b08cc..65a197c45742a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/socket_gn/moz.build b/third_party/libwebrtc/rtc_base/socket_gn/moz.build
-index 4b08aeb0de918..710871916811f 100644
+index 25090bb71a..d4f5a5f72b 100644
 --- a/third_party/libwebrtc/rtc_base/socket_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/socket_gn/moz.build
 @@ -151,6 +151,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5772,7 +6260,7 @@ index 4b08aeb0de918..710871916811f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/socket_server_gn/moz.build b/third_party/libwebrtc/rtc_base/socket_server_gn/moz.build
-index d4654af6fc1f7..fbf7baddffa28 100644
+index c8422272d8..52de83238d 100644
 --- a/third_party/libwebrtc/rtc_base/socket_server_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/socket_server_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5787,7 +6275,7 @@ index d4654af6fc1f7..fbf7baddffa28 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/ssl_adapter_gn/moz.build b/third_party/libwebrtc/rtc_base/ssl_adapter_gn/moz.build
-index 599001039a487..d184a89973898 100644
+index 5918111073..4eed42fbea 100644
 --- a/third_party/libwebrtc/rtc_base/ssl_adapter_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/ssl_adapter_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5802,7 +6290,7 @@ index 599001039a487..d184a89973898 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/stringutils_gn/moz.build b/third_party/libwebrtc/rtc_base/stringutils_gn/moz.build
-index 5016b4fce0592..3bd638067b05f 100644
+index 75921a43ab..22c1666b2a 100644
 --- a/third_party/libwebrtc/rtc_base/stringutils_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/stringutils_gn/moz.build
 @@ -147,6 +147,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5816,8 +6304,23 @@ index 5016b4fce0592..3bd638067b05f 100644
  if CONFIG["TARGET_CPU"] == "mips32":
  
      DEFINES["MIPS32_LE"] = True
+diff --git a/third_party/libwebrtc/rtc_base/strong_alias_gn/moz.build b/third_party/libwebrtc/rtc_base/strong_alias_gn/moz.build
+index 04a9115ab9..33985429f0 100644
+--- a/third_party/libwebrtc/rtc_base/strong_alias_gn/moz.build
++++ b/third_party/libwebrtc/rtc_base/strong_alias_gn/moz.build
+@@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+     DEFINES["WEBRTC_ARCH_ARM_V7"] = True
+     DEFINES["WEBRTC_HAS_NEON"] = True
+ 
++if CONFIG["TARGET_CPU"] == "loongarch64":
++
++    DEFINES["_GNU_SOURCE"] = True
++
+ if CONFIG["TARGET_CPU"] == "mips32":
+ 
+     DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/swap_queue_gn/moz.build b/third_party/libwebrtc/rtc_base/swap_queue_gn/moz.build
-index b84cec9997f36..05d753843959a 100644
+index ca2c7814e8..e37cd370de 100644
 --- a/third_party/libwebrtc/rtc_base/swap_queue_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/swap_queue_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5832,7 +6335,7 @@ index b84cec9997f36..05d753843959a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/synchronization/mutex_gn/moz.build b/third_party/libwebrtc/rtc_base/synchronization/mutex_gn/moz.build
-index c1704d2629495..6b346305bbc0d 100644
+index b643fe459c..594e4321ea 100644
 --- a/third_party/libwebrtc/rtc_base/synchronization/mutex_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/synchronization/mutex_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5847,7 +6350,7 @@ index c1704d2629495..6b346305bbc0d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/synchronization/sequence_checker_internal_gn/moz.build b/third_party/libwebrtc/rtc_base/synchronization/sequence_checker_internal_gn/moz.build
-index e4f72d3635309..c3cf0e6275aac 100644
+index bb5927b75d..ac396e7d49 100644
 --- a/third_party/libwebrtc/rtc_base/synchronization/sequence_checker_internal_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/synchronization/sequence_checker_internal_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5862,7 +6365,7 @@ index e4f72d3635309..c3cf0e6275aac 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/synchronization/yield_gn/moz.build b/third_party/libwebrtc/rtc_base/synchronization/yield_gn/moz.build
-index 98232a67bd399..6c775aa652282 100644
+index 395ae6db1d..01ebb5d3b0 100644
 --- a/third_party/libwebrtc/rtc_base/synchronization/yield_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/synchronization/yield_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5877,7 +6380,7 @@ index 98232a67bd399..6c775aa652282 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/synchronization/yield_policy_gn/moz.build b/third_party/libwebrtc/rtc_base/synchronization/yield_policy_gn/moz.build
-index 40dcd7ba2f70e..0c08d9e2ba307 100644
+index 9b37438275..09b236427f 100644
 --- a/third_party/libwebrtc/rtc_base/synchronization/yield_policy_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/synchronization/yield_policy_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5892,7 +6395,7 @@ index 40dcd7ba2f70e..0c08d9e2ba307 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/system/arch_gn/moz.build b/third_party/libwebrtc/rtc_base/system/arch_gn/moz.build
-index 1d1555984fb07..7c795caae78c9 100644
+index eab84dd331..2c2693b224 100644
 --- a/third_party/libwebrtc/rtc_base/system/arch_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/system/arch_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5907,7 +6410,7 @@ index 1d1555984fb07..7c795caae78c9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/system/file_wrapper_gn/moz.build b/third_party/libwebrtc/rtc_base/system/file_wrapper_gn/moz.build
-index 807f4726e1026..0055ebd41ff05 100644
+index 4fa2a39958..21ffa1f6c2 100644
 --- a/third_party/libwebrtc/rtc_base/system/file_wrapper_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/system/file_wrapper_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5922,7 +6425,7 @@ index 807f4726e1026..0055ebd41ff05 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/system/ignore_warnings_gn/moz.build b/third_party/libwebrtc/rtc_base/system/ignore_warnings_gn/moz.build
-index 7a5b33257453f..42561daf5711b 100644
+index d807d9e45d..35743644d3 100644
 --- a/third_party/libwebrtc/rtc_base/system/ignore_warnings_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/system/ignore_warnings_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5937,7 +6440,7 @@ index 7a5b33257453f..42561daf5711b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/system/inline_gn/moz.build b/third_party/libwebrtc/rtc_base/system/inline_gn/moz.build
-index 7df25c5644f17..06e4935660aa5 100644
+index e427abf570..78f566d60b 100644
 --- a/third_party/libwebrtc/rtc_base/system/inline_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/system/inline_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5952,7 +6455,7 @@ index 7df25c5644f17..06e4935660aa5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/system/no_unique_address_gn/moz.build b/third_party/libwebrtc/rtc_base/system/no_unique_address_gn/moz.build
-index 17a93fe6bf50f..6d1e015fede37 100644
+index 8003a8f5e6..9c66fb6e6c 100644
 --- a/third_party/libwebrtc/rtc_base/system/no_unique_address_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/system/no_unique_address_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5967,7 +6470,7 @@ index 17a93fe6bf50f..6d1e015fede37 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/system/rtc_export_gn/moz.build b/third_party/libwebrtc/rtc_base/system/rtc_export_gn/moz.build
-index e0c1fd16dc3e2..396a651192e55 100644
+index d58855bc2c..e729cf85f6 100644
 --- a/third_party/libwebrtc/rtc_base/system/rtc_export_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/system/rtc_export_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5982,7 +6485,7 @@ index e0c1fd16dc3e2..396a651192e55 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/system/unused_gn/moz.build b/third_party/libwebrtc/rtc_base/system/unused_gn/moz.build
-index 11c7d7e1a9c32..7e5d26eabfb2c 100644
+index 14c87f46cf..14748b2962 100644
 --- a/third_party/libwebrtc/rtc_base/system/unused_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/system/unused_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -5997,7 +6500,7 @@ index 11c7d7e1a9c32..7e5d26eabfb2c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/system/warn_current_thread_is_deadlocked_gn/moz.build b/third_party/libwebrtc/rtc_base/system/warn_current_thread_is_deadlocked_gn/moz.build
-index 72142098bf1c4..94e93e2c94741 100644
+index 639589a852..3685f98223 100644
 --- a/third_party/libwebrtc/rtc_base/system/warn_current_thread_is_deadlocked_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/system/warn_current_thread_is_deadlocked_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6012,7 +6515,7 @@ index 72142098bf1c4..94e93e2c94741 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/task_utils/repeating_task_gn/moz.build b/third_party/libwebrtc/rtc_base/task_utils/repeating_task_gn/moz.build
-index b6057410da79c..e6ac836fe84e8 100644
+index 330b87a2f8..64cc25cd84 100644
 --- a/third_party/libwebrtc/rtc_base/task_utils/repeating_task_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/task_utils/repeating_task_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6027,7 +6530,7 @@ index b6057410da79c..e6ac836fe84e8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/third_party/base64/base64_gn/moz.build b/third_party/libwebrtc/rtc_base/third_party/base64/base64_gn/moz.build
-index cd7049d1e1ad1..ff094d9427734 100644
+index 813e85ca2e..02109571ff 100644
 --- a/third_party/libwebrtc/rtc_base/third_party/base64/base64_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/third_party/base64/base64_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6042,7 +6545,7 @@ index cd7049d1e1ad1..ff094d9427734 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/third_party/sigslot/sigslot_gn/moz.build b/third_party/libwebrtc/rtc_base/third_party/sigslot/sigslot_gn/moz.build
-index b4ca57145cffb..be9d399baf38b 100644
+index dc375810b3..58b2ab2e02 100644
 --- a/third_party/libwebrtc/rtc_base/third_party/sigslot/sigslot_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/third_party/sigslot/sigslot_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6057,7 +6560,7 @@ index b4ca57145cffb..be9d399baf38b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/threading_gn/moz.build b/third_party/libwebrtc/rtc_base/threading_gn/moz.build
-index 53ae39a12405f..679258f514ddd 100644
+index 56cbe529d1..2c8fb04588 100644
 --- a/third_party/libwebrtc/rtc_base/threading_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/threading_gn/moz.build
 @@ -170,6 +170,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6072,7 +6575,7 @@ index 53ae39a12405f..679258f514ddd 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/timeutils_gn/moz.build b/third_party/libwebrtc/rtc_base/timeutils_gn/moz.build
-index 55044da704f09..54b8976af8d06 100644
+index bb37032aff..a43a48fd04 100644
 --- a/third_party/libwebrtc/rtc_base/timeutils_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/timeutils_gn/moz.build
 @@ -152,6 +152,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6087,7 +6590,7 @@ index 55044da704f09..54b8976af8d06 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/type_traits_gn/moz.build b/third_party/libwebrtc/rtc_base/type_traits_gn/moz.build
-index 6e5a6266c98d0..bd1429ccb868f 100644
+index 1236cdcdc0..e6e91fb175 100644
 --- a/third_party/libwebrtc/rtc_base/type_traits_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/type_traits_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6102,7 +6605,7 @@ index 6e5a6266c98d0..bd1429ccb868f 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/unique_id_generator_gn/moz.build b/third_party/libwebrtc/rtc_base/unique_id_generator_gn/moz.build
-index 144e5ff789f9d..d96430b2e7807 100644
+index a3b15450a5..91dd02ba91 100644
 --- a/third_party/libwebrtc/rtc_base/unique_id_generator_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/unique_id_generator_gn/moz.build
 @@ -131,6 +131,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6117,7 +6620,7 @@ index 144e5ff789f9d..d96430b2e7807 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/units/unit_base_gn/moz.build b/third_party/libwebrtc/rtc_base/units/unit_base_gn/moz.build
-index 1a73da55be6de..ab73c96ec8a87 100644
+index 4bf43cc484..a9f6528204 100644
 --- a/third_party/libwebrtc/rtc_base/units/unit_base_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/units/unit_base_gn/moz.build
 @@ -135,6 +135,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6132,7 +6635,7 @@ index 1a73da55be6de..ab73c96ec8a87 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/weak_ptr_gn/moz.build b/third_party/libwebrtc/rtc_base/weak_ptr_gn/moz.build
-index 24bcc6accf790..2f76d89047de2 100644
+index cd3c1db313..1b48412e86 100644
 --- a/third_party/libwebrtc/rtc_base/weak_ptr_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/weak_ptr_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6147,7 +6650,7 @@ index 24bcc6accf790..2f76d89047de2 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/rtc_base/zero_memory_gn/moz.build b/third_party/libwebrtc/rtc_base/zero_memory_gn/moz.build
-index 3cb03f6879696..9a3495582c7a5 100644
+index bfff36ec02..7b5eb60689 100644
 --- a/third_party/libwebrtc/rtc_base/zero_memory_gn/moz.build
 +++ b/third_party/libwebrtc/rtc_base/zero_memory_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6162,7 +6665,7 @@ index 3cb03f6879696..9a3495582c7a5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/system_wrappers/denormal_disabler_gn/moz.build b/third_party/libwebrtc/system_wrappers/denormal_disabler_gn/moz.build
-index cd0bc1b144b83..6bfcafef69be3 100644
+index e112c4874c..2a83b4c6e5 100644
 --- a/third_party/libwebrtc/system_wrappers/denormal_disabler_gn/moz.build
 +++ b/third_party/libwebrtc/system_wrappers/denormal_disabler_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6177,7 +6680,7 @@ index cd0bc1b144b83..6bfcafef69be3 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/system_wrappers/field_trial_gn/moz.build b/third_party/libwebrtc/system_wrappers/field_trial_gn/moz.build
-index 30aa20ae3ede5..1a9247571a3b5 100644
+index 460a3a1137..fe7d699a57 100644
 --- a/third_party/libwebrtc/system_wrappers/field_trial_gn/moz.build
 +++ b/third_party/libwebrtc/system_wrappers/field_trial_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6192,7 +6695,7 @@ index 30aa20ae3ede5..1a9247571a3b5 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/system_wrappers/metrics_gn/moz.build b/third_party/libwebrtc/system_wrappers/metrics_gn/moz.build
-index 2347fbcbacf53..64db8cecaa80e 100644
+index 29156ca219..8ab3e074dc 100644
 --- a/third_party/libwebrtc/system_wrappers/metrics_gn/moz.build
 +++ b/third_party/libwebrtc/system_wrappers/metrics_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6207,7 +6710,7 @@ index 2347fbcbacf53..64db8cecaa80e 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/system_wrappers/system_wrappers_gn/moz.build b/third_party/libwebrtc/system_wrappers/system_wrappers_gn/moz.build
-index 161fe336d913c..65d379234a186 100644
+index 02d7c603b9..969a57e972 100644
 --- a/third_party/libwebrtc/system_wrappers/system_wrappers_gn/moz.build
 +++ b/third_party/libwebrtc/system_wrappers/system_wrappers_gn/moz.build
 @@ -168,6 +168,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6222,7 +6725,7 @@ index 161fe336d913c..65d379234a186 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/test/network/simulated_network_gn/moz.build b/third_party/libwebrtc/test/network/simulated_network_gn/moz.build
-index 26939945bfb98..9ccc1b5e02f2d 100644
+index bedfa0c56d..307fe40fa1 100644
 --- a/third_party/libwebrtc/test/network/simulated_network_gn/moz.build
 +++ b/third_party/libwebrtc/test/network/simulated_network_gn/moz.build
 @@ -143,6 +143,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6237,7 +6740,7 @@ index 26939945bfb98..9ccc1b5e02f2d 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/test/rtp_test_utils_gn/moz.build b/third_party/libwebrtc/test/rtp_test_utils_gn/moz.build
-index 5a0d4a3984ef3..4ea4016ab1fce 100644
+index 8ce02c0e89..c7f19a51f7 100644
 --- a/third_party/libwebrtc/test/rtp_test_utils_gn/moz.build
 +++ b/third_party/libwebrtc/test/rtp_test_utils_gn/moz.build
 @@ -147,6 +147,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6251,443 +6754,8 @@ index 5a0d4a3984ef3..4ea4016ab1fce 100644
  if CONFIG["TARGET_CPU"] == "mips32":
  
      DEFINES["MIPS32_LE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/algorithm/algorithm_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/algorithm/algorithm_gn/moz.build
-index 696c19c0a0908..8fe6e8be0139f 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/algorithm/algorithm_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/algorithm/algorithm_gn/moz.build
-@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
-     DEFINES["_WINDOWS"] = True
-     DEFINES["__STD_C"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/algorithm/container_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/algorithm/container_gn/moz.build
-index 376a6873a7de1..e6157f2d3e2bb 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/algorithm/container_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/algorithm/container_gn/moz.build
-@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
-     DEFINES["_WINDOWS"] = True
-     DEFINES["__STD_C"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/atomic_hook_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/atomic_hook_gn/moz.build
-index 1dbf8b3037110..7cf1035a0bf2d 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/atomic_hook_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/atomic_hook_gn/moz.build
-@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
-     DEFINES["_WINDOWS"] = True
-     DEFINES["__STD_C"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/base_internal_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/base_internal_gn/moz.build
-index c74d13c51a7fd..04eb10e737168 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/base_internal_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/base_internal_gn/moz.build
-@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
-     DEFINES["_WINDOWS"] = True
-     DEFINES["__STD_C"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/config_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/config_gn/moz.build
-index 5cd792ccd5d26..f01a3d7920fab 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/config_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/config_gn/moz.build
-@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
-     DEFINES["_WINDOWS"] = True
-     DEFINES["__STD_C"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/core_headers_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/core_headers_gn/moz.build
-index 26296e769d534..8e63fb471ea10 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/core_headers_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/core_headers_gn/moz.build
-@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
-     DEFINES["_WINDOWS"] = True
-     DEFINES["__STD_C"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/log_severity_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/log_severity_gn/moz.build
-index 284ba12620092..25693df8caa18 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/log_severity_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/log_severity_gn/moz.build
-@@ -101,6 +101,10 @@ if CONFIG["TARGET_CPU"] == "arm":
-         "-mfpu=neon"
-     ]
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/nullability_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/nullability_gn/moz.build
-index f152e046ce649..bcbd06dea2621 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/nullability_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/nullability_gn/moz.build
-@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
-     DEFINES["_WINDOWS"] = True
-     DEFINES["__STD_C"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/raw_logging_internal_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/raw_logging_internal_gn/moz.build
-index 67100a47728f6..bc4df9942bdf5 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/raw_logging_internal_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/raw_logging_internal_gn/moz.build
-@@ -101,6 +101,10 @@ if CONFIG["TARGET_CPU"] == "arm":
-         "-mfpu=neon"
-     ]
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/throw_delegate_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/throw_delegate_gn/moz.build
-index 06b91ef80d221..c89bb5e994930 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/base/throw_delegate_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/base/throw_delegate_gn/moz.build
-@@ -101,6 +101,10 @@ if CONFIG["TARGET_CPU"] == "arm":
-         "-mfpu=neon"
-     ]
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/cleanup/cleanup_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/cleanup/cleanup_gn/moz.build
-index 8ed66c3ce2c63..ca4101d72c102 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/cleanup/cleanup_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/cleanup/cleanup_gn/moz.build
-@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
-     DEFINES["_WINDOWS"] = True
-     DEFINES["__STD_C"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/cleanup/cleanup_internal_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/cleanup/cleanup_internal_gn/moz.build
-index 0f3944e348c4c..0e30135bbb61f 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/cleanup/cleanup_internal_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/cleanup/cleanup_internal_gn/moz.build
-@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
-     DEFINES["_WINDOWS"] = True
-     DEFINES["__STD_C"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/container/compressed_tuple_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/container/compressed_tuple_gn/moz.build
-index 758e27e19bdfe..ebac3923d8848 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/container/compressed_tuple_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/container/compressed_tuple_gn/moz.build
-@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
-     DEFINES["_WINDOWS"] = True
-     DEFINES["__STD_C"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/container/inlined_vector_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/container/inlined_vector_gn/moz.build
-index 0aeeb25380b2e..8095e437b2435 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/container/inlined_vector_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/container/inlined_vector_gn/moz.build
-@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
-     DEFINES["_WINDOWS"] = True
-     DEFINES["__STD_C"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/container/inlined_vector_internal_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/container/inlined_vector_internal_gn/moz.build
-index 3b6744eda7335..8c6de006b5c3f 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/container/inlined_vector_internal_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/container/inlined_vector_internal_gn/moz.build
-@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
-     DEFINES["_WINDOWS"] = True
-     DEFINES["__STD_C"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/functional/any_invocable_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/functional/any_invocable_gn/moz.build
-index 63e6206cdfb47..2af18da4caf1f 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/functional/any_invocable_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/functional/any_invocable_gn/moz.build
-@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
-     DEFINES["_WINDOWS"] = True
-     DEFINES["__STD_C"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/functional/bind_front_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/functional/bind_front_gn/moz.build
-index c26f1ed6a4812..64f2808f3c904 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/functional/bind_front_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/functional/bind_front_gn/moz.build
-@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
-     DEFINES["_WINDOWS"] = True
-     DEFINES["__STD_C"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/memory/memory_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/memory/memory_gn/moz.build
-index 398b663a3d1ea..6e8505c311784 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/memory/memory_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/memory/memory_gn/moz.build
-@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
-     DEFINES["_WINDOWS"] = True
-     DEFINES["__STD_C"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/meta/type_traits_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/meta/type_traits_gn/moz.build
-index 6d2e55152f525..67080088dd359 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/meta/type_traits_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/meta/type_traits_gn/moz.build
-@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
-     DEFINES["_WINDOWS"] = True
-     DEFINES["__STD_C"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/numeric/bits_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/numeric/bits_gn/moz.build
-index 765dc92eb6d30..3aaddd05a899c 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/numeric/bits_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/numeric/bits_gn/moz.build
-@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
-     DEFINES["_WINDOWS"] = True
-     DEFINES["__STD_C"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/numeric/int128_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/numeric/int128_gn/moz.build
-index 0d1a183abaf9f..f6a72bb07e575 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/numeric/int128_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/numeric/int128_gn/moz.build
-@@ -101,6 +101,10 @@ if CONFIG["TARGET_CPU"] == "arm":
-         "-mfpu=neon"
-     ]
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/strings/string_view_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/strings/string_view_gn/moz.build
-index 4002fa6263030..62943daaa9896 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/strings/string_view_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/strings/string_view_gn/moz.build
-@@ -101,6 +101,10 @@ if CONFIG["TARGET_CPU"] == "arm":
-         "-mfpu=neon"
-     ]
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/strings/strings_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/strings/strings_gn/moz.build
-index 8105bb2f27d1d..789fb9bc7cd6e 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/strings/strings_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/strings/strings_gn/moz.build
-@@ -106,6 +106,10 @@ if CONFIG["TARGET_CPU"] == "arm":
-         "-mfpu=neon"
-     ]
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/bad_optional_access_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/bad_optional_access_gn/moz.build
-index 25164c3e5f91b..2c5d7f3de36b2 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/bad_optional_access_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/bad_optional_access_gn/moz.build
-@@ -101,6 +101,10 @@ if CONFIG["TARGET_CPU"] == "arm":
-         "-mfpu=neon"
-     ]
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/bad_variant_access_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/bad_variant_access_gn/moz.build
-index 83007237aa435..448a79a6f908e 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/bad_variant_access_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/bad_variant_access_gn/moz.build
-@@ -101,6 +101,10 @@ if CONFIG["TARGET_CPU"] == "arm":
-         "-mfpu=neon"
-     ]
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/optional_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/optional_gn/moz.build
-index 890fa95dc8507..b399b73c72bcc 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/optional_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/optional_gn/moz.build
-@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
-     DEFINES["_WINDOWS"] = True
-     DEFINES["__STD_C"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/span_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/span_gn/moz.build
-index 438c3e8f7ca61..f64a2b73bf2ad 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/span_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/span_gn/moz.build
-@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
-     DEFINES["_WINDOWS"] = True
-     DEFINES["__STD_C"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/variant_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/variant_gn/moz.build
-index b548c0214b550..dc3a973fe547a 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/types/variant_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/types/variant_gn/moz.build
-@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
-     DEFINES["_WINDOWS"] = True
-     DEFINES["__STD_C"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
-diff --git a/third_party/libwebrtc/third_party/abseil-cpp/absl/utility/utility_gn/moz.build b/third_party/libwebrtc/third_party/abseil-cpp/absl/utility/utility_gn/moz.build
-index c47e6649127c3..6738c524bc3ad 100644
---- a/third_party/libwebrtc/third_party/abseil-cpp/absl/utility/utility_gn/moz.build
-+++ b/third_party/libwebrtc/third_party/abseil-cpp/absl/utility/utility_gn/moz.build
-@@ -91,6 +91,10 @@ if CONFIG["OS_TARGET"] == "WINNT":
-     DEFINES["_WINDOWS"] = True
-     DEFINES["__STD_C"] = True
- 
-+if CONFIG["TARGET_CPU"] == "loongarch64":
-+
-+    DEFINES["_GNU_SOURCE"] = True
-+
- if CONFIG["TARGET_CPU"] == "mips32":
- 
-     DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/third_party/libyuv/libyuv_gn/moz.build b/third_party/libwebrtc/third_party/libyuv/libyuv_gn/moz.build
-index a3038e0c4a61a..b7f3404ef0e7c 100644
+index 32e84e422d..c189baeda4 100644
 --- a/third_party/libwebrtc/third_party/libyuv/libyuv_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/libyuv/libyuv_gn/moz.build
 @@ -133,6 +133,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6702,7 +6770,7 @@ index a3038e0c4a61a..b7f3404ef0e7c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/third_party/pffft/pffft_gn/moz.build b/third_party/libwebrtc/third_party/pffft/pffft_gn/moz.build
-index 836a04a7c7234..dc7c06ffc21f6 100644
+index 836a04a7c7..dc7c06ffc2 100644
 --- a/third_party/libwebrtc/third_party/pffft/pffft_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/pffft/pffft_gn/moz.build
 @@ -105,6 +105,11 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6718,7 +6786,7 @@ index 836a04a7c7234..dc7c06ffc21f6 100644
  
      DEFINES["PFFFT_SIMD_DISABLE"] = True
 diff --git a/third_party/libwebrtc/third_party/rnnoise/rnn_vad_gn/moz.build b/third_party/libwebrtc/third_party/rnnoise/rnn_vad_gn/moz.build
-index b10b4c330ef81..2dfd79a68cf7a 100644
+index b10b4c330e..2dfd79a68c 100644
 --- a/third_party/libwebrtc/third_party/rnnoise/rnn_vad_gn/moz.build
 +++ b/third_party/libwebrtc/third_party/rnnoise/rnn_vad_gn/moz.build
 @@ -104,6 +104,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6733,7 +6801,7 @@ index b10b4c330ef81..2dfd79a68cf7a 100644
  
      DEFINES["_GNU_SOURCE"] = True
 diff --git a/third_party/libwebrtc/video/adaptation/video_adaptation_gn/moz.build b/third_party/libwebrtc/video/adaptation/video_adaptation_gn/moz.build
-index 54334034a2908..a361d16f18130 100644
+index 92db0ecf14..733ad9677d 100644
 --- a/third_party/libwebrtc/video/adaptation/video_adaptation_gn/moz.build
 +++ b/third_party/libwebrtc/video/adaptation/video_adaptation_gn/moz.build
 @@ -163,6 +163,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6748,7 +6816,7 @@ index 54334034a2908..a361d16f18130 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/config/encoder_config_gn/moz.build b/third_party/libwebrtc/video/config/encoder_config_gn/moz.build
-index 605a6b14f7f5c..dfe435da93a7a 100644
+index 25d4e52bc2..4458ec919c 100644
 --- a/third_party/libwebrtc/video/config/encoder_config_gn/moz.build
 +++ b/third_party/libwebrtc/video/config/encoder_config_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6763,7 +6831,7 @@ index 605a6b14f7f5c..dfe435da93a7a 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/config/streams_config_gn/moz.build b/third_party/libwebrtc/video/config/streams_config_gn/moz.build
-index 3014de4682043..83fb010b0b8a8 100644
+index 84750d67a3..60e1adc086 100644
 --- a/third_party/libwebrtc/video/config/streams_config_gn/moz.build
 +++ b/third_party/libwebrtc/video/config/streams_config_gn/moz.build
 @@ -156,6 +156,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6778,7 +6846,7 @@ index 3014de4682043..83fb010b0b8a8 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/decode_synchronizer_gn/moz.build b/third_party/libwebrtc/video/decode_synchronizer_gn/moz.build
-index c1ae808ab1bbf..ff744edf9a7e9 100644
+index e5b92baba4..318312bb2e 100644
 --- a/third_party/libwebrtc/video/decode_synchronizer_gn/moz.build
 +++ b/third_party/libwebrtc/video/decode_synchronizer_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6793,7 +6861,7 @@ index c1ae808ab1bbf..ff744edf9a7e9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/frame_cadence_adapter_gn/moz.build b/third_party/libwebrtc/video/frame_cadence_adapter_gn/moz.build
-index 6e073f2e20c88..e0c3d716a8179 100644
+index 5817a5b68a..70b60938e7 100644
 --- a/third_party/libwebrtc/video/frame_cadence_adapter_gn/moz.build
 +++ b/third_party/libwebrtc/video/frame_cadence_adapter_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6808,7 +6876,7 @@ index 6e073f2e20c88..e0c3d716a8179 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/frame_decode_scheduler_gn/moz.build b/third_party/libwebrtc/video/frame_decode_scheduler_gn/moz.build
-index dfe1ecd08c0cd..4f39955e9f382 100644
+index ae358f5489..e6d728e268 100644
 --- a/third_party/libwebrtc/video/frame_decode_scheduler_gn/moz.build
 +++ b/third_party/libwebrtc/video/frame_decode_scheduler_gn/moz.build
 @@ -146,6 +146,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6823,7 +6891,7 @@ index dfe1ecd08c0cd..4f39955e9f382 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/frame_decode_timing_gn/moz.build b/third_party/libwebrtc/video/frame_decode_timing_gn/moz.build
-index f1b85291c7701..2754fa11c1634 100644
+index 0deade49e8..023979923b 100644
 --- a/third_party/libwebrtc/video/frame_decode_timing_gn/moz.build
 +++ b/third_party/libwebrtc/video/frame_decode_timing_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6838,7 +6906,7 @@ index f1b85291c7701..2754fa11c1634 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/frame_dumping_decoder_gn/moz.build b/third_party/libwebrtc/video/frame_dumping_decoder_gn/moz.build
-index 001433ce9ffec..9338f84a50f2c 100644
+index 8129c6209e..f16ee7de50 100644
 --- a/third_party/libwebrtc/video/frame_dumping_decoder_gn/moz.build
 +++ b/third_party/libwebrtc/video/frame_dumping_decoder_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6853,7 +6921,7 @@ index 001433ce9ffec..9338f84a50f2c 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/frame_dumping_encoder_gn/moz.build b/third_party/libwebrtc/video/frame_dumping_encoder_gn/moz.build
-index a3bf0c641a1dd..27a5d945deabc 100644
+index 25b047e379..4bb8d34042 100644
 --- a/third_party/libwebrtc/video/frame_dumping_encoder_gn/moz.build
 +++ b/third_party/libwebrtc/video/frame_dumping_encoder_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6868,7 +6936,7 @@ index a3bf0c641a1dd..27a5d945deabc 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/render/incoming_video_stream_gn/moz.build b/third_party/libwebrtc/video/render/incoming_video_stream_gn/moz.build
-index 42488b31f3f81..721ef67ace649 100644
+index 1669990518..88255d201e 100644
 --- a/third_party/libwebrtc/video/render/incoming_video_stream_gn/moz.build
 +++ b/third_party/libwebrtc/video/render/incoming_video_stream_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6883,7 +6951,7 @@ index 42488b31f3f81..721ef67ace649 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/render/video_render_frames_gn/moz.build b/third_party/libwebrtc/video/render/video_render_frames_gn/moz.build
-index 24bd462a0c8ef..c4709991ec748 100644
+index 6a9ad8451a..d7c9f30c4c 100644
 --- a/third_party/libwebrtc/video/render/video_render_frames_gn/moz.build
 +++ b/third_party/libwebrtc/video/render/video_render_frames_gn/moz.build
 @@ -150,6 +150,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6898,7 +6966,7 @@ index 24bd462a0c8ef..c4709991ec748 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/task_queue_frame_decode_scheduler_gn/moz.build b/third_party/libwebrtc/video/task_queue_frame_decode_scheduler_gn/moz.build
-index d1ee8ffccb724..1bae2bfe1b1fd 100644
+index b2df93f203..ecfe1039e6 100644
 --- a/third_party/libwebrtc/video/task_queue_frame_decode_scheduler_gn/moz.build
 +++ b/third_party/libwebrtc/video/task_queue_frame_decode_scheduler_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6913,7 +6981,7 @@ index d1ee8ffccb724..1bae2bfe1b1fd 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/unique_timestamp_counter_gn/moz.build b/third_party/libwebrtc/video/unique_timestamp_counter_gn/moz.build
-index b0eb431cfba75..636f41f80f9ea 100644
+index edd42aa502..40c35a89cf 100644
 --- a/third_party/libwebrtc/video/unique_timestamp_counter_gn/moz.build
 +++ b/third_party/libwebrtc/video/unique_timestamp_counter_gn/moz.build
 @@ -139,6 +139,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6928,7 +6996,7 @@ index b0eb431cfba75..636f41f80f9ea 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/video_gn/moz.build b/third_party/libwebrtc/video/video_gn/moz.build
-index 09826d37f927c..3ca669afab8b4 100644
+index 73a0749f29..f5efc5419d 100644
 --- a/third_party/libwebrtc/video/video_gn/moz.build
 +++ b/third_party/libwebrtc/video/video_gn/moz.build
 @@ -174,6 +174,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6943,7 +7011,7 @@ index 09826d37f927c..3ca669afab8b4 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/video_receive_stream_timeout_tracker_gn/moz.build b/third_party/libwebrtc/video/video_receive_stream_timeout_tracker_gn/moz.build
-index d24bf03a5991f..f29c6509d473b 100644
+index 2ddf1cba30..cbddf5e9f5 100644
 --- a/third_party/libwebrtc/video/video_receive_stream_timeout_tracker_gn/moz.build
 +++ b/third_party/libwebrtc/video/video_receive_stream_timeout_tracker_gn/moz.build
 @@ -154,6 +154,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6958,7 +7026,7 @@ index d24bf03a5991f..f29c6509d473b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/video_stream_buffer_controller_gn/moz.build b/third_party/libwebrtc/video/video_stream_buffer_controller_gn/moz.build
-index b99c992d4953d..bb35fd9f657ac 100644
+index f86dbd03a9..7e1915cfd5 100644
 --- a/third_party/libwebrtc/video/video_stream_buffer_controller_gn/moz.build
 +++ b/third_party/libwebrtc/video/video_stream_buffer_controller_gn/moz.build
 @@ -155,6 +155,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -6973,10 +7041,10 @@ index b99c992d4953d..bb35fd9f657ac 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/video_stream_encoder_impl_gn/moz.build b/third_party/libwebrtc/video/video_stream_encoder_impl_gn/moz.build
-index a51248556ab13..7e4144879dd4b 100644
+index 2c9ea4a7d6..f16aaabd07 100644
 --- a/third_party/libwebrtc/video/video_stream_encoder_impl_gn/moz.build
 +++ b/third_party/libwebrtc/video/video_stream_encoder_impl_gn/moz.build
-@@ -160,6 +160,10 @@ if CONFIG["TARGET_CPU"] == "arm":
+@@ -163,6 +163,10 @@ if CONFIG["TARGET_CPU"] == "arm":
      DEFINES["WEBRTC_ARCH_ARM_V7"] = True
      DEFINES["WEBRTC_HAS_NEON"] = True
  
@@ -6988,7 +7056,7 @@ index a51248556ab13..7e4144879dd4b 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/video/video_stream_encoder_interface_gn/moz.build b/third_party/libwebrtc/video/video_stream_encoder_interface_gn/moz.build
-index 7eeb5d9f42031..e56f626416bc9 100644
+index 68109330f1..1e2b0a8a1a 100644
 --- a/third_party/libwebrtc/video/video_stream_encoder_interface_gn/moz.build
 +++ b/third_party/libwebrtc/video/video_stream_encoder_interface_gn/moz.build
 @@ -142,6 +142,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7003,7 +7071,7 @@ index 7eeb5d9f42031..e56f626416bc9 100644
  
      DEFINES["MIPS32_LE"] = True
 diff --git a/third_party/libwebrtc/webrtc_gn/moz.build b/third_party/libwebrtc/webrtc_gn/moz.build
-index 0a5908916a503..4ba08802c685c 100644
+index 50e90f5868..c8498f563f 100644
 --- a/third_party/libwebrtc/webrtc_gn/moz.build
 +++ b/third_party/libwebrtc/webrtc_gn/moz.build
 @@ -170,6 +170,10 @@ if CONFIG["TARGET_CPU"] == "arm":
@@ -7017,6 +7085,3 @@ index 0a5908916a503..4ba08802c685c 100644
  if CONFIG["TARGET_CPU"] == "mips32":
  
      DEFINES["MIPS32_LE"] = True
--- 
-2.45.2
-

--- a/firefox-developer-edition/loong.patch
+++ b/firefox-developer-edition/loong.patch
@@ -1,19 +1,21 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 7dd56a8..3a8d3eb 100644
+index 24108d3..ea5a09c 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -113,6 +113,20 @@ prepare() {
+@@ -112,6 +112,22 @@ prepare() {
    patch -Np1 -i ../firefox-install-dir.patch
  
    echo -n "$_google_api_key" >google-api-key
 +  
 +  # Patches for loong64
 +  patch -Np1 -i ../0001-Add-support-for-LoongArch64.patch
++  patch -Np1 -i ../0002-update-skia-generate_mozbuild.py-to-fix-lasx.patch
 +  patch -Np1 -i ../0003-update-gn_processor.py-to-support-linux-on-loong64.patch
 +  patch -Np1 -i ../0004-Re-generate-libwebrtc-moz.build-files.patch
 +  patch -Np1 -i ../0005-enable-webrtc-for-loongarch64-in-toolkit-moz.configu.patch
 +  patch -Np1 -i ../0006-Fix-libyuv-unified-source-and-LoongArch-SIMD-build.patch
 +  patch -Np1 -i ../0011-Add-missing-loongarch-lsx-code-for-libpng.patch
++  patch -Np1 -i ../Fix-virtual-environment-sysconfig-path-calculation.patch
 +
 +  # Add ` -mcmodel=medium` to CFLAGS etc.
 +  # to avoid `relocation R_LARCH_B26 overflow`
@@ -23,7 +25,7 @@ index 7dd56a8..3a8d3eb 100644
  
    cat >../mozconfig <<END
  ac_add_options --enable-application=browser
-@@ -125,7 +139,6 @@ ac_add_options --enable-optimize
+@@ -124,7 +140,6 @@ ac_add_options --enable-optimize
  ac_add_options --enable-rust-simd
  ac_add_options --enable-linker=lld
  ac_add_options --disable-install-strip
@@ -31,7 +33,7 @@ index 7dd56a8..3a8d3eb 100644
  ac_add_options --disable-bootstrap
  ac_add_options --with-wasi-sysroot=/usr/share/wasi-sysroot
  
-@@ -151,7 +164,7 @@ ac_add_options --with-system-nss
+@@ -150,7 +165,7 @@ ac_add_options --with-system-nss
  # Features
  ac_add_options --enable-alsa
  ac_add_options --enable-jack
@@ -40,27 +42,33 @@ index 7dd56a8..3a8d3eb 100644
  ac_add_options --disable-updater
  ac_add_options --disable-tests
  END
-@@ -286,4 +299,23 @@ Version=2
+@@ -285,4 +300,29 @@ Version=2
  END
  }
  
 +source+=('0001-Add-support-for-LoongArch64.patch'
++         '0002-update-skia-generate_mozbuild.py-to-fix-lasx.patch'
 +         '0003-update-gn_processor.py-to-support-linux-on-loong64.patch'
 +         '0004-Re-generate-libwebrtc-moz.build-files.patch'
 +         '0005-enable-webrtc-for-loongarch64-in-toolkit-moz.configu.patch'
 +         '0006-Fix-libyuv-unified-source-and-LoongArch-SIMD-build.patch'
-+         '0011-Add-missing-loongarch-lsx-code-for-libpng.patch')
-+sha256sums+=('348e1a20000db9fac4715580581163495de4380d446ab01177671719b41082b3'
++         '0011-Add-missing-loongarch-lsx-code-for-libpng.patch'
++         'Fix-virtual-environment-sysconfig-path-calculation.patch::https://d2mfgivbiy2fiw.cloudfront.net/file/data/pxz4qctdxdsbqgpugrpq/PHID-FILE-3h4o67ucyhtrw3ov4jkb/D231480.1736391766.diff')
++sha256sums+=('5e02e377cd857844ef06ab83acb93261a7198349a9ebf57324b03088fe0a264b'
++             'cb107d68f2ea8e01bb1597f83739963dbba5dd8889ae90b9f18c7321a91178f5'
 +             '5c29035ab562b0f722b1975f02def279f3cccf3fd3d153c6e54126289b095c99'
-+             'd0ef34bade8bed6072166eafc651b0703f90732f257215390421adb76c96e2b3'
++             'd205c7d8252fb15b750d1f950fb4b4fe52049d16538570e61b0f1f2ee3a6e535'
 +             '9bd75fce6d86d5d755e6ab047e7eaa39f87a19e596ee20e3f6c03cd4c4a7d348'
 +             '62574c6426173eebd80d4676ede30214050e2b6be87e293f906aaba85214b277'
-+             'da6733b8ca23d9de4f4c2ee1ff2bdc111128da4ec403e385bb576f2e229d1f6e')
-+b2sums+=('28f29b1fe9f8f2a80f9ea5ddebd459c21f54ee0523bd5781888d213945333613c963abbab175ca8a2386270d0caaaa0f247c26f725a2695fb520ef5f094f978d'
++             'da6733b8ca23d9de4f4c2ee1ff2bdc111128da4ec403e385bb576f2e229d1f6e'
++             'ce87b2337cdbd4839b89a5c1809eb6c4a0abdf41c645b7f11d4f375e3151625c')
++b2sums+=('53df7ac4d378e2d666cf36f4f8dccce1591d0f76f1fe37d3a542968fdb73b501a44163b663f8a3a7f59a20ec10369af78f9a84d454cbd3b544f6f1a4d4d23967'
++         'b9d3c120a9427d8b5bb1534f81cc54f40f20f75893ed2f7ac54a291ab05f73591a068c3ba1be720276ef13921e4f3542e7cdc82a0a953e42f72df1703125b6b1'
 +         '178bb4227daadd9c6872cc3ed0c795257023fadd8e5572e28a1c6f0825066be4e6fbb23bd3b67f7883645ac6dd567aeacdff20e383ba3482860852d256d7a75e'
-+         '0495057c581f405b08b28debfaf2f98801b1a7344269985f7660fa803ca2caa8b55427d406b22684ee5980faac3dfb3de763e5b3ff892cc9b1487a21ae2c2f7f'
++         '99cd33c62fb900d46519f658834ecbf8a6237f6ad82c3a64e6bb6706a7d20ac8662518114f3f966ef4666d24c2f3906409da52af3875b357c402b5722b945b20'
 +         '8fead507b6662bb2c0bdc85a55c9ce0d7780376235adff616f0aa0fa7c9121d57bebbbbd996a75e129f92478fe41fae17948a887ca5f45d24284a243ee3048a5'
 +         '814ee097d8539a7170f099ce1d3e2350ca6f2b8b7a252b4abfca0065d78d463773fb1f64014d7869fe3916ba20286f0e9612b8700c8b0a8410e0ee0a85236bf1'
-+         '4b0f39835f67b6b1ab120f4cb038e1afd169b84b4f8bf18b669468b6ac3543de3e131947aca616ca5db6f9cb0f97c58dd6115af9c0138a41f5f990a5b6e304c7')
++         '4b0f39835f67b6b1ab120f4cb038e1afd169b84b4f8bf18b669468b6ac3543de3e131947aca616ca5db6f9cb0f97c58dd6115af9c0138a41f5f990a5b6e304c7'
++         '09403862d7c72ce2a91e786138ab6da5fe76dad0b2e66ce91c4bcefd651e00633f8e91cd7da7c62bd0c7153dddf4a86c12c4a8aabbbc219f393a856fe0c17b0f')
 +
  # vim:set sw=2 sts=-1 et:


### PR DESCRIPTION
* Rebase to the new source
* Fix missing source in skia's generate_mozbuild.py and moz.build
* Fix build with python 3.13