### PR TITLE
addpatch: webkit2gtk, ver=2.46.3-1

### DIFF
--- a/webkit2gtk/add-lasx-sources-to-CMakeList.txt.patch
+++ b/webkit2gtk/add-lasx-sources-to-CMakeList.txt.patch
@@ -1,0 +1,49 @@
+From 887b4b4dd0ccb34f71ef68b0423c2430a2098c4a Mon Sep 17 00:00:00 2001
+From: Zhou Qiankang <wszqkzqk@qq.com>
+Date: Wed, 27 Nov 2024 16:53:17 +0800
+Subject: [PATCH] add lasx sources to CMakeList.txt
+
+Signed-off-by: Zhou Qiankang <wszqkzqk@qq.com>
+---
+ Source/ThirdParty/skia/CMakeLists.txt | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/Source/ThirdParty/skia/CMakeLists.txt b/Source/ThirdParty/skia/CMakeLists.txt
+index dca346d4..a517c949 100644
+--- a/Source/ThirdParty/skia/CMakeLists.txt
++++ b/Source/ThirdParty/skia/CMakeLists.txt
+@@ -177,6 +177,7 @@ add_library(Skia STATIC
+     src/core/SkBitmapProcState_matrixProcs.cpp
+     src/core/SkBitmapProcState_opts.cpp
+     src/core/SkBitmapProcState_opts_ssse3.cpp
++    src/core/SkBitmapProcState_opts_lasx.cpp
+     src/core/SkBlendMode.cpp
+     src/core/SkBlendModeBlender.cpp
+     src/core/SkBlitMask_opts.cpp
+@@ -184,6 +185,7 @@ add_library(Skia STATIC
+     src/core/SkBlitRow_D32.cpp
+     src/core/SkBlitRow_opts.cpp
+     src/core/SkBlitRow_opts_hsw.cpp
++    src/core/SkBlitRow_opts_lasx.cpp
+     src/core/SkBlitter.cpp
+     src/core/SkBlitter_A8.cpp
+     src/core/SkBlitter_ARGB32.cpp
+@@ -339,6 +341,7 @@ add_library(Skia STATIC
+     src/core/SkSwizzler_opts.cpp
+     src/core/SkSwizzler_opts_hsw.cpp
+     src/core/SkSwizzler_opts_ssse3.cpp
++    src/core/SkSwizzler_opts_lasx.cpp
+     src/core/SkTaskGroup.cpp
+     src/core/SkTextBlob.cpp
+     src/core/SkTypeface.cpp
+@@ -874,6 +877,7 @@ add_library(Skia STATIC
+ 
+     src/opts/SkOpts_hsw.cpp
+     src/opts/SkOpts_skx.cpp
++    src/opts/SkOpts_lasx.cpp
+ 
+     src/ports/SkFontConfigInterface.cpp
+     src/ports/SkFontConfigInterface_direct.cpp
+-- 
+2.47.1
+

--- a/webkit2gtk/loong.patch
+++ b/webkit2gtk/loong.patch
@@ -1,0 +1,25 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 7e631a5..0b30c37 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -120,6 +120,8 @@ validpgpkeys=(
+ 
+ prepare() {
+   cd webkitgtk-$pkgver
++  patch -p1 -i "${srcdir}/loongarch-simde-use-a-portable-version-to-avoid-comp.patch"
++  patch -p1 -i "${srcdir}/add-lasx-sources-to-CMakeList.txt.patch"
+ }
+ 
+ build() {
+@@ -190,4 +192,11 @@ package_webkit2gtk-docs() {
+   mv doc/* "$pkgdir"
+ }
+ 
++source+=("loongarch-simde-use-a-portable-version-to-avoid-comp.patch"
++         "add-lasx-sources-to-CMakeList.txt.patch")
++sha256sums+=('9d386e91becb40c811f67858de5857f321cedfda4b6c4b6d171fb69c8640cfbc'
++             '47bdffdb426b38dff53c5ecf14c231179b5106f46c0c0f06b6eb8f3c14a1d3f3')
++b2sums+=('e35fc51cb8083e632928e29c4f5b484e5cdb5787b3822c3f2ce019fbb408c093365c7316a82f94afdb382ec4b521f21b44d37d26ab05c9a68e448efbe09d2b68'
++         '70e8cf541386212f83a0b569385b2d8d99679f52f189820417e12f5915492d1e9660261db91a3cc60b9082c39180825d9ec83c949cc02585de772ca83b85fa65')
++
+ # vim:set sw=2 sts=-1 et:

--- a/webkit2gtk/loongarch-simde-use-a-portable-version-to-avoid-comp.patch
+++ b/webkit2gtk/loongarch-simde-use-a-portable-version-to-avoid-comp.patch
@@ -1,0 +1,26 @@
+From 9f3ddbb605985e95e4936d08b28b2ec003a93ee6 Mon Sep 17 00:00:00 2001
+From: Zhou Qiankang <wszqkzqk@qq.com>
+Date: Wed, 27 Nov 2024 13:27:45 +0800
+Subject: [PATCH] loongarch,simde :use a portable version to avoid compilation
+ errors
+
+Signed-off-by: Zhou Qiankang <wszqkzqk@qq.com>
+---
+ Source/WTF/wtf/simde/arm/neon.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/Source/WTF/wtf/simde/arm/neon.h b/Source/WTF/wtf/simde/arm/neon.h
+index 28dc5821..0a2e96d9 100644
+--- a/Source/WTF/wtf/simde/arm/neon.h
++++ b/Source/WTF/wtf/simde/arm/neon.h
+@@ -8788,6 +8788,7 @@ SIMDE_BEGIN_DECLS_
+     !(defined(HEDLEY_MSVC_VERSION) && defined(__clang__)) && \
+     !(defined(SIMDE_ARCH_MIPS) && defined(__clang__)) && \
+     !(defined(SIMDE_ARCH_ZARCH) && defined(__clang__)) && \
++    !(defined(SIMDE_ARCH_LOONGARCH) && defined(__clang__)) && \
+     !(defined(__clang__) && defined(SIMDE_ARCH_RISCV64)) && ( \
+       defined(SIMDE_X86_AVX512FP16_NATIVE) || \
+       (defined(SIMDE_ARCH_X86_SSE2) && HEDLEY_GCC_VERSION_CHECK(12,0,0)) || \
+-- 
+2.47.1
+


### PR DESCRIPTION
* Backport simde's fix to build with clang: https://github.com/simd-everywhere/simde/commit/600050dbd79edaca29cc9649ddb9502041111323
* Add lasx sources to CMakeList.txt