### PR TITLE
updpatch: xorg-server, ver=21.1.14-1.1

### DIFF
--- a/xorg-server/10-modeset.conf
+++ b/xorg-server/10-modeset.conf
@@ -1,6 +1,0 @@
-Section "Device"
-	Identifier "Generic Kernel Modesetting Device"
-	Driver "modesetting"
-	Option "kmsdev" "/dev/dri/card0"
-	Option "ShadowFB" "true"
-EndSection

--- a/xorg-server/loong.patch
+++ b/xorg-server/loong.patch
@@ -1,6 +1,8 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 0340c45..4f369d4 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -45,8 +45,15 @@ sha512sums=('8893b7e236ffb2001d75df98af6480548bc2f5c129d2df1e377730d26c0f0d6a6fa
+@@ -45,8 +45,13 @@ sha512sums=('bdfdab4374174af9a49d4c25ea456e867a2e30a7795b751a77c946df0560c9418ba
  
  prepare() {
    cd ${pkgbase}
@@ -8,15 +10,13 @@
 +  patch -Np1 -i ../0001-modesetting-match-against-Multimedia-Video-Controlle.patch
  }
  
-+source+=('10-modeset.conf'
-+         '0001-modesetting-match-against-Multimedia-Video-Controlle.patch')
-+sha512sums+=('1aa711f4948cd1557d77bd47a64ea92be55cf737b8204214c6c3ae2ecd00dc6928fd7a789d1aa5faaff5d6162f895a41efd332e8f1710d0a7c9b33326b057ec5'
-+             '0e55cc994dd8f1309c6ea40cb1f5b2d763d850a466c9d30bd8619fd68ce369b19f098d28ab684db1bd2758a6402654cf93188651e863f0e1be4eed8cf9b40e14')
++source+=('0001-modesetting-match-against-Multimedia-Video-Controlle.patch')
++sha512sums+=('0e55cc994dd8f1309c6ea40cb1f5b2d763d850a466c9d30bd8619fd68ce369b19f098d28ab684db1bd2758a6402654cf93188651e863f0e1be4eed8cf9b40e14')
 +
  build() {
    # Since pacman 5.0.2-2, hardened flags are now enabled in makepkg.conf
    # With them, modules fail to load with undefined symbol.
-@@ -64,6 +71,7 @@ build() {
+@@ -64,6 +69,7 @@ build() {
      -D xephyr=true \
      -D glamor=true \
      -D udev=true \
@@ -24,11 +24,3 @@
      -D dtrace=false \
      -D systemd_logind=true \
      -D suid_wrapper=true \
-@@ -126,6 +134,7 @@ package_xorg-server() {
- 
-   # distro specific files must be installed in /usr/share/X11/xorg.conf.d
-   install -m755 -d "${pkgdir}/etc/X11/xorg.conf.d"
-+  install -m644 -Dt "${pkgdir}/usr/share/X11/xorg.conf.d" 10-modeset.conf
- 
-   # license
-   install -m644 -Dt "${pkgdir}/usr/share/licenses/${pkgname}" "${pkgbase}"/COPYING


### PR DESCRIPTION
 - remove outdated patch *10-modeset.conf* to fix external video card issue
 `(II) Platform probe for /sys/devices/pci0000:00/0000:00:10.0/0000:07:00.0/drm/card1`
 `(EE) open /dev/dri/card0: No such file or directory`