### PR TITLE
addpatch: kio-extras, ver=24.12.0-1

### DIFF
--- a/kio-extras/loong.patch
+++ b/kio-extras/loong.patch
@@ -1,0 +1,12 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index eeb287c..906340b 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -35,7 +35,6 @@ depends=(gcc-libs
+          qt6-5compat
+          qt6-base
+          qt6-svg
+-         ripgrep-all
+          smbclient
+          solid
+          syntax-highlighting)


### PR DESCRIPTION
* Remove ripgrep-all from depends since it's missing