### PR TITLE
addpatch: openpgl, ver=0.7.0-1

### DIFF
--- a/openpgl/loong.patch
+++ b/openpgl/loong.patch
@@ -1,0 +1,27 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index c0e7e7c..fea2b19 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -15,6 +15,14 @@ sha512sums=('f5482ddf13217f81936098101c9bc16e63c36f79500aef25d15f7725deb5578ace7
+ 
+ build() {
+   cd openpgl-$pkgver
++
++  patch -p1 -i "${srcdir}/use-simde.patch"
++
++  # SIMDE_ENABLE_NATIVE_ALIASES will cause conflict
++  # error: conflicting types for ‘__m128i’; have ‘simde__m128i’
++  export CFLAGS="${CFLAGS} -DSIMDE_NO_NATIVE"
++  export CXXFLAGS="${CXXFLAGS} -DSIMDE_NO_NATIVE"
++
+   cmake \
+     -Bbuild \
+     -GNinja \
+@@ -29,3 +37,7 @@ package() {
+   cd openpgl-$pkgver
+   DESTDIR="$pkgdir" ninja -C build install
+ }
++
++makedepends+=(simde)
++source+=("use-simde.patch::https://github.com/Cryolitia-Forks/openpgl/commit/77074e2ff062a16ad20f071189dac56e6d075d52.patch")
++sha512sums+=('4ba2fdd16104e3da16458bf25253085b42df4e305af1887e5c24f41ef0acdac23204f7c7a7ebd50a010dc17bf8bd3d8bd8cd572e47e9abad98ba923bca8221b2')


### PR DESCRIPTION
* Apply https://github.com/Cryolitia-Forks/openpgl/commit/77074e2ff062a16ad20f071189dac56e6d075d52 to build on loong64
* Use simde to provide x86 intrinsics
  * Bug: error: conflicting declaration ‘typedef simde__m128i __m128i’
  * Temporarily switch to `SIMDE_NO_NATIVE`
  * This actually disables SIMD