### PR TITLE
updpatch: glibc, ver=2.40+r16+gaa533d58ff-2

### DIFF
--- a/glibc/loong.patch
+++ b/glibc/loong.patch
@@ -1,5 +1,5 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 76322a6..5520525 100644
+index 26c440a..82cb7cb 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
 @@ -7,14 +7,14 @@
@@ -28,78 +28,27 @@ index 76322a6..5520525 100644
  
    [[ -d glibc-$pkgver ]] && ln -s glibc-$pkgver glibc
    cd glibc
-@@ -61,11 +61,11 @@ build() {
- 
-   # _FORTIFY_SOURCE=3 causes testsuite build failure and is unnecessary during
-   # actual builds (support is built-in via --enable-fortify-source).
--  CFLAGS=${CFLAGS/-Wp,-D_FORTIFY_SOURCE=3/}
-+  CFLAGS=${CFLAGS/-Wp,-D_FORTIFY_SOURCE=?/}
-+  CFLAGS=${CFLAGS/-fno-plt/}
- 
-   (
-     cd glibc-build
--
-     echo "slibdir=/usr/lib" >> configparms
-     echo "rtlddir=/usr/lib" >> configparms
-     echo "sbindir=/usr/bin" >> configparms
-@@ -83,28 +83,6 @@ build() {
+@@ -51,7 +51,6 @@ build() {
+       --enable-bind-now
+       --enable-fortify-source
+       --enable-kernel=4.4
+-      --enable-multi-arch
+       --enable-stack-protector=strong
+       --enable-systemtap
+       --disable-nscd
+@@ -83,6 +82,7 @@ build() {
      make info
    )
  
--  (
--    cd lib32-glibc-build
--    export CC="gcc -m32 -mstackrealign"
--    export CXX="g++ -m32 -mstackrealign"
--
--    # remove frame pointer flags due to crashes of nvidia driver on steam starts
--    # See https://gitlab.archlinux.org/archlinux/packaging/packages/glibc/-/issues/10
--    CFLAGS=${CFLAGS/-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer/}
--
--    echo "slibdir=/usr/lib32" >> configparms
--    echo "rtlddir=/usr/lib32" >> configparms
--    echo "sbindir=/usr/bin" >> configparms
--    echo "rootsbindir=/usr/bin" >> configparms
--
--    "${srcdir}"/glibc/configure \
--        --host=i686-pc-linux-gnu \
--        --libdir=/usr/lib32 \
--        --libexecdir=/usr/lib32 \
--        "${_configure_flags[@]}"
--
--    make -O
--  )
++  : <<COMMENT_SEPARATOR
+   (
+     cd lib32-glibc-build
+     export CC="gcc -m32 -mstackrealign"
+@@ -105,6 +105,7 @@ build() {
+ 
+     make -O
+   )
++COMMENT_SEPARATOR
  
    # pregenerate locales here instead of in package
    # functions because localedef does not like fakeroot
-@@ -189,31 +167,6 @@ package_glibc() {
-   install -Dm644 "${srcdir}"/sdt-config.h "${pkgdir}"/usr/include/sys/sdt-config.h
- }
- 
--package_lib32-glibc() {
--  pkgdesc='GNU C Library (32-bit)'
--  depends=("glibc=$pkgver")
--  options+=('!emptydirs')
--  install=lib32-glibc.install
--
--  cd lib32-glibc-build
--
--  make DESTDIR="${pkgdir}" install
--  rm -rf "${pkgdir}"/{etc,sbin,usr/{bin,sbin,share},var}
--
--  # We need to keep 32 bit specific header files
--  find "${pkgdir}"/usr/include -type f -not -name '*-32.h' -delete
--
--  # Dynamic linker
--  install -d "${pkgdir}"/usr/lib
--  ln -s ../lib32/ld-linux.so.2 "${pkgdir}"/usr/lib/
--
--  # Add lib32 paths to the default library search path
--  install -Dm644 "${srcdir}"/lib32-glibc.conf "${pkgdir}"/etc/ld.so.conf.d/lib32-glibc.conf
--
--  # Symlink /usr/lib32/locale to /usr/lib/locale
--  ln -s ../lib/locale "${pkgdir}"/usr/lib32/locale
--}
--
- package_glibc-locales() {
-   pkgdesc='Pregenerated locales for GNU C Library'
-   depends=("glibc=$pkgver")


### PR DESCRIPTION
* Removed additional modification of CFLAGS, since it is already integrated into devtools-loong64