### PR TITLE
addpatch: openrct2, ver=0.4.17-1

### DIFF
--- a/openrct2/loong.patch
+++ b/openrct2/loong.patch
@@ -1,0 +1,21 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 86f5e0b..80a764d 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -24,6 +24,9 @@ sha256sums=('991c4a3eb599439e09715bd36ea0de42a11215edff4e5576304dc38524a6ab8d'
+ 
+ prepare() {
+   cd "$srcdir/OpenRCT2-$pkgver"
++
++  patch -p1 -i "${srcdir}/add-loong-support.patch"
++
+   mkdir build
+ 
+   # add cmake command to patch googletest with https://github.com/google/googletest/pull/3024
+@@ -55,3 +58,6 @@ package() {
+   rm "$pkgdir/usr/lib/libopenrct2.a"
+   rmdir "$pkgdir/usr/lib"
+ }
++
++source+=("add-loong-support.patch::https://github.com/OpenRCT2/OpenRCT2/commit/935dc6815dc396d7f3b7b10b91f03531e7bf6f88.patch")
++sha256sums+=('aa86769d04fd8853adaab45f9c019a0b0a259271cdb81a1fa6cb8e032cba69cb')


### PR DESCRIPTION
* Apply https://github.com/OpenRCT2/OpenRCT2/commit/935dc6815dc396d7f3b7b10b91f03531e7bf6f88 to build on loong64