### PR TITLE
updpatch: devtools, ver=1:1.3.0-1.1

### DIFF
--- a/devtools/loong.patch
+++ b/devtools/loong.patch
@@ -1,8 +1,8 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 15b7a67..fdcfa34 100644
+index 4b06398..ff946d0 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -36,7 +36,7 @@ depends=(
+@@ -38,7 +38,7 @@ depends=(
  )
  makedepends=(
    asciidoctor
@@ -11,10 +11,20 @@ index 15b7a67..fdcfa34 100644
  )
  checkdepends=(
    bats
-@@ -72,4 +72,6 @@ package() {
+@@ -61,6 +61,7 @@ b2sums=('40c2f8fb81a939a027b772f215b31c73d7f8003415335e5c2667589f0e5ddd786e627f4
+ 
+ build() {
+   cd ${pkgname}-${pkgver}
++  patch -Np1 -i "${srcdir}/add-a-default-value-for-terminal-width.patch"
+   make BUILDTOOLVER="${epoch}:${pkgver}-${pkgrel}-${arch}" PREFIX=/usr
+ }
+ 
+@@ -74,4 +75,8 @@ package() {
    make PREFIX=/usr DESTDIR="${pkgdir}" install
  }
  
-+optdepends_loong64=("devtools-loong64: Support to build loong64 pkgs")
++source+=("add-a-default-value-for-terminal-width.patch::https://gitlab.archlinux.org/archlinux/devtools/-/commit/e8ab01d66230bc7375ee8ecb0a34c65d4ef466f7.patch")
++sha256sums+=('a68eed521866c2599b8e0d73d20feeee9df243ae2248c36e452a6d3d99b47a7d')
++b2sums+=('d488b4061adebc6cae157817fca3001b2465eff44a7be4d370d705520830e984a6e6afc95546171c7df65656e8fca57dc14da6e8bdb5f40d99011c4a2e894934')
 +
  # vim: ts=2 sw=2 et:


### PR DESCRIPTION
* Apply https://gitlab.archlinux.org/archlinux/devtools/-/merge_requests/289 to fix checkpkg