### PR TITLE
addpatch: hedgedoc, ver=1.9.9-2

### DIFF
--- a/hedgedoc/loong.patch
+++ b/hedgedoc/loong.patch
@@ -1,0 +1,11 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index c555a4b..4c4a71a 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -131,3 +131,6 @@ package() {
+   # Install systemd service file.
+   install -Dm0644 -t "${pkgdir}/usr/lib/systemd/system/" "${srcdir}"/hedgedoc.service
+ }
++
++depends=(${depends[@]/'nodejs'/'nodejs-lts-iron'})
++makedepends=(${makedepends[@]/'nodejs'/'nodejs-lts-iron'} 'python' 'python-setuptools')


### PR DESCRIPTION
- Switch to Node.js v20 because Hedgedoc uses Yarn v4.
- Add some makedepends for building native module
- See also: https://github.com/felixonmars/archriscv-packages/commit/8323610be6eda351cd9957994faa7d524d0da201