### PR TITLE
addpatch: premake, ver=5.0beta3-1

### DIFF
--- a/premake/loong.patch
+++ b/premake/loong.patch
@@ -1,22 +1,11 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 01eb384..fd1861f 100644
+index 01eb384..dcaffae 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -14,6 +14,26 @@ depends=('glibc')
+@@ -14,6 +14,15 @@ depends=('glibc')
  source=("https://github.com/premake/premake-core/releases/download/v${_pkgver}/premake-${_pkgver}-src.zip")
  sha512sums=('a349dabe3db5b503c283e836da89a5239007696f87756fe34e011bee655c86cd8ccc1c0c00f72a46d0d10302c2f5d67e37d566313e68a16406924a8ba70c5d8f')
  
-+
-+# add loongarch64 support
-+source+=(
-+  "premake-riscv.patch::https://github.com/premake/premake-core/commit/82c9d90495940e2d0d574e1c7849e9698f23b090.patch"
-+  "premake-loong.patch::https://github.com/premake/premake-core/commit/928397f72c00979d57ec4688cb1fb26ec7f2449b.patch"
-+)
-+sha512sums+=(
-+  'd5dbd55bc27ac909c700b56fbd66b12c13d0133a3bfc4b42f964c5e7e8da961ddc40ddb922c5860558245507d0195c8cfd7301c04ad33bb983ca5125dad13cf3'
-+  'f4c89cf642747480073ab89d5787cc3e0500e6cc05d3e66c535dbe6f93341165415bf2a7da7ba7e897381d547dd458de9b5d2a0b23ccfe91f0d6e13801040b7a'
-+)
-+
 +prepare() {
 +  cd "premake-$_pkgver-src/"
 +
@@ -29,9 +18,19 @@ index 01eb384..fd1861f 100644
  build() {
    cd "premake-$_pkgver-src/build/gmake2.unix"
  
-@@ -26,3 +46,5 @@ package() {
+@@ -26,3 +35,15 @@ package() {
    install -Dm755 "bin/release/premake5" "${pkgdir}/usr/bin/premake5"
    install -Dm644 LICENSE.txt "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
  }
 +
++
++# add loongarch64 support
 +makedepends=('dos2unix')
++source+=(
++  "premake-riscv.patch::https://github.com/premake/premake-core/commit/82c9d90495940e2d0d574e1c7849e9698f23b090.patch"
++  "premake-loong.patch::https://github.com/premake/premake-core/commit/928397f72c00979d57ec4688cb1fb26ec7f2449b.patch"
++)
++sha512sums+=(
++  'd5dbd55bc27ac909c700b56fbd66b12c13d0133a3bfc4b42f964c5e7e8da961ddc40ddb922c5860558245507d0195c8cfd7301c04ad33bb983ca5125dad13cf3'
++  'f4c89cf642747480073ab89d5787cc3e0500e6cc05d3e66c535dbe6f93341165415bf2a7da7ba7e897381d547dd458de9b5d2a0b23ccfe91f0d6e13801040b7a'
++)

--- a/premake/loong.patch
+++ b/premake/loong.patch
@@ -1,0 +1,34 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 01eb384..3d17698 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -13,6 +13,29 @@ license=('BSD')
+ depends=('glibc')
+ source=("https://github.com/premake/premake-core/releases/download/v${_pkgver}/premake-${_pkgver}-src.zip")
+ sha512sums=('a349dabe3db5b503c283e836da89a5239007696f87756fe34e011bee655c86cd8ccc1c0c00f72a46d0d10302c2f5d67e37d566313e68a16406924a8ba70c5d8f')
++makedepends=('dos2unix')
++
++# add loongarch64 support
++source+=(
++  "premake-rescv.patch::https://github.com/premake/premake-core/commit/610924f549c1f61233fe1f5ab930b8bbc4489755.patch"
++  "premake-rescv2.patch::https://github.com/premake/premake-core/commit/25cab6fbd596bf97c14d496f4f0ed61bcbb6e45e.patch"
++  "premake-loong.patch::https://github.com/premake/premake-core/commit/928397f72c00979d57ec4688cb1fb26ec7f2449b.patch"
++)
++sha512sums+=(
++  '8988d8be35c7804c75093da85d0c0ed57c191c7e0bd4f001575f2833a2803f4492529fab711357bd51d79c7b99326e97a0550053d8ee0440c9d102a541090d40'
++  '734d10bca50241a0c248c403efc49c87ec8a292c50ba17ecbc95b580d1733285f2a6bce451c5b3fcdabd9f77456b359d5c9fa9ca03dbf3b7d038fbaca28354a6'
++  'f4c89cf642747480073ab89d5787cc3e0500e6cc05d3e66c535dbe6f93341165415bf2a7da7ba7e897381d547dd458de9b5d2a0b23ccfe91f0d6e13801040b7a'
++)
++
++prepare() {
++  cd "premake-$_pkgver-src/"
++
++  # add support for loongarch64
++  unix2dos -O ../premake-rescv.patch | patch -Np1 --binary
++  unix2dos -O ../premake-rescv2.patch | patch -Np1 --binary
++  unix2dos -O ../premake-loong.patch | patch -Np1 --binary
++
++}
+ 
+ build() {
+   cd "premake-$_pkgver-src/build/gmake2.unix"

--- a/premake/loong.patch
+++ b/premake/loong.patch
@@ -1,22 +1,19 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 01eb384..3d17698 100644
+index 01eb384..fd1861f 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -13,6 +13,29 @@ license=('BSD')
- depends=('glibc')
+@@ -14,6 +14,26 @@ depends=('glibc')
  source=("https://github.com/premake/premake-core/releases/download/v${_pkgver}/premake-${_pkgver}-src.zip")
  sha512sums=('a349dabe3db5b503c283e836da89a5239007696f87756fe34e011bee655c86cd8ccc1c0c00f72a46d0d10302c2f5d67e37d566313e68a16406924a8ba70c5d8f')
-+makedepends=('dos2unix')
+ 
 +
 +# add loongarch64 support
 +source+=(
-+  "premake-rescv.patch::https://github.com/premake/premake-core/commit/610924f549c1f61233fe1f5ab930b8bbc4489755.patch"
-+  "premake-rescv2.patch::https://github.com/premake/premake-core/commit/25cab6fbd596bf97c14d496f4f0ed61bcbb6e45e.patch"
++  "premake-riscv.patch::https://github.com/premake/premake-core/commit/82c9d90495940e2d0d574e1c7849e9698f23b090.patch"
 +  "premake-loong.patch::https://github.com/premake/premake-core/commit/928397f72c00979d57ec4688cb1fb26ec7f2449b.patch"
 +)
 +sha512sums+=(
-+  '8988d8be35c7804c75093da85d0c0ed57c191c7e0bd4f001575f2833a2803f4492529fab711357bd51d79c7b99326e97a0550053d8ee0440c9d102a541090d40'
-+  '734d10bca50241a0c248c403efc49c87ec8a292c50ba17ecbc95b580d1733285f2a6bce451c5b3fcdabd9f77456b359d5c9fa9ca03dbf3b7d038fbaca28354a6'
++  'd5dbd55bc27ac909c700b56fbd66b12c13d0133a3bfc4b42f964c5e7e8da961ddc40ddb922c5860558245507d0195c8cfd7301c04ad33bb983ca5125dad13cf3'
 +  'f4c89cf642747480073ab89d5787cc3e0500e6cc05d3e66c535dbe6f93341165415bf2a7da7ba7e897381d547dd458de9b5d2a0b23ccfe91f0d6e13801040b7a'
 +)
 +
@@ -24,11 +21,17 @@ index 01eb384..3d17698 100644
 +  cd "premake-$_pkgver-src/"
 +
 +  # add support for loongarch64
-+  unix2dos -O ../premake-rescv.patch | patch -Np1 --binary
-+  unix2dos -O ../premake-rescv2.patch | patch -Np1 --binary
-+  unix2dos -O ../premake-loong.patch | patch -Np1 --binary
++  unix2dos -O "../premake-riscv.patch" | patch -Np1 --binary
++  unix2dos -O "../premake-loong.patch" | patch -Np1 --binary
 +
 +}
- 
++
  build() {
    cd "premake-$_pkgver-src/build/gmake2.unix"
+ 
+@@ -26,3 +46,5 @@ package() {
+   install -Dm755 "bin/release/premake5" "${pkgdir}/usr/bin/premake5"
+   install -Dm644 LICENSE.txt "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+ }
++
++makedepends=('dos2unix')

--- a/premake/loong.patch
+++ b/premake/loong.patch
@@ -1,15 +1,14 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 01eb384..3b47c2b 100644
+index 01eb384..52873af 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -26,3 +26,24 @@ package() {
+@@ -26,3 +26,23 @@ package() {
    install -Dm755 "bin/release/premake5" "${pkgdir}/usr/bin/premake5"
    install -Dm644 LICENSE.txt "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
  }
 +
 +
 +# add loongarch64 support
-+# since riscv support (added recently) is also waiting for new release and their code do impact loong patch, add riscv patch as well.
 +makedepends=('dos2unix')
 +source+=(
 +  "premake-riscv.patch::https://github.com/premake/premake-core/commit/82c9d90495940e2d0d574e1c7849e9698f23b090.patch"

--- a/premake/loong.patch
+++ b/premake/loong.patch
@@ -1,24 +1,8 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 01eb384..dcaffae 100644
+index 01eb384..52873af 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -14,6 +14,15 @@ depends=('glibc')
- source=("https://github.com/premake/premake-core/releases/download/v${_pkgver}/premake-${_pkgver}-src.zip")
- sha512sums=('a349dabe3db5b503c283e836da89a5239007696f87756fe34e011bee655c86cd8ccc1c0c00f72a46d0d10302c2f5d67e37d566313e68a16406924a8ba70c5d8f')
- 
-+prepare() {
-+  cd "premake-$_pkgver-src/"
-+
-+  # add support for loongarch64
-+  unix2dos -O "../premake-riscv.patch" | patch -Np1 --binary
-+  unix2dos -O "../premake-loong.patch" | patch -Np1 --binary
-+
-+}
-+
- build() {
-   cd "premake-$_pkgver-src/build/gmake2.unix"
- 
-@@ -26,3 +35,15 @@ package() {
+@@ -26,3 +26,23 @@ package() {
    install -Dm755 "bin/release/premake5" "${pkgdir}/usr/bin/premake5"
    install -Dm644 LICENSE.txt "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
  }
@@ -34,3 +18,11 @@ index 01eb384..dcaffae 100644
 +  'd5dbd55bc27ac909c700b56fbd66b12c13d0133a3bfc4b42f964c5e7e8da961ddc40ddb922c5860558245507d0195c8cfd7301c04ad33bb983ca5125dad13cf3'
 +  'f4c89cf642747480073ab89d5787cc3e0500e6cc05d3e66c535dbe6f93341165415bf2a7da7ba7e897381d547dd458de9b5d2a0b23ccfe91f0d6e13801040b7a'
 +)
++
++prepare() {
++  cd "premake-$_pkgver-src/"
++
++  unix2dos -O "../premake-riscv.patch" | patch -Np1 --binary
++  unix2dos -O "../premake-loong.patch" | patch -Np1 --binary
++
++}

--- a/premake/loong.patch
+++ b/premake/loong.patch
@@ -1,14 +1,15 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 01eb384..52873af 100644
+index 01eb384..3b47c2b 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -26,3 +26,23 @@ package() {
+@@ -26,3 +26,24 @@ package() {
    install -Dm755 "bin/release/premake5" "${pkgdir}/usr/bin/premake5"
    install -Dm644 LICENSE.txt "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
  }
 +
 +
 +# add loongarch64 support
++# since riscv support (added recently) is also waiting for new release and their code do impact loong patch, add riscv patch as well.
 +makedepends=('dos2unix')
 +source+=(
 +  "premake-riscv.patch::https://github.com/premake/premake-core/commit/82c9d90495940e2d0d574e1c7849e9698f23b090.patch"


### PR DESCRIPTION
Add loongarch64 support for premake. 
Recent [PR](https://github.com/premake/premake-core/pull/2363) has been merged by upstream. 
Waiting for new release.

**NOTE**
Also add riscv patch here. Riscv support (added recently) is also waiting for new release.  My patch can only be directly applied on the basis of the RV fix; otherwise, patch conflicts will occur.