### PR TITLE
addpatch: electron32, ver=32.2.7-1

### DIFF
--- a/electron32/compiler-rt-adjust-paths-loong64.patch
+++ b/electron32/compiler-rt-adjust-paths-loong64.patch
@@ -1,0 +1,14 @@
+--- a/build/config/clang/BUILD.gn
++++ b/build/config/clang/BUILD.gn
+@@ -166,6 +169,11 @@ template("clang_lib") {
+         assert(false)  # Unhandled target platform
+       }
+ 
++      # Bit of a hack to make this find builtins from compiler-rt >= 16
++      if (is_linux || is_chromeos) {
++        _dir = "linux"
++      }
++
+       _clang_lib_dir = "$clang_base_path/lib/clang/$clang_version/lib"
+       _lib_file = "${_prefix}clang_rt.${_libname}${_suffix}.${_ext}"
+       libs = [ "$_clang_lib_dir/$_dir/$_lib_file" ]

--- a/electron32/depot_tools-loong64-support.patch
+++ b/electron32/depot_tools-loong64-support.patch
@@ -1,0 +1,14 @@
+diff --git a/cipd b/cipd
+index 7f9cca27..3acbe4ad 100755
+--- a/cipd
++++ b/cipd
+@@ -80,6 +80,9 @@ if [ -z $ARCH ]; then
+     riscv64)
+       ARCH=riscv64
+       ;;
++    loongarch64)
++      ARCH=loong64
++      ;;
+     *)
+       >&2 echo "UNKNOWN Machine architecture: ${UNAME}"
+       exit 1

--- a/electron32/electron-add-loong64-support.patch
+++ b/electron32/electron-add-loong64-support.patch
@@ -1,0 +1,10369 @@
+diff --git a/patches/boringssl/.patches b/patches/boringssl/.patches
+index 9dffabe3d9..981c833dd6 100644
+--- a/patches/boringssl/.patches
++++ b/patches/boringssl/.patches
+@@ -1,3 +1,4 @@
+ expose_ripemd160.patch
+ revert_track_ssl_error_zero_return_explicitly.patch
+ feat_expose_several_extra_cipher_functions.patch
++loong64_support.patch
+diff --git a/patches/boringssl/loong64_support.patch b/patches/boringssl/loong64_support.patch
+new file mode 100644
+index 0000000000..8778bdfd90
+--- /dev/null
++++ b/patches/boringssl/loong64_support.patch
+@@ -0,0 +1,20 @@
++From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
++From: darkyzhou <me@zqy.io>
++Date: Mon, 18 Nov 2024 15:49:06 +0000
++Subject: loong64 support
++
++Co-authored-by: Jiajie Chen <c@jia.je>
++
++diff --git a/include/openssl/target.h b/include/openssl/target.h
++index 2760f52ce8ef92f6b8c9800568f096ce8e551b35..c53990fe8eb11a691876f1370d7e047b71996cee 100644
++--- a/include/openssl/target.h
+++++ b/include/openssl/target.h
++@@ -54,6 +54,8 @@
++ #define OPENSSL_32_BIT
++ #elif defined(__myriad2__)
++ #define OPENSSL_32_BIT
+++#elif defined(__loongarch__) && __SIZEOF_POINTER__ == 8
+++#define OPENSSL_64_BIT
++ #else
++ // The list above enumerates the platforms that BoringSSL supports. For these
++ // platforms we keep a reasonable bar of not breaking them: automated test
+diff --git a/patches/breakpad/.patches b/patches/breakpad/.patches
+new file mode 100644
+index 0000000000..ea62e0c740
+--- /dev/null
++++ b/patches/breakpad/.patches
+@@ -0,0 +1 @@
++loong64_support.patch
+diff --git a/patches/breakpad/loong64_support.patch b/patches/breakpad/loong64_support.patch
+new file mode 100644
+index 0000000000..81eca14e30
+--- /dev/null
++++ b/patches/breakpad/loong64_support.patch
+@@ -0,0 +1,43 @@
++From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
++From: darkyzhou <me@zqy.io>
++Date: Fri, 29 Nov 2024 01:52:56 +0000
++Subject: loong64 support
++
++
++diff --git a/src/common/linux/dump_symbols.cc b/src/common/linux/dump_symbols.cc
++index 55fa98469d81798cab823343f17c3a21f2a9b86e..2d03c6c0e57b4dac5a0854e69d3b6cb5bdae93d5 100644
++--- a/src/common/linux/dump_symbols.cc
+++++ b/src/common/linux/dump_symbols.cc
++@@ -111,6 +111,10 @@ using google_breakpad::wasteful_vector;
++ #define EM_AARCH64      183
++ #endif
++ 
+++#ifdef EM_LOONGARCH
+++#define EM_LOONGARCH    258
+++#endif
+++
++ // Define ZStd compression if host machine does not include this define.
++ #ifndef ELFCOMPRESS_ZSTD
++ #define ELFCOMPRESS_ZSTD 2
++@@ -1119,6 +1123,7 @@ const char* ElfArchitecture(const typename ElfClass::Ehdr* elf_header) {
++     case EM_X86_64:     return "x86_64";
++     case EM_RISCV:      return "riscv";
++     case EM_NDS32:      return "nds32";
+++    case EM_LOONGARCH:  return "loongarch64";
++     default: return NULL;
++   }
++ }
++diff --git a/src/common/linux/memory_mapped_file.cc b/src/common/linux/memory_mapped_file.cc
++index a7b96eb591f741546005a53f9d8125df421ef881..6ad11042be8228e1a37f5b15377e9de1cca05cc2 100644
++--- a/src/common/linux/memory_mapped_file.cc
+++++ b/src/common/linux/memory_mapped_file.cc
++@@ -72,7 +72,8 @@ bool MemoryMappedFile::Map(const char* path, size_t offset) {
++ 
++ #if defined(__x86_64__) || defined(__aarch64__) || \
++    (defined(__mips__) && _MIPS_SIM == _ABI64) || \
++-   (defined(__riscv) && __riscv_xlen == 64)
+++   (defined(__riscv) && __riscv_xlen == 64) || \
+++   (defined(__loongarch__) && __loongarch_grlen == 64)
++ 
++   struct kernel_stat st;
++   if (sys_fstat(fd, &st) == -1 || st.st_size < 0) {
+diff --git a/patches/chromium/.patches b/patches/chromium/.patches
+index 42badd0707..202e3e6972 100644
+--- a/patches/chromium/.patches
++++ b/patches/chromium/.patches
+@@ -142,3 +142,4 @@ cherry-pick-923797bac925.patch
+ cherry-pick-e699ac35ac6c.patch
+ ui_add_missing_shortcut_text_for_vkey_command_on_linux.patch
+ wayland_support_outgoing_dnd_sessions_with_no_offered_mime_types.patch
++loong64_support.patch
+\ No newline at end of file
+diff --git a/patches/chromium/loong64_support.patch b/patches/chromium/loong64_support.patch
+new file mode 100644
+index 0000000000..a7df560fba
+--- /dev/null
++++ b/patches/chromium/loong64_support.patch
+@@ -0,0 +1,3656 @@
++From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
++From: darkyzhou <me@zqy.io>
++Date: Tue, 19 Nov 2024 01:44:44 +0000
++Subject: loong64 support
++
++Co-authored-by: Jiajie Chen <c@jia.je>
++
++diff --git a/base/allocator/partition_allocator/partition_alloc.gni b/base/allocator/partition_allocator/partition_alloc.gni
++index 46cf090f852929d776b217dc973e1e8e792dcb9e..c87f455c4a36338b0f0dda98fd7d38ea03965f06 100644
++--- a/base/allocator/partition_allocator/partition_alloc.gni
+++++ b/base/allocator/partition_allocator/partition_alloc.gni
++@@ -242,7 +242,7 @@ declare_args() {
++ 
++ stack_scan_supported =
++     current_cpu == "x64" || current_cpu == "x86" || current_cpu == "arm" ||
++-    current_cpu == "arm64" || current_cpu == "riscv64"
+++    current_cpu == "arm64" || current_cpu == "riscv64" || current_cpu == "loong64"
++ 
++ # We want to provide assertions that guard against inconsistent build
++ # args, but there is no point in having them fire if we're not building
++diff --git a/base/allocator/partition_allocator/src/partition_alloc/BUILD.gn b/base/allocator/partition_allocator/src/partition_alloc/BUILD.gn
++index f3e9c4c00fb7225b23e21745d969b3718e43f839..2ef0200f2181e86528ad0c3b98c2be200d4fa233 100644
++--- a/base/allocator/partition_allocator/src/partition_alloc/BUILD.gn
+++++ b/base/allocator/partition_allocator/src/partition_alloc/BUILD.gn
++@@ -460,6 +460,9 @@ if (is_clang_or_gcc) {
++     } else if (current_cpu == "riscv64") {
++       assert(stack_scan_supported)
++       sources += [ "stack/asm/riscv64/push_registers_asm.cc" ]
+++    } else if (current_cpu == "loong64") {
+++      assert(stack_scan_supported)
+++      sources += [ "stack/asm/loong64/push_registers_asm.cc" ]
++     } else {
++       # To support a trampoline for another arch, please refer to v8/src/heap/base.
++       assert(!stack_scan_supported)
++diff --git a/base/allocator/partition_allocator/src/partition_alloc/stack/asm/loong64/push_registers_asm.cc b/base/allocator/partition_allocator/src/partition_alloc/stack/asm/loong64/push_registers_asm.cc
++new file mode 100644
++index 0000000000000000000000000000000000000000..574c9ea846e0707f634600bb4de358b7ba65f674
++--- /dev/null
+++++ b/base/allocator/partition_allocator/src/partition_alloc/stack/asm/loong64/push_registers_asm.cc
++@@ -0,0 +1,49 @@
+++// Copyright 2023 The Chromium Authors
+++// Use of this source code is governed by a BSD-style license that can be
+++// found in the LICENSE file.
+++
+++// Push all callee-saved registers to get them on the stack for conservative
+++// stack scanning.
+++//
+++// See asm/x64/push_registers_asm.cc for why the function is not generated
+++// using clang.
+++//
+++// Calling convention source:
+++// https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
+++asm(".global PAPushAllRegistersAndIterateStack             \n"
+++    ".type PAPushAllRegistersAndIterateStack, %function    \n"
+++    ".hidden PAPushAllRegistersAndIterateStack             \n"
+++    "PAPushAllRegistersAndIterateStack:                    \n"
+++    // Push all callee-saved registers and save return address.
+++    "  addi.d $sp, $sp, -96                              \n"
+++    // Save return address.
+++    "  st.d $ra, $sp, 88                                 \n"
+++    // sp is callee-saved.
+++    "  st.d $sp, $sp, 80                                 \n"
+++    // s0-s9(fp) are callee-saved.
+++    "  st.d $fp, $sp, 72                                 \n"
+++    "  st.d $s8, $sp, 64                                 \n"
+++    "  st.d $s7, $sp, 56                                 \n"
+++    "  st.d $s6, $sp, 48                                 \n"
+++    "  st.d $s5, $sp, 40                                 \n"
+++    "  st.d $s4, $sp, 32                                 \n"
+++    "  st.d $s3, $sp, 24                                 \n"
+++    "  st.d $s2, $sp, 16                                 \n"
+++    "  st.d $s1, $sp, 8                                  \n"
+++    "  st.d $s0, $sp, 0                                  \n"
+++    // Maintain frame pointer(fp is s9).
+++    "  move $fp, $sp                                     \n"
+++    // Pass 1st parameter (a0) unchanged (Stack*).
+++    // Pass 2nd parameter (a1) unchanged (StackVisitor*).
+++    // Save 3rd parameter (a2; IterateStackCallback) to a3.
+++    "  move $a3, $a2                                     \n"
+++    // Pass 3rd parameter as sp (stack pointer).
+++    "  move $a2, $sp                                     \n"
+++    // Call the callback.
+++    "  jirl $ra, $a3, 0                                  \n"
+++    // Load return address.
+++    "  ld.d $ra, $sp, 88                                 \n"
+++    // Restore frame pointer.
+++    "  ld.d $fp, $sp, 72                                 \n"
+++    "  addi.d $sp, $sp, 96                               \n"
+++    "  jr $ra                                            \n");
++diff --git a/base/system/sys_info.cc b/base/system/sys_info.cc
++index b74d6550715dec595a3ac630b759ef36f7461c59..1ebbbd70cefc14144e57042acaf2f251dcefe80d 100644
++--- a/base/system/sys_info.cc
+++++ b/base/system/sys_info.cc
++@@ -255,6 +255,8 @@ std::string SysInfo::ProcessCPUArchitecture() {
++   return "ARM_64";
++ #elif defined(ARCH_CPU_RISCV64)
++   return "RISCV_64";
+++#elif defined(ARCH_CPU_LOONGARCH64)
+++  return "LOONGARCH_64";
++ #else
++   return std::string();
++ #endif
++diff --git a/build/config/clang/BUILD.gn b/build/config/clang/BUILD.gn
++index e6d80a8d485f18c7882a484d325613fa36b1f9b7..335a19a654553c7ad90768bae6cc14a7c635efbd 100644
++--- a/build/config/clang/BUILD.gn
+++++ b/build/config/clang/BUILD.gn
++@@ -190,14 +190,15 @@ template("clang_lib") {
++       } else if (is_apple) {
++         _dir = "darwin"
++       } else if (is_linux || is_chromeos) {
+++        _dir = "linux"
++         if (current_cpu == "x64") {
++-          _dir = "x86_64-unknown-linux-gnu"
+++          _suffix = "-x86_64"
++         } else if (current_cpu == "x86") {
++-          _dir = "i386-unknown-linux-gnu"
++-        } else if (current_cpu == "arm") {
++-          _dir = "armv7-unknown-linux-gnueabihf"
+++          _suffix = "-i386"
++         } else if (current_cpu == "arm64") {
++-          _dir = "aarch64-unknown-linux-gnu"
+++          _suffix = "-aarch64"
+++        } else if (current_cpu == "loong64") {
+++          _suffix = "-loongarch64"
++         } else {
++           assert(false)  # Unhandled cpu type
++         }
++diff --git a/build/config/rust.gni b/build/config/rust.gni
++index fd4c6834429b9677defb93a7e51231e4776ccb04..983a18d15f5405c40f125d680eafe95e1dc55d85 100644
++--- a/build/config/rust.gni
+++++ b/build/config/rust.gni
++@@ -204,6 +204,8 @@ if (is_linux || is_chromeos) {
++     }
++   } else if (current_cpu == "riscv64") {
++     rust_abi_target = "riscv64gc-unknown-linux-gnu"
+++  } else if (current_cpu == "loong64") {
+++    rust_abi_target = "loongarch64-unknown-linux-gnu"
++   } else {
++     # Best guess for other future platforms.
++     rust_abi_target = current_cpu + "-unknown-linux-gnu"
++@@ -292,6 +294,8 @@ if (current_cpu == "x86") {
++   rust_target_arch = "powerpc64"
++ } else if (current_cpu == "riscv64") {
++   rust_target_arch = "riscv64"
+++} else if (current_cpu == "loong64") {
+++  rust_target_arch = "loongarch64"
++ }
++ 
++ assert(!toolchain_has_rust || rust_target_arch != "")
++diff --git a/build/nocompile.gni b/build/nocompile.gni
++index 242e9104fc10ab17468e208bea0e72a6eb606018..8d152bd8adb4313f0b1f7d7d38dbb822d3c6ff3f 100644
++--- a/build/nocompile.gni
+++++ b/build/nocompile.gni
++@@ -119,10 +119,10 @@ if (enable_nocompile_tests) {
++         rebased_obj_path,
++         rebased_depfile_path,
++         "--",
++-        "{{cflags}}",
++-        "{{cflags_cc}}",
++-        "{{defines}}",
++-        "{{include_dirs}}",
+++        # "{{cflags}}",
+++        # "{{cflags_cc}}",
+++        # "{{defines}}",
+++        # "{{include_dirs}}",
++ 
++         # No need to generate an object file for nocompile tests.
++         "-Xclang",
++diff --git a/build/rust/rust_bindgen.gni b/build/rust/rust_bindgen.gni
++index bf110ca93cbb5e0216058675c57a6830ea0cfd15..3f37e15cda2da3be6b519d3251bad9484dca1ea8 100644
++--- a/build/rust/rust_bindgen.gni
+++++ b/build/rust/rust_bindgen.gni
++@@ -75,11 +75,11 @@ template("rust_bindgen") {
++     sources = [ invoker.header ]
++ 
++     if (!defined(configs)) {
++-      configs = []
+++      # configs = []
++     }
++ 
++     # Several important compiler flags come from default_compiler_configs
++-    configs += default_compiler_configs
+++    # configs += default_compiler_configs
++ 
++     output_dir = "$target_gen_dir"
++     out_gen_rs = "$output_dir/${target_name}.rs"
++@@ -130,10 +130,10 @@ template("rust_bindgen") {
++ 
++     args += [
++       "--",
++-      "{{defines}}",
++-      "{{include_dirs}}",
++-      "{{cflags}}",
++-      "{{cflags_c}}",
+++      # "{{defines}}",
+++      # "{{include_dirs}}",
+++      # "{{cflags}}",
+++      # "{{cflags_c}}",
++     ]
++ 
++     # libclang will run the system `clang` to find the "resource dir" which it
++diff --git a/build/rust/rust_target.gni b/build/rust/rust_target.gni
++index 10371f12c0a836d3e99f8fea4c1185198d4b7f0d..add7eb8a98dc50b2d959b5bb2670acf3bb9a747d 100644
++--- a/build/rust/rust_target.gni
+++++ b/build/rust/rust_target.gni
++@@ -399,6 +399,9 @@ template("rust_target") {
++       if (_rustc_metadata != "") {
++         rustflags += [ "-Cmetadata=${_rustc_metadata}" ]
++       }
+++      if (current_cpu == "loong64") {
+++        rustflags += [ "-Ccode-model=medium" ]
+++      }
++       rustenv = _rustenv
++ 
++       if (_generate_crate_root) {
++diff --git a/content/common/user_agent.cc b/content/common/user_agent.cc
++index 070658460eb74513b83e746f20d80af5b79a2df3..39bff2d78b1379dd1a26fa30106ef35243d2d8ef 100644
++--- a/content/common/user_agent.cc
+++++ b/content/common/user_agent.cc
++@@ -174,6 +174,8 @@ std::string GetCpuArchitecture() {
++               cpu_info.substr(2, 2) == "86") ||
++              base::StartsWith(cpu_info, "x86")) {
++     return "x86";
+++  } else if (base::StartsWith(cpu_info, "loong")) {
+++    return "loongarch";
++   }
++ #elif BUILDFLAG(IS_FUCHSIA)
++   std::string cpu_arch = base::SysInfo::ProcessCPUArchitecture();
++diff --git a/extensions/common/api/runtime.json b/extensions/common/api/runtime.json
++index 58034dfdd2516d8d54e5a9c7a0ade0f37d237cab..600be2fb7a31c02fe625a0954c657e0233c89087 100644
++--- a/extensions/common/api/runtime.json
+++++ b/extensions/common/api/runtime.json
++@@ -98,7 +98,8 @@
++             {"name": "x86-32", "description": "Specifies the processer architecture as x86-32."},
++             {"name": "x86-64", "description": "Specifies the processer architecture as x86-64."},
++             {"name": "mips", "description": "Specifies the processer architecture as mips."},
++-            {"name": "mips64", "description": "Specifies the processer architecture as mips64."}
+++            {"name": "mips64", "description": "Specifies the processer architecture as mips64."},
+++            {"name": "loong64", "description": "Specifies the processer architecture as loong64."}
++          ],
++         "description": "The machine's processor architecture."
++       },
++@@ -111,7 +112,8 @@
++           {"name": "x86-32", "description": "Specifies the native client architecture as x86-32."},
++           {"name": "x86-64", "description": "Specifies the native client architecture as x86-64."},
++           {"name": "mips", "description": "Specifies the native client architecture as mips."},
++-          {"name": "mips64", "description": "Specifies the native client architecture as mips64."}
+++          {"name": "mips64", "description": "Specifies the native client architecture as mips64."},
+++          {"name": "loong64", "description": "Specifies the native client architecture as loong64."}
++         ]
++       },
++       {
++diff --git a/sandbox/features.gni b/sandbox/features.gni
++index 8434144118b49c33a60fa455153a0e2d498a08a7..189bb35f8e4dadb6565f38a1a2fb70007f3ea680 100644
++--- a/sandbox/features.gni
+++++ b/sandbox/features.gni
++@@ -9,7 +9,7 @@
++ use_seccomp_bpf = (is_linux || is_chromeos || is_android) &&
++                   (current_cpu == "x86" || current_cpu == "x64" ||
++                    current_cpu == "arm" || current_cpu == "arm64" ||
++-                   current_cpu == "mipsel" || current_cpu == "mips64el")
+++                   current_cpu == "mipsel" || current_cpu == "mips64el" || current_cpu == "loong64")
++ 
++ # SSBD (Speculative Store Bypass Disable) is a mitigation of Spectre Variant 4.
++ # As Spectre Variant 4 can be mitigated by site isolation, opt-out SSBD on site
++diff --git a/sandbox/linux/bpf_dsl/linux_syscall_ranges.h b/sandbox/linux/bpf_dsl/linux_syscall_ranges.h
++index 1d0590b7dd6ce003c20d45b3b108261182bb841a..92f0a6245ff9640894fb8515de34792b5fccfd35 100644
++--- a/sandbox/linux/bpf_dsl/linux_syscall_ranges.h
+++++ b/sandbox/linux/bpf_dsl/linux_syscall_ranges.h
++@@ -56,6 +56,13 @@
++ #define MAX_PUBLIC_SYSCALL __NR_syscalls
++ #define MAX_SYSCALL MAX_PUBLIC_SYSCALL
++ 
+++#elif defined(__loongarch__)
+++
+++#include <asm-generic/unistd.h>
+++#define MIN_SYSCALL 0u
+++#define MAX_PUBLIC_SYSCALL __NR_syscalls
+++#define MAX_SYSCALL MAX_PUBLIC_SYSCALL
+++
++ #else
++ #error "Unsupported architecture"
++ #endif
++diff --git a/sandbox/linux/bpf_dsl/seccomp_macros.h b/sandbox/linux/bpf_dsl/seccomp_macros.h
++index 87d5825aa3ddb43e666e8e70deb6f4c429468023..2f1ba99e7a18593f647694dc156fb3df45d27a1d 100644
++--- a/sandbox/linux/bpf_dsl/seccomp_macros.h
+++++ b/sandbox/linux/bpf_dsl/seccomp_macros.h
++@@ -343,6 +343,47 @@ struct regs_struct {
++ #define SECCOMP_PT_PARM4(_regs) (_regs).regs[3]
++ #define SECCOMP_PT_PARM5(_regs) (_regs).regs[4]
++ #define SECCOMP_PT_PARM6(_regs) (_regs).regs[5]
+++
+++#elif defined(__loongarch__)
+++struct regs_struct {
+++  unsigned long long regs[32];
+++  unsigned long long pc;
+++};
+++
+++#define SECCOMP_ARCH AUDIT_ARCH_LOONGARCH64
+++
+++#define SECCOMP_REG(_ctx, _reg) ((_ctx)->uc_mcontext.__gregs[_reg])
+++
+++#define SECCOMP_RESULT(_ctx) SECCOMP_REG(_ctx, 4)
+++#define SECCOMP_SYSCALL(_ctx) SECCOMP_REG(_ctx, 11)
+++#define SECCOMP_IP(_ctx) (_ctx)->uc_mcontext.__pc
+++#define SECCOMP_PARM1(_ctx) SECCOMP_REG(_ctx, 4)
+++#define SECCOMP_PARM2(_ctx) SECCOMP_REG(_ctx, 5)
+++#define SECCOMP_PARM3(_ctx) SECCOMP_REG(_ctx, 6)
+++#define SECCOMP_PARM4(_ctx) SECCOMP_REG(_ctx, 7)
+++#define SECCOMP_PARM5(_ctx) SECCOMP_REG(_ctx, 8)
+++#define SECCOMP_PARM6(_ctx) SECCOMP_REG(_ctx, 9)
+++
+++#define SECCOMP_NR_IDX (offsetof(struct arch_seccomp_data, nr))
+++#define SECCOMP_ARCH_IDX (offsetof(struct arch_seccomp_data, arch))
+++#define SECCOMP_IP_MSB_IDX \
+++  (offsetof(struct arch_seccomp_data, instruction_pointer) + 4)
+++#define SECCOMP_IP_LSB_IDX \
+++  (offsetof(struct arch_seccomp_data, instruction_pointer) + 0)
+++#define SECCOMP_ARG_MSB_IDX(nr) \
+++  (offsetof(struct arch_seccomp_data, args) + 8 * (nr) + 4)
+++#define SECCOMP_ARG_LSB_IDX(nr) \
+++  (offsetof(struct arch_seccomp_data, args) + 8 * (nr) + 0)
+++
+++#define SECCOMP_PT_RESULT(_regs) (_regs).regs[4]
+++#define SECCOMP_PT_SYSCALL(_regs) (_regs).regs[11]
+++#define SECCOMP_PT_IP(_regs) (_regs).pc
+++#define SECCOMP_PT_PARM1(_regs) (_regs).regs[4]
+++#define SECCOMP_PT_PARM2(_regs) (_regs).regs[5]
+++#define SECCOMP_PT_PARM3(_regs) (_regs).regs[6]
+++#define SECCOMP_PT_PARM4(_regs) (_regs).regs[7]
+++#define SECCOMP_PT_PARM5(_regs) (_regs).regs[8]
+++#define SECCOMP_PT_PARM6(_regs) (_regs).regs[9]
++ #else
++ #error Unsupported target platform
++ 
++diff --git a/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc b/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
++index 7bde501115bdf9ad91c8c907a128a6c9e183f7a0..5745a8da7e50538484b489fec35332d1c8ab6872 100644
++--- a/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
+++++ b/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
++@@ -193,7 +193,7 @@ ResultExpr EvaluateSyscallImpl(int fs_denied_errno,
++     return RestrictFcntlCommands();
++ #endif
++ 
++-#if !defined(__aarch64__)
+++#if !defined(__aarch64__) && !defined(__loongarch__)
++   // fork() is never used as a system call (clone() is used instead), but we
++   // have seen it in fallback code on Android.
++   if (sysno == __NR_fork) {
++@@ -255,7 +255,7 @@ ResultExpr EvaluateSyscallImpl(int fs_denied_errno,
++   }
++ 
++ #if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
++-    defined(__aarch64__)
+++    defined(__aarch64__) || defined(__loongarch__)
++   if (sysno == __NR_mmap)
++     return RestrictMmapFlags();
++ #endif
++@@ -276,7 +276,7 @@ ResultExpr EvaluateSyscallImpl(int fs_denied_errno,
++     return RestrictPrctl();
++ 
++ #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
++-    defined(__aarch64__)
+++    defined(__aarch64__) || defined(__loongarch__)
++   if (sysno == __NR_socketpair) {
++     // Only allow AF_UNIX, PF_UNIX. Crash if anything else is seen.
++     static_assert(AF_UNIX == PF_UNIX,
++@@ -302,6 +302,7 @@ ResultExpr EvaluateSyscallImpl(int fs_denied_errno,
++     return Allow();
++   }
++ 
+++#if !defined(__loongarch__)
++   // The fstatat syscalls are file system syscalls, which will be denied below
++   // with fs_denied_errno. However some allowed fstat syscalls are rewritten by
++   // libc implementations to fstatat syscalls, and we need to rewrite them back.
++@@ -319,6 +320,7 @@ ResultExpr EvaluateSyscallImpl(int fs_denied_errno,
++     return If(mask == STATX_BASIC_STATS, Error(ENOSYS))
++         .Else(Error(fs_denied_errno));
++   }
+++#endif
++ 
++   if (SyscallSets::IsFileSystem(sysno) ||
++       SyscallSets::IsCurrentDirectory(sysno)) {
++@@ -366,7 +368,7 @@ ResultExpr EvaluateSyscallImpl(int fs_denied_errno,
++   // Allow creating pipes, but don't allow weird flags to pipe2().
++   // O_NOTIFICATION_PIPE (== O_EXCL) can be used to create
++   // "notification pipes", which are rarely used.
++-#if !defined(__aarch64__)
+++#if !defined(__aarch64__) && !defined(__loongarch__)
++   if (sysno == __NR_pipe) {
++     return Allow();
++   }
++diff --git a/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.cc b/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.cc
++index 455fb78098113fb06be918366f1fb5ff419a3871..ddac5dd795ead022fc1fa23c5428a65a157b8125 100644
++--- a/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.cc
+++++ b/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.cc
++@@ -359,6 +359,7 @@ intptr_t SIGSYSSchedHandler(const struct arch_seccomp_data& args,
++ 
++ intptr_t SIGSYSFstatatHandler(const struct arch_seccomp_data& args,
++                               void* fs_denied_errno) {
+++#if !defined(__loongarch__)
++   if (args.nr == __NR_fstatat_default) {
++     if (*reinterpret_cast<const char*>(args.args[1]) == '\0' &&
++         args.args[3] == static_cast<uint64_t>(AT_EMPTY_PATH)) {
++@@ -367,6 +368,7 @@ intptr_t SIGSYSFstatatHandler(const struct arch_seccomp_data& args,
++     }
++     return -reinterpret_cast<intptr_t>(fs_denied_errno);
++   }
+++#endif
++ 
++   CrashSIGSYS_Handler(args, fs_denied_errno);
++ 
++diff --git a/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc b/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
++index bb0e13f4d2d9c85267ca790144f3898eb3cd3829..38beceaa6afe2df71766f742e6e4f7a6e8fe65be 100644
++--- a/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
+++++ b/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
++@@ -37,7 +37,7 @@
++ 
++ #if (BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS_LACROS)) && \
++     !defined(__arm__) && !defined(__aarch64__) &&             \
++-    !defined(PTRACE_GET_THREAD_AREA)
+++    !defined(PTRACE_GET_THREAD_AREA) && !defined(__loongarch__)
++ // Also include asm/ptrace-abi.h since ptrace.h in older libc (for instance
++ // the one in Ubuntu 16.04 LTS) is missing PTRACE_GET_THREAD_AREA.
++ // asm/ptrace-abi.h doesn't exist on arm32 and PTRACE_GET_THREAD_AREA isn't
++@@ -347,7 +347,7 @@ ResultExpr RestrictFutex() {
++       .Cases({FUTEX_WAIT, FUTEX_WAKE, FUTEX_REQUEUE, FUTEX_CMP_REQUEUE,
++ #if BUILDFLAG(ENABLE_MUTEX_PRIORITY_INHERITANCE)
++               // Enable priority-inheritance operations.
++-              FUTEX_LOCK_PI, FUTEX_UNLOCK_PI, FUTEX_TRYLOCK_PI,
+++              FUTEX_LOCK_PI, FUTEX_LOCK_PI2, FUTEX_UNLOCK_PI, FUTEX_TRYLOCK_PI,
++               FUTEX_WAIT_REQUEUE_PI, FUTEX_CMP_REQUEUE_PI,
++ #endif  // BUILDFLAG(ENABLE_MUTEX_PRIORITY_INHERITANCE)
++               FUTEX_WAKE_OP, FUTEX_WAIT_BITSET, FUTEX_WAKE_BITSET},
++@@ -464,8 +464,11 @@ ResultExpr RestrictPtrace() {
++   return Switch(request)
++       .Cases({
++ #if !defined(__aarch64__)
++-                 PTRACE_GETREGS, PTRACE_GETFPREGS, PTRACE_GET_THREAD_AREA,
+++                 PTRACE_GETREGS, PTRACE_GETFPREGS,
++                  PTRACE_GETREGSET,
+++#if !defined(__loongarch__)
+++                 PTRACE_GET_THREAD_AREA,
+++#endif
++ #endif
++ #if defined(__arm__)
++                  PTRACE_GETVFPREGS,
++diff --git a/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc b/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
++index 4cde2837d47f8d1e1816f83b15388d5c650d4754..43589c8e246fe43234a5001eccb46e1259e45ad3 100644
++--- a/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
+++++ b/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
++@@ -103,7 +103,7 @@ bool SyscallSets::IsUmask(int sysno) {
++ // Both EPERM and ENOENT are valid errno unless otherwise noted in comment.
++ bool SyscallSets::IsFileSystem(int sysno) {
++   switch (sysno) {
++-#if !defined(__aarch64__)
+++#if !defined(__aarch64__) && !defined(__loongarch__)
++     case __NR_access:  // EPERM not a valid errno.
++     case __NR_chmod:
++     case __NR_chown:
++@@ -161,7 +161,9 @@ bool SyscallSets::IsFileSystem(int sysno) {
++ #endif
++     case __NR_openat:
++     case __NR_readlinkat:
+++#if !defined(__loongarch__)
++     case __NR_renameat:
+++#endif
++     case __NR_renameat2:
++ #if defined(__i386__) || defined(__arm__) || \
++     (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS))
++@@ -211,7 +213,11 @@ bool SyscallSets::IsTruncate(int sysno) {
++ 
++ bool SyscallSets::IsAllowedFileSystemAccessViaFd(int sysno) {
++   switch (sysno) {
+++#if !defined(__loongarch__)
++     case __NR_fstat:
+++#else
+++    case __NR_statx:
+++#endif
++     case __NR_ftruncate:
++ #if defined(__i386__) || defined(__arm__) || \
++     (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS))
++@@ -241,7 +247,7 @@ bool SyscallSets::IsAllowedFileSystemAccessViaFd(int sysno) {
++     case __NR_oldfstat:
++ #endif
++ #if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
++-    defined(__aarch64__)
+++    defined(__aarch64__) || defined(__loongarch__)
++     case __NR_sync_file_range:  // EPERM not a valid errno.
++ #elif defined(__arm__)
++     case __NR_arm_sync_file_range:  // EPERM not a valid errno.
++@@ -260,7 +266,7 @@ bool SyscallSets::IsDeniedFileSystemAccessViaFd(int sysno) {
++ #if defined(__i386__) || defined(__arm__)
++     case __NR_fchown32:
++ #endif
++-#if !defined(__aarch64__)
+++#if !defined(__aarch64__) && !defined(__loongarch__)
++     case __NR_getdents:    // EPERM not a valid errno.
++ #endif
++     case __NR_getdents64:  // EPERM not a valid errno.
++@@ -339,7 +345,7 @@ bool SyscallSets::IsProcessPrivilegeChange(int sysno) {
++ bool SyscallSets::IsProcessGroupOrSession(int sysno) {
++   switch (sysno) {
++     case __NR_setpgid:
++-#if !defined(__aarch64__)
+++#if !defined(__aarch64__) && !defined(__loongarch__)
++     case __NR_getpgrp:
++ #endif
++     case __NR_setsid:
++@@ -373,7 +379,7 @@ bool SyscallSets::IsAllowedSignalHandling(int sysno) {
++     case __NR_rt_sigqueueinfo:
++     case __NR_rt_sigsuspend:
++     case __NR_rt_tgsigqueueinfo:
++-#if !defined(__aarch64__)
+++#if !defined(__aarch64__) && !defined(__loongarch__)
++     case __NR_signalfd:
++ #endif
++     case __NR_signalfd4:
++@@ -397,12 +403,12 @@ bool SyscallSets::IsAllowedOperationOnFd(int sysno) {
++   switch (sysno) {
++     case __NR_close:
++     case __NR_dup:
++-#if !defined(__aarch64__)
+++#if !defined(__aarch64__) && !defined(__loongarch__)
++     case __NR_dup2:
++ #endif
++     case __NR_dup3:
++ #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
++-    defined(__aarch64__)
+++    defined(__aarch64__) || defined(__loongarch__)
++     case __NR_shutdown:
++ #endif
++       return true;
++@@ -441,7 +447,7 @@ bool SyscallSets::IsAllowedProcessStartOrDeath(int sysno) {
++       return true;
++     case __NR_clone:  // Should be parameter-restricted.
++     case __NR_setns:  // Privileged.
++-#if !defined(__aarch64__)
+++#if !defined(__aarch64__) && !defined(__loongarch__)
++     case __NR_fork:
++ #endif
++ #if defined(__i386__) || defined(__x86_64__)
++@@ -452,7 +458,7 @@ bool SyscallSets::IsAllowedProcessStartOrDeath(int sysno) {
++ #endif
++     case __NR_set_tid_address:
++     case __NR_unshare:
++-#if !defined(__mips__) && !defined(__aarch64__)
+++#if !defined(__mips__) && !defined(__aarch64__) && !defined(__loongarch__)
++     case __NR_vfork:
++ #endif
++     default:
++@@ -477,7 +483,7 @@ bool SyscallSets::IsAllowedFutex(int sysno) {
++ 
++ bool SyscallSets::IsAllowedEpoll(int sysno) {
++   switch (sysno) {
++-#if !defined(__aarch64__)
+++#if !defined(__aarch64__) && !defined(__loongarch__)
++     case __NR_epoll_create:
++     case __NR_epoll_wait:
++ #endif
++@@ -499,7 +505,7 @@ bool SyscallSets::IsAllowedEpoll(int sysno) {
++ bool SyscallSets::IsDeniedGetOrModifySocket(int sysno) {
++   switch (sysno) {
++ #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
++-    defined(__aarch64__)
+++    defined(__aarch64__) || defined(__loongarch__)
++     case __NR_accept:
++     case __NR_accept4:
++     case __NR_bind:
++@@ -553,7 +559,7 @@ bool SyscallSets::IsAllowedAddressSpaceAccess(int sysno) {
++     case __NR_mincore:
++     case __NR_mlockall:
++ #if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
++-    defined(__aarch64__)
+++    defined(__aarch64__) || defined(__loongarch__)
++     case __NR_mmap:
++ #endif
++ #if defined(__i386__) || defined(__arm__) || \
++@@ -586,7 +592,7 @@ bool SyscallSets::IsAllowedGeneralIo(int sysno) {
++     (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS))
++     case __NR__llseek:
++ #endif
++-#if !defined(__aarch64__)
+++#if !defined(__aarch64__) && !defined(__loongarch__)
++     case __NR_poll:
++ #endif
++     case __NR_ppoll:
++@@ -607,7 +613,7 @@ bool SyscallSets::IsAllowedGeneralIo(int sysno) {
++     case __NR_recv:
++ #endif
++ #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
++-    defined(__aarch64__)
+++    defined(__aarch64__) || defined(__loongarch__)
++     case __NR_recvfrom:  // Could specify source.
++     case __NR_recvmsg:   // Could specify source.
++ #endif
++@@ -622,7 +628,7 @@ bool SyscallSets::IsAllowedGeneralIo(int sysno) {
++     case __NR_send:
++ #endif
++ #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
++-    defined(__aarch64__)
+++    defined(__aarch64__) || defined(__loongarch__)
++     case __NR_sendmsg:  // Could specify destination.
++     case __NR_sendto:   // Could specify destination.
++ #endif
++@@ -671,7 +677,7 @@ bool SyscallSets::IsSeccomp(int sysno) {
++ bool SyscallSets::IsAllowedBasicScheduler(int sysno) {
++   switch (sysno) {
++     case __NR_sched_yield:
++-#if !defined(__aarch64__)
+++#if !defined(__aarch64__) && !defined(__loongarch__)
++     case __NR_pause:
++ #endif
++     case __NR_nanosleep:
++@@ -755,7 +761,7 @@ bool SyscallSets::IsNuma(int sysno) {
++     case __NR_getcpu:
++     case __NR_mbind:
++ #if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
++-    defined(__aarch64__)
+++    defined(__aarch64__) || defined(__loongarch__)
++     case __NR_migrate_pages:
++ #endif
++     case __NR_move_pages:
++@@ -803,7 +809,9 @@ bool SyscallSets::IsGlobalProcessEnvironment(int sysno) {
++     case __NR_getrusage:
++     case __NR_personality:  // Can change its personality as well.
++     case __NR_prlimit64:    // Like setrlimit / getrlimit.
+++#if !defined(__loongarch__)
++     case __NR_setrlimit:
+++#endif
++     case __NR_times:
++       return true;
++     default:
++@@ -825,7 +833,7 @@ bool SyscallSets::IsDebug(int sysno) {
++ 
++ bool SyscallSets::IsGlobalSystemStatus(int sysno) {
++   switch (sysno) {
++-#if !defined(__aarch64__)
+++#if !defined(__aarch64__) && !defined(__loongarch__)
++     case __NR__sysctl:
++     case __NR_sysfs:
++ #endif
++@@ -843,7 +851,7 @@ bool SyscallSets::IsGlobalSystemStatus(int sysno) {
++ 
++ bool SyscallSets::IsEventFd(int sysno) {
++   switch (sysno) {
++-#if !defined(__aarch64__)
+++#if !defined(__aarch64__) && !defined(__loongarch__)
++     case __NR_eventfd:
++ #endif
++     case __NR_eventfd2:
++@@ -895,7 +903,7 @@ bool SyscallSets::IsKeyManagement(int sysno) {
++ }
++ 
++ #if defined(__x86_64__) || defined(__arm__) || defined(__aarch64__) || \
++-    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS))
+++    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS)) || defined(__loongarch__)
++ bool SyscallSets::IsSystemVSemaphores(int sysno) {
++   switch (sysno) {
++     case __NR_semctl:
++@@ -915,7 +923,7 @@ bool SyscallSets::IsSystemVSemaphores(int sysno) {
++ 
++ #if defined(__i386__) || defined(__x86_64__) || defined(__arm__) || \
++     defined(__aarch64__) ||                                         \
++-    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS))
+++    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS)) || defined(__loongarch__)
++ // These give a lot of ambient authority and bypass the setuid sandbox.
++ bool SyscallSets::IsSystemVSharedMemory(int sysno) {
++   switch (sysno) {
++@@ -931,7 +939,7 @@ bool SyscallSets::IsSystemVSharedMemory(int sysno) {
++ #endif
++ 
++ #if defined(__x86_64__) || defined(__arm__) || defined(__aarch64__) || \
++-    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS))
+++    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS)) || defined(__loongarch__)
++ bool SyscallSets::IsSystemVMessageQueue(int sysno) {
++   switch (sysno) {
++     case __NR_msgctl:
++@@ -962,7 +970,7 @@ bool SyscallSets::IsSystemVIpc(int sysno) {
++ 
++ bool SyscallSets::IsAnySystemV(int sysno) {
++ #if defined(__x86_64__) || defined(__arm__) || defined(__aarch64__) || \
++-    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS))
+++    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS)) || defined(__loongarch__)
++   return IsSystemVMessageQueue(sysno) || IsSystemVSemaphores(sysno) ||
++          IsSystemVSharedMemory(sysno);
++ #elif defined(__i386__) || \
++@@ -999,7 +1007,7 @@ bool SyscallSets::IsAdvancedScheduler(int sysno) {
++ bool SyscallSets::IsInotify(int sysno) {
++   switch (sysno) {
++     case __NR_inotify_add_watch:
++-#if !defined(__aarch64__)
+++#if !defined(__aarch64__) && !defined(__loongarch__)
++     case __NR_inotify_init:
++ #endif
++     case __NR_inotify_init1:
++@@ -1134,7 +1142,7 @@ bool SyscallSets::IsMisc(int sysno) {
++ #if defined(__x86_64__)
++     case __NR_tuxcall:
++ #endif
++-#if !defined(__aarch64__)
+++#if !defined(__aarch64__) && !defined(__loongarch__)
++     case __NR_vserver:
++ #endif
++       return true;
++diff --git a/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h b/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h
++index 9be7b03ec4377efa7ead49d190a91a194c45494e..39522700467a64527e06e2c3afcb755e384e9db3 100644
++--- a/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h
+++++ b/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h
++@@ -79,18 +79,18 @@ class SANDBOX_EXPORT SyscallSets {
++   static bool IsAsyncIo(int sysno);
++   static bool IsKeyManagement(int sysno);
++ #if defined(__x86_64__) || defined(__arm__) || defined(__aarch64__) || \
++-    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS))
+++    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS)) || defined(__loongarch__)
++   static bool IsSystemVSemaphores(int sysno);
++ #endif
++ #if defined(__i386__) || defined(__x86_64__) || defined(__arm__) || \
++     defined(__aarch64__) ||                                         \
++-    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS))
+++    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS)) || defined(__loongarch__)
++   // These give a lot of ambient authority and bypass the setuid sandbox.
++   static bool IsSystemVSharedMemory(int sysno);
++ #endif
++ 
++ #if defined(__x86_64__) || defined(__arm__) || defined(__aarch64__) || \
++-    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS))
+++    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS)) || defined(__loongarch__)
++   static bool IsSystemVMessageQueue(int sysno);
++ #endif
++ 
++diff --git a/sandbox/linux/seccomp-bpf/syscall.cc b/sandbox/linux/seccomp-bpf/syscall.cc
++index 6b772c563c7fd4401ba1b0dd549205c2116f2df4..7e1a2277b319d049c4b289ee6872b3cb1f100e20 100644
++--- a/sandbox/linux/seccomp-bpf/syscall.cc
+++++ b/sandbox/linux/seccomp-bpf/syscall.cc
++@@ -23,7 +23,7 @@ namespace sandbox {
++ namespace {
++ 
++ #if defined(ARCH_CPU_X86_FAMILY) || defined(ARCH_CPU_ARM_FAMILY) || \
++-    defined(ARCH_CPU_MIPS_FAMILY)
+++    defined(ARCH_CPU_MIPS_FAMILY) || defined(ARCH_CPU_LOONGARCH_FAMILY)
++ // Number that's not currently used by any Linux kernel ABIs.
++ const int kInvalidSyscallNumber = 0x351d3;
++ #else
++@@ -313,6 +313,27 @@ asm(// We need to be able to tell the kernel exactly where we made a
++     "2:ret\n"
++     ".cfi_endproc\n"
++     ".size SyscallAsm, .-SyscallAsm\n"
+++#elif defined(__loongarch__)
+++    ".text\n"
+++    ".align 2\n"
+++    ".type SyscallAsm, %function\n"
+++    "SyscallAsm:\n"
+++    ".cfi_startproc\n"
+++    "bge $a0, $zero, 1f\n"
+++    "la.pcrel $a0, 2f\n"
+++    "b 2f\n"
+++    "1:ld.d $a5, $a6, 40\n"
+++    "ld.d $a4, $a6, 32\n"
+++    "ld.d $a3, $a6, 24\n"
+++    "ld.d $a2, $a6, 16\n"
+++    "ld.d $a1, $a6, 8\n"
+++    "move $a7, $a0\n"
+++    "ld.d $a0, $a6, 0\n"
+++    // Enter the kernel
+++    "syscall 0\n"
+++    "2:ret\n"
+++    ".cfi_endproc\n"
+++    ".size SyscallAsm, .-SyscallAsm\n"
++ #endif
++     );  // asm
++ 
++@@ -430,6 +451,18 @@ intptr_t Syscall::Call(int nr,
++     ret = inout;
++   }
++ 
+++#elif defined(__loongarch__)
+++  intptr_t ret;
+++  {
+++    register intptr_t inout __asm__("$r4") = nr;
+++    register const intptr_t* data __asm__("$r10") = args;
+++    asm volatile("bl SyscallAsm\n"
+++                 : "=r"(inout)
+++                 : "0"(inout), "r"(data)
+++                 : "memory", "$r5", "$r6", "$r7", "$r8", "$r9", "$r11", "$r1");
+++    ret = inout;
+++  }
+++
++ #else
++ #error "Unimplemented architecture"
++ #endif
++diff --git a/sandbox/linux/services/credentials.cc b/sandbox/linux/services/credentials.cc
++index 5d1615d206dc3dfd8925deb384d76e6eab190e1c..8821c35aff2d7cbc8e200baed33be3fe1184b886 100644
++--- a/sandbox/linux/services/credentials.cc
+++++ b/sandbox/linux/services/credentials.cc
++@@ -85,7 +85,7 @@ bool ChrootToSafeEmptyDir() {
++   pid_t pid = -1;
++   alignas(16) char stack_buf[PTHREAD_STACK_MIN];
++ #if defined(ARCH_CPU_X86_FAMILY) || defined(ARCH_CPU_ARM_FAMILY) || \
++-    defined(ARCH_CPU_MIPS_FAMILY)
+++    defined(ARCH_CPU_MIPS_FAMILY) || defined(ARCH_CPU_LOONGARCH_FAMILY)
++   // The stack grows downward.
++   void* stack = stack_buf + sizeof(stack_buf);
++ #else
++diff --git a/sandbox/linux/services/syscall_wrappers.cc b/sandbox/linux/services/syscall_wrappers.cc
++index 74d48f1f91490620b4ce6a693eea78bd75acef59..e2c8a0a2dbeb0187a88cc529b671d9a98a20ee84 100644
++--- a/sandbox/linux/services/syscall_wrappers.cc
+++++ b/sandbox/linux/services/syscall_wrappers.cc
++@@ -5,6 +5,7 @@
++ #include "sandbox/linux/services/syscall_wrappers.h"
++ 
++ #include <fcntl.h>
+++#include <linux/stat.h>
++ #include <pthread.h>
++ #include <sched.h>
++ #include <setjmp.h>
++@@ -58,7 +59,7 @@ long sys_clone(unsigned long flags,
++   if (ctid) MSAN_UNPOISON(ctid, sizeof(*ctid));
++   // See kernel/fork.c in Linux. There is different ordering of sys_clone
++   // parameters depending on CONFIG_CLONE_BACKWARDS* configuration options.
++-#if defined(ARCH_CPU_X86_64)
+++#if defined(ARCH_CPU_X86_64) || defined(ARCH_CPU_LOONGARCH_FAMILY)
++   return syscall(__NR_clone, flags, child_stack, ptid, ctid, tls);
++ #elif defined(ARCH_CPU_X86) || defined(ARCH_CPU_ARM_FAMILY) || \
++     defined(ARCH_CPU_MIPS_FAMILY)
++@@ -163,9 +164,53 @@ int sys_sigaction(int signum,
++   return sigaction(signum, act, oldact);
++ }
++ 
+++// follow glibc __cp_stat64_statx
+++void statx_to_stat(struct kernel_stat* to, struct kernel_statx* from) {
+++  memset(to, 0, sizeof(struct kernel_stat));
+++  to->st_dev = ((from->stx_dev_minor & 0xff) | (from->stx_dev_major << 8) |
+++                ((from->stx_dev_minor & ~0xff) << 12));
+++  to->st_rdev = ((from->stx_rdev_minor & 0xff) | (from->stx_rdev_major << 8) |
+++                 ((from->stx_rdev_minor & ~0xff) << 12));
+++  to->st_ino = from->stx_ino;
+++  to->st_mode = from->stx_mode;
+++  to->st_nlink = from->stx_nlink;
+++  to->st_uid = from->stx_uid;
+++  to->st_gid = from->stx_gid;
+++  to->st_atime_ = from->stx_atime.tv_sec;
+++  to->st_atime_nsec_ = from->stx_atime.tv_nsec;
+++  to->st_mtime_ = from->stx_mtime.tv_sec;
+++  to->st_mtime_nsec_ = from->stx_mtime.tv_nsec;
+++  to->st_ctime_ = from->stx_ctime.tv_sec;
+++  to->st_ctime_nsec_ = from->stx_ctime.tv_nsec;
+++  to->st_size = from->stx_size;
+++  to->st_blocks = from->stx_blocks;
+++  to->st_blksize = from->stx_blksize;
+++}
+++
+++int sys_statx(int fd,
+++              const char* path,
+++              int flags,
+++              unsigned int mask,
+++              struct kernel_statx* statx_buf) {
+++#if defined(__NR_statx)
+++  int res = syscall(__NR_statx, fd, path, flags, mask, statx_buf);
+++  if (res == 0)
+++    MSAN_UNPOISON(statx_buf, sizeof(*statx_buf));
+++  return res;
+++#else  // defined(__NR_statx)
+++  RAW_CHECK(false);
+++  return -ENOSYS;
+++#endif
+++}
+++
++ int sys_stat(const char* path, struct kernel_stat* stat_buf) {
++   int res;
++-#if !defined(__NR_stat)
+++#if defined(__NR_statx)
+++  kernel_statx statx_buf;
+++  res = syscall(__NR_statx, AT_FDCWD, path, AT_NO_AUTOMOUNT, STATX_BASIC_STATS, &statx_buf);
+++  if (res == 0)
+++    statx_to_stat(stat_buf, &statx_buf);
+++#elif !defined(__NR_stat)
++   res = syscall(__NR_newfstatat, AT_FDCWD, path, stat_buf, 0);
++ #else
++   res = syscall(__NR_stat, path, stat_buf);
++@@ -177,7 +222,12 @@ int sys_stat(const char* path, struct kernel_stat* stat_buf) {
++ 
++ int sys_lstat(const char* path, struct kernel_stat* stat_buf) {
++   int res;
++-#if !defined(__NR_lstat)
+++#if defined(__NR_statx)
+++  kernel_statx statx_buf;
+++  res = syscall(__NR_statx, AT_FDCWD, path, AT_NO_AUTOMOUNT | AT_SYMLINK_NOFOLLOW, STATX_BASIC_STATS, &statx_buf);
+++  if (res == 0)
+++    statx_to_stat(stat_buf, &statx_buf);
+++#elif !defined(__NR_lstat)
++   res = syscall(__NR_newfstatat, AT_FDCWD, path, stat_buf, AT_SYMLINK_NOFOLLOW);
++ #else
++   res = syscall(__NR_lstat, path, stat_buf);
++diff --git a/sandbox/linux/services/syscall_wrappers.h b/sandbox/linux/services/syscall_wrappers.h
++index a6b22eb5387eb56b7cd524daa1c985483a6f061a..824be9def67e3941f8736b14eb4b133994d462c3 100644
++--- a/sandbox/linux/services/syscall_wrappers.h
+++++ b/sandbox/linux/services/syscall_wrappers.h
++@@ -19,6 +19,7 @@ struct cap_hdr;
++ struct cap_data;
++ struct kernel_stat;
++ struct kernel_stat64;
+++struct kernel_statx;
++ struct landlock_ruleset_attr;
++ 
++ namespace sandbox {
++@@ -92,6 +93,7 @@ SANDBOX_EXPORT int sys_sigaction(int signum,
++ // architectures, with the same capabilities as stat() and lstat().
++ SANDBOX_EXPORT int sys_stat(const char* path, struct kernel_stat* stat_buf);
++ SANDBOX_EXPORT int sys_lstat(const char* path, struct kernel_stat* stat_buf);
+++SANDBOX_EXPORT int sys_statx(int fd, const char* path, int flags, unsigned int mask, struct kernel_statx* statx_buf);
++ 
++ // Takes care of unpoisoning |stat_buf| for MSAN. Check-fails if fstatat64() is
++ // not a supported syscall on the current platform.
++diff --git a/sandbox/linux/syscall_broker/broker_client.cc b/sandbox/linux/syscall_broker/broker_client.cc
++index 848af1020ded70327a9927ab8723af9be985f593..7e9f214183024f11aaa5b4b09bcc8f1f6d6eb38e 100644
++--- a/sandbox/linux/syscall_broker/broker_client.cc
+++++ b/sandbox/linux/syscall_broker/broker_client.cc
++@@ -198,6 +198,21 @@ int BrokerClient::Stat64(const char* pathname,
++                            sizeof(*sb));
++ }
++ 
+++int BrokerClient::Statx(const char* pathname,
+++                         bool follow_links,
+++                         struct kernel_statx* sb) const {
+++  if (!pathname || !sb)
+++    return -EFAULT;
+++
+++  if (fast_check_in_client_ &&
+++      !CommandStatIsSafe(policy_->allowed_command_set,
+++                         *policy_->file_permissions, pathname)) {
+++    return -policy_->file_permissions->denied_errno();
+++  }
+++  return StatFamilySyscall(COMMAND_STATX, pathname, follow_links, sb,
+++                           sizeof(*sb));
+++}
+++
++ int BrokerClient::Unlink(const char* path) const {
++   if (!path)
++     return -EFAULT;
++diff --git a/sandbox/linux/syscall_broker/broker_client.h b/sandbox/linux/syscall_broker/broker_client.h
++index 9d0fdee5f3a2cad6bf89bd200f81517547314d5c..1c7f951436973b38a3bb75c8ad5615cbbe0bec4a 100644
++--- a/sandbox/linux/syscall_broker/broker_client.h
+++++ b/sandbox/linux/syscall_broker/broker_client.h
++@@ -67,6 +67,9 @@ class SANDBOX_EXPORT BrokerClient : public SyscallDispatcher {
++   int Stat64(const char* pathname,
++              bool follow_links,
++              struct kernel_stat64* sb) const override;
+++  int Statx(const char* pathname,
+++             bool follow_links,
+++             struct kernel_statx* sb) const override;
++   int Unlink(const char* unlink) const override;
++   int InotifyAddWatch(int fd,
++                       const char* pathname,
++diff --git a/sandbox/linux/syscall_broker/broker_command.h b/sandbox/linux/syscall_broker/broker_command.h
++index d44c42fe2b23274b485a9f58f8edcd7fbd4e5faf..5fd22d8186f1a1d6fed861e622d6d207605e0f54 100644
++--- a/sandbox/linux/syscall_broker/broker_command.h
+++++ b/sandbox/linux/syscall_broker/broker_command.h
++@@ -42,6 +42,7 @@ enum BrokerCommand {
++   COMMAND_RMDIR,
++   COMMAND_STAT,
++   COMMAND_STAT64,
+++  COMMAND_STATX,
++   COMMAND_UNLINK,
++   COMMAND_INOTIFY_ADD_WATCH,
++ 
++diff --git a/sandbox/linux/syscall_broker/broker_file_permission.h b/sandbox/linux/syscall_broker/broker_file_permission.h
++index 7771ae1521d017db68ef6c75c87ad1c45921538d..a4c0089dbe0acc46529567bc2051b49b2a97c949 100644
++--- a/sandbox/linux/syscall_broker/broker_file_permission.h
+++++ b/sandbox/linux/syscall_broker/broker_file_permission.h
++@@ -5,6 +5,7 @@
++ #ifndef SANDBOX_LINUX_SYSCALL_BROKER_BROKER_FILE_PERMISSION_H_
++ #define SANDBOX_LINUX_SYSCALL_BROKER_BROKER_FILE_PERMISSION_H_
++ 
+++#include <cstdint>
++ #include <bitset>
++ #include <cstdint>
++ #include <string>
++diff --git a/sandbox/linux/syscall_broker/broker_host.cc b/sandbox/linux/syscall_broker/broker_host.cc
++index 7afa8b2395c15a2cfc5cad7c9ee718cd6679665e..21a10f20e74c87f86aabc419fe944fe012966699 100644
++--- a/sandbox/linux/syscall_broker/broker_host.cc
+++++ b/sandbox/linux/syscall_broker/broker_host.cc
++@@ -302,6 +302,21 @@ void BrokerHost::StatFileForIPC(BrokerCommand command_type,
++     RAW_CHECK(reply->AddIntToMessage(0));
++     RAW_CHECK(
++         reply->AddDataToMessage(reinterpret_cast<char*>(&sb), sizeof(sb)));
+++#elif defined(__loongarch__)
+++    // handle COMMAND_STATX
+++    DCHECK(command_type == COMMAND_STATX);
+++    struct kernel_statx sb;
+++
+++    int sts = sandbox::sys_statx(AT_FDCWD, file_to_access,
+++                                     follow_links ? 0 : AT_SYMLINK_NOFOLLOW,
+++				     STATX_BASIC_STATS, &sb);
+++    if (sts < 0) {
+++      RAW_CHECK(reply->AddIntToMessage(-errno));
+++      return;
+++    }
+++    RAW_CHECK(reply->AddIntToMessage(0));
+++    RAW_CHECK(
+++        reply->AddDataToMessage(reinterpret_cast<char*>(&sb), sizeof(sb)));
++ #else  // defined(__NR_fstatat64)
++     // We should not reach here on 64-bit systems, as the *stat*64() are only
++     // necessary on 32-bit.
++@@ -441,7 +456,8 @@ bool BrokerHost::HandleRemoteCommand(BrokerSimpleMessage* message,
++       break;
++     }
++     case COMMAND_STAT:
++-    case COMMAND_STAT64: {
+++    case COMMAND_STAT64:
+++    case COMMAND_STATX: {
++       const char* requested_filename;
++       if (!message->ReadString(&requested_filename)) {
++         return false;
++diff --git a/sandbox/linux/syscall_broker/broker_process.cc b/sandbox/linux/syscall_broker/broker_process.cc
++index a452430a906e59d830f121270412e1cf40d900ca..3144c80a2e00e2dc0561f7bf0d5713a9e121f8e7 100644
++--- a/sandbox/linux/syscall_broker/broker_process.cc
+++++ b/sandbox/linux/syscall_broker/broker_process.cc
++@@ -122,44 +122,46 @@ bool BrokerProcess::IsSyscallBrokerable(int sysno, bool fast_check) const {
++   // and are default disabled in Android. So, we should refuse to broker them
++   // to be consistent with the platform's restrictions.
++   switch (sysno) {
++-#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID)
+++#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID) && !defined(__loongarch__)
++     case __NR_access:
++ #endif
++     case __NR_faccessat:
++     case __NR_faccessat2:
++       return !fast_check || policy_->allowed_command_set.test(COMMAND_ACCESS);
++ 
++-#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID)
+++#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID) && !defined(__loongarch__)
++     case __NR_mkdir:
++ #endif
++     case __NR_mkdirat:
++       return !fast_check || policy_->allowed_command_set.test(COMMAND_MKDIR);
++ 
++-#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID)
+++#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID) && !defined(__loongarch__)
++     case __NR_open:
++ #endif
++     case __NR_openat:
++       return !fast_check || policy_->allowed_command_set.test(COMMAND_OPEN);
++ 
++-#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID)
+++#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID) && !defined(__loongarch__)
++     case __NR_readlink:
++ #endif
++     case __NR_readlinkat:
++       return !fast_check || policy_->allowed_command_set.test(COMMAND_READLINK);
++ 
++-#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID)
+++#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID) && !defined(__loongarch__)
++     case __NR_rename:
++ #endif
+++#if !defined(__loongarch__)
++     case __NR_renameat:
+++#endif
++     case __NR_renameat2:
++       return !fast_check || policy_->allowed_command_set.test(COMMAND_RENAME);
++ 
++-#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID)
+++#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID) && !defined(__loongarch__)
++     case __NR_rmdir:
++       return !fast_check || policy_->allowed_command_set.test(COMMAND_RMDIR);
++ #endif
++ 
++-#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID)
+++#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID) && !defined(__loongarch__)
++     case __NR_stat:
++     case __NR_lstat:
++ #endif
++@@ -169,6 +171,9 @@ bool BrokerProcess::IsSyscallBrokerable(int sysno, bool fast_check) const {
++ #if defined(__NR_fstatat64)
++     case __NR_fstatat64:
++ #endif
+++#if defined(__NR_statx)
+++    case __NR_statx:
+++#endif
++ #if defined(__x86_64__) || defined(__aarch64__)
++     case __NR_newfstatat:
++ #endif
++@@ -184,7 +189,7 @@ bool BrokerProcess::IsSyscallBrokerable(int sysno, bool fast_check) const {
++       return !fast_check || policy_->allowed_command_set.test(COMMAND_STAT);
++ #endif
++ 
++-#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID)
+++#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID) && !defined(__loongarch__)
++     case __NR_unlink:
++       return !fast_check || policy_->allowed_command_set.test(COMMAND_UNLINK);
++ #endif
++diff --git a/sandbox/linux/syscall_broker/syscall_dispatcher.cc b/sandbox/linux/syscall_broker/syscall_dispatcher.cc
++index a0de94badee68269516ab3800dd238611f9db47d..1c5c354a3390d3592eae80befea20b2274f4d1dc 100644
++--- a/sandbox/linux/syscall_broker/syscall_dispatcher.cc
+++++ b/sandbox/linux/syscall_broker/syscall_dispatcher.cc
++@@ -174,6 +174,19 @@ int SyscallDispatcher::DispatchSyscall(const arch_seccomp_data& args) {
++       return Stat64(reinterpret_cast<const char*>(args.args[0]), true,
++                     reinterpret_cast<struct kernel_stat64*>(args.args[1]));
++ #endif
+++#if defined(__NR_statx)
+++    case __NR_statx:
+++      // we have ensured that the statx does not have AT_EMPTY_PATH in HandleViaBroker()
+++      // so this is stat/lstat instead of fstat
+++      // see PerformStatat
+++      if (static_cast<int>(args.args[0]) != AT_FDCWD) {
+++        return -EPERM;
+++      }
+++
+++      return Statx(reinterpret_cast<const char*>(args.args[1]),
+++		   !(static_cast<int>(args.args[2]) & AT_SYMLINK_NOFOLLOW),
+++                   reinterpret_cast<struct kernel_statx*>(args.args[4]));
+++#endif
++ #if defined(__NR_lstat)
++     case __NR_lstat:
++       // See https://crbug.com/847096
++diff --git a/sandbox/linux/syscall_broker/syscall_dispatcher.h b/sandbox/linux/syscall_broker/syscall_dispatcher.h
++index 906c37d922f46122bfe07503ee4afee156e4e0c2..1804f4883791975ea0db93cd24f0ac33bb9dff73 100644
++--- a/sandbox/linux/syscall_broker/syscall_dispatcher.h
+++++ b/sandbox/linux/syscall_broker/syscall_dispatcher.h
++@@ -49,6 +49,9 @@ class SANDBOX_EXPORT SyscallDispatcher {
++   virtual int Stat64(const char* pathname,
++                      bool follow_links,
++                      struct kernel_stat64* sb) const = 0;
+++  virtual int Statx(const char* pathname,
+++                     bool follow_links,
+++                     struct kernel_statx* sb) const = 0;
++ 
++   // Emulates unlink()/unlinkat().
++   virtual int Unlink(const char* unlink) const = 0;
++diff --git a/sandbox/linux/system_headers/linux_seccomp.h b/sandbox/linux/system_headers/linux_seccomp.h
++index 8690a96eb01b1b4f7b5df8f91f5c7c2476088c5d..45d7a1781958b27bbc0369a08f8c239df7ce65f8 100644
++--- a/sandbox/linux/system_headers/linux_seccomp.h
+++++ b/sandbox/linux/system_headers/linux_seccomp.h
++@@ -39,6 +39,10 @@
++ #define EM_AARCH64 183
++ #endif
++ 
+++#ifndef EM_LOONGARCH64
+++#define EM_LOONGARCH64 258
+++#endif
+++
++ #ifndef __AUDIT_ARCH_64BIT
++ #define __AUDIT_ARCH_64BIT 0x80000000
++ #endif
++@@ -71,6 +75,10 @@
++ #define AUDIT_ARCH_AARCH64 (EM_AARCH64 | __AUDIT_ARCH_64BIT | __AUDIT_ARCH_LE)
++ #endif
++ 
+++#ifndef AUDIT_ARCH_LOONGARCH64
+++#define AUDIT_ARCH_LOONGARCH64 (EM_LOONGARCH64 | __AUDIT_ARCH_64BIT | __AUDIT_ARCH_LE)
+++#endif
+++
++ // For prctl.h
++ #ifndef PR_SET_SECCOMP
++ #define PR_SET_SECCOMP               22
++diff --git a/sandbox/linux/system_headers/linux_signal.h b/sandbox/linux/system_headers/linux_signal.h
++index 69ccaf108157863ecfa326f8c8e01fd698c882be..0d29396a6c31a80d6c5850a9f9b4a420d63df335 100644
++--- a/sandbox/linux/system_headers/linux_signal.h
+++++ b/sandbox/linux/system_headers/linux_signal.h
++@@ -13,7 +13,7 @@
++ // (not undefined, but defined different values and in different memory
++ // layouts). So, fill the gap here.
++ #if defined(__i386__) || defined(__x86_64__) || defined(__arm__) || \
++-    defined(__aarch64__)
+++    defined(__aarch64__) || defined(__loongarch__)
++ 
++ #define LINUX_SIGHUP 1
++ #define LINUX_SIGINT 2
++diff --git a/sandbox/linux/system_headers/linux_stat.h b/sandbox/linux/system_headers/linux_stat.h
++index 3aae8cbced775eed6ffa0eb4c5e18776b5554bf3..7b4ca05e6b67e27ba2c168b08c1762761a6f4431 100644
++--- a/sandbox/linux/system_headers/linux_stat.h
+++++ b/sandbox/linux/system_headers/linux_stat.h
++@@ -150,7 +150,7 @@ struct kernel_stat {
++   int st_blocks;
++   int st_pad4[14];
++ };
++-#elif defined(__aarch64__)
+++#elif defined(__aarch64__) || defined(__loongarch__)
++ struct kernel_stat {
++   unsigned long st_dev;
++   unsigned long st_ino;
++@@ -175,6 +175,40 @@ struct kernel_stat {
++ };
++ #endif
++ 
+++// from linux include/uapi/linux/stat.h
+++struct kernel_statx_timestamp {
+++  long tv_sec;
+++  unsigned int tv_nsec;
+++  int __reserved;
+++};
+++
+++struct kernel_statx {
+++  unsigned int stx_mask;
+++  unsigned int stx_blksize;
+++  unsigned long stx_attributes;
+++  unsigned int stx_nlink;
+++  unsigned int stx_uid;
+++  unsigned int stx_gid;
+++  unsigned short stx_mode;
+++  unsigned short __spare0[1];
+++  unsigned long stx_ino;
+++  unsigned long stx_size;
+++  unsigned long stx_blocks;
+++  unsigned long stx_attributes_mask;
+++  struct kernel_statx_timestamp stx_atime;
+++  struct kernel_statx_timestamp stx_btime;
+++  struct kernel_statx_timestamp stx_ctime;
+++  struct kernel_statx_timestamp stx_mtime;
+++  unsigned int stx_rdev_major;
+++  unsigned int stx_rdev_minor;
+++  unsigned int stx_dev_major;
+++  unsigned int stx_dev_minor;
+++  unsigned long stx_mnt_id;
+++  unsigned int stx_dio_mem_align;
+++  unsigned int stx_dio_offset_align;
+++  unsigned long __spare3[12];
+++};
+++
++ #if !defined(AT_EMPTY_PATH)
++ #define AT_EMPTY_PATH 0x1000
++ #endif
++@@ -207,8 +241,14 @@ using default_stat_struct = struct kernel_stat;
++ #define __NR_fstatat_default __NR_newfstatat
++ #define __NR_fstat_default __NR_fstat
++ 
+++#elif defined(__NR_statx)
+++
+++namespace sandbox {
+++using default_stat_struct = struct kernel_statx;
+++}  // namespace sandbox
+++
++ #else
++-#error "one of fstatat64 and newfstatat must be defined"
+++#error "one of fstatat64, newfstatat and statx must be defined"
++ #endif
++ 
++ #endif  // SANDBOX_LINUX_SYSTEM_HEADERS_LINUX_STAT_H_
++diff --git a/sandbox/linux/system_headers/linux_syscalls.h b/sandbox/linux/system_headers/linux_syscalls.h
++index 438147b4018b6b6a8ba051b143316efc7ba54115..46a6f91b7774eca48d4428f0185dd04a918500b4 100644
++--- a/sandbox/linux/system_headers/linux_syscalls.h
+++++ b/sandbox/linux/system_headers/linux_syscalls.h
++@@ -35,5 +35,9 @@
++ #include "sandbox/linux/system_headers/arm64_linux_syscalls.h"
++ #endif
++ 
+++#if defined(__loongarch__)
+++#include "sandbox/linux/system_headers/loong64_linux_syscalls.h"
+++#endif
+++
++ #endif  // SANDBOX_LINUX_SYSTEM_HEADERS_LINUX_SYSCALLS_H_
++ 
++diff --git a/sandbox/linux/system_headers/loong64_linux_syscalls.h b/sandbox/linux/system_headers/loong64_linux_syscalls.h
++new file mode 100644
++index 0000000000000000000000000000000000000000..808d6de7403e01657a8a787f62a96d1ecbcea054
++--- /dev/null
+++++ b/sandbox/linux/system_headers/loong64_linux_syscalls.h
++@@ -0,0 +1,1194 @@
+++// Copyright 2023 The Chromium Authors
+++// Use of this source code is governed by a BSD-style license that can be
+++// found in the LICENSE file.
+++
+++#ifndef SANDBOX_LINUX_SYSTEM_HEADERS_LOONG64_LINUX_SYSCALLS_H_
+++#define SANDBOX_LINUX_SYSTEM_HEADERS_LOONG64_LINUX_SYSCALLS_H_
+++
+++#include <asm-generic/unistd.h>
+++
+++#if !defined(__NR_io_setup)
+++#define __NR_io_setup 0
+++#endif
+++
+++#if !defined(__NR_io_destroy)
+++#define __NR_io_destroy 1
+++#endif
+++
+++#if !defined(__NR_io_submit)
+++#define __NR_io_submit 2
+++#endif
+++
+++#if !defined(__NR_io_cancel)
+++#define __NR_io_cancel 3
+++#endif
+++
+++#if !defined(__NR_io_getevents)
+++#define __NR_io_getevents 4
+++#endif
+++
+++#if !defined(__NR_setxattr)
+++#define __NR_setxattr 5
+++#endif
+++
+++#if !defined(__NR_lsetxattr)
+++#define __NR_lsetxattr 6
+++#endif
+++
+++#if !defined(__NR_fsetxattr)
+++#define __NR_fsetxattr 7
+++#endif
+++
+++#if !defined(__NR_getxattr)
+++#define __NR_getxattr 8
+++#endif
+++
+++#if !defined(__NR_lgetxattr)
+++#define __NR_lgetxattr 9
+++#endif
+++
+++#if !defined(__NR_fgetxattr)
+++#define __NR_fgetxattr 10
+++#endif
+++
+++#if !defined(__NR_listxattr)
+++#define __NR_listxattr 11
+++#endif
+++
+++#if !defined(__NR_llistxattr)
+++#define __NR_llistxattr 12
+++#endif
+++
+++#if !defined(__NR_flistxattr)
+++#define __NR_flistxattr 13
+++#endif
+++
+++#if !defined(__NR_removexattr)
+++#define __NR_removexattr 14
+++#endif
+++
+++#if !defined(__NR_lremovexattr)
+++#define __NR_lremovexattr 15
+++#endif
+++
+++#if !defined(__NR_fremovexattr)
+++#define __NR_fremovexattr 16
+++#endif
+++
+++#if !defined(__NR_getcwd)
+++#define __NR_getcwd 17
+++#endif
+++
+++#if !defined(__NR_lookup_dcookie)
+++#define __NR_lookup_dcookie 18
+++#endif
+++
+++#if !defined(__NR_eventfd2)
+++#define __NR_eventfd2 19
+++#endif
+++
+++#if !defined(__NR_epoll_create1)
+++#define __NR_epoll_create1 20
+++#endif
+++
+++#if !defined(__NR_epoll_ctl)
+++#define __NR_epoll_ctl 21
+++#endif
+++
+++#if !defined(__NR_epoll_pwait)
+++#define __NR_epoll_pwait 22
+++#endif
+++
+++#if !defined(__NR_dup)
+++#define __NR_dup 23
+++#endif
+++
+++#if !defined(__NR_dup3)
+++#define __NR_dup3 24
+++#endif
+++
+++#if !defined(__NR_fcntl)
+++#define __NR_fcntl 25
+++#endif
+++
+++#if !defined(__NR_inotify_init1)
+++#define __NR_inotify_init1 26
+++#endif
+++
+++#if !defined(__NR_inotify_add_watch)
+++#define __NR_inotify_add_watch 27
+++#endif
+++
+++#if !defined(__NR_inotify_rm_watch)
+++#define __NR_inotify_rm_watch 28
+++#endif
+++
+++#if !defined(__NR_ioctl)
+++#define __NR_ioctl 29
+++#endif
+++
+++#if !defined(__NR_ioprio_set)
+++#define __NR_ioprio_set 30
+++#endif
+++
+++#if !defined(__NR_ioprio_get)
+++#define __NR_ioprio_get 31
+++#endif
+++
+++#if !defined(__NR_flock)
+++#define __NR_flock 32
+++#endif
+++
+++#if !defined(__NR_mknodat)
+++#define __NR_mknodat 33
+++#endif
+++
+++#if !defined(__NR_mkdirat)
+++#define __NR_mkdirat 34
+++#endif
+++
+++#if !defined(__NR_unlinkat)
+++#define __NR_unlinkat 35
+++#endif
+++
+++#if !defined(__NR_symlinkat)
+++#define __NR_symlinkat 36
+++#endif
+++
+++#if !defined(__NR_linkat)
+++#define __NR_linkat 37
+++#endif
+++
+++#if !defined(__NR_umount2)
+++#define __NR_umount2 39
+++#endif
+++
+++#if !defined(__NR_mount)
+++#define __NR_mount 40
+++#endif
+++
+++#if !defined(__NR_pivot_root)
+++#define __NR_pivot_root 41
+++#endif
+++
+++#if !defined(__NR_nfsservctl)
+++#define __NR_nfsservctl 42
+++#endif
+++
+++#if !defined(__NR_statfs)
+++#define __NR_statfs 43
+++#endif
+++
+++#if !defined(__NR_fstatfs)
+++#define __NR_fstatfs 44
+++#endif
+++
+++#if !defined(__NR_truncate)
+++#define __NR_truncate 45
+++#endif
+++
+++#if !defined(__NR_ftruncate)
+++#define __NR_ftruncate 46
+++#endif
+++
+++#if !defined(__NR_fallocate)
+++#define __NR_fallocate 47
+++#endif
+++
+++#if !defined(__NR_faccessat)
+++#define __NR_faccessat 48
+++#endif
+++
+++#if !defined(__NR_chdir)
+++#define __NR_chdir 49
+++#endif
+++
+++#if !defined(__NR_fchdir)
+++#define __NR_fchdir 50
+++#endif
+++
+++#if !defined(__NR_chroot)
+++#define __NR_chroot 51
+++#endif
+++
+++#if !defined(__NR_fchmod)
+++#define __NR_fchmod 52
+++#endif
+++
+++#if !defined(__NR_fchmodat)
+++#define __NR_fchmodat 53
+++#endif
+++
+++#if !defined(__NR_fchownat)
+++#define __NR_fchownat 54
+++#endif
+++
+++#if !defined(__NR_fchown)
+++#define __NR_fchown 55
+++#endif
+++
+++#if !defined(__NR_openat)
+++#define __NR_openat 56
+++#endif
+++
+++#if !defined(__NR_close)
+++#define __NR_close 57
+++#endif
+++
+++#if !defined(__NR_vhangup)
+++#define __NR_vhangup 58
+++#endif
+++
+++#if !defined(__NR_pipe2)
+++#define __NR_pipe2 59
+++#endif
+++
+++#if !defined(__NR_quotactl)
+++#define __NR_quotactl 60
+++#endif
+++
+++#if !defined(__NR_getdents64)
+++#define __NR_getdents64 61
+++#endif
+++
+++#if !defined(__NR_lseek)
+++#define __NR_lseek 62
+++#endif
+++
+++#if !defined(__NR_read)
+++#define __NR_read 63
+++#endif
+++
+++#if !defined(__NR_write)
+++#define __NR_write 64
+++#endif
+++
+++#if !defined(__NR_readv)
+++#define __NR_readv 65
+++#endif
+++
+++#if !defined(__NR_writev)
+++#define __NR_writev 66
+++#endif
+++
+++#if !defined(__NR_pread64)
+++#define __NR_pread64 67
+++#endif
+++
+++#if !defined(__NR_pwrite64)
+++#define __NR_pwrite64 68
+++#endif
+++
+++#if !defined(__NR_preadv)
+++#define __NR_preadv 69
+++#endif
+++
+++#if !defined(__NR_pwritev)
+++#define __NR_pwritev 70
+++#endif
+++
+++#if !defined(__NR_sendfile)
+++#define __NR_sendfile 71
+++#endif
+++
+++#if !defined(__NR_pselect6)
+++#define __NR_pselect6 72
+++#endif
+++
+++#if !defined(__NR_ppoll)
+++#define __NR_ppoll 73
+++#endif
+++
+++#if !defined(__NR_signalfd4)
+++#define __NR_signalfd4 74
+++#endif
+++
+++#if !defined(__NR_vmsplice)
+++#define __NR_vmsplice 75
+++#endif
+++
+++#if !defined(__NR_splice)
+++#define __NR_splice 76
+++#endif
+++
+++#if !defined(__NR_tee)
+++#define __NR_tee 77
+++#endif
+++
+++#if !defined(__NR_readlinkat)
+++#define __NR_readlinkat 78
+++#endif
+++
+++#if !defined(__NR_sync)
+++#define __NR_sync 81
+++#endif
+++
+++#if !defined(__NR_fsync)
+++#define __NR_fsync 82
+++#endif
+++
+++#if !defined(__NR_fdatasync)
+++#define __NR_fdatasync 83
+++#endif
+++
+++#if !defined(__NR_sync_file_range)
+++#define __NR_sync_file_range 84
+++#endif
+++
+++#if !defined(__NR_timerfd_create)
+++#define __NR_timerfd_create 85
+++#endif
+++
+++#if !defined(__NR_timerfd_settime)
+++#define __NR_timerfd_settime 86
+++#endif
+++
+++#if !defined(__NR_timerfd_gettime)
+++#define __NR_timerfd_gettime 87
+++#endif
+++
+++#if !defined(__NR_utimensat)
+++#define __NR_utimensat 88
+++#endif
+++
+++#if !defined(__NR_acct)
+++#define __NR_acct 89
+++#endif
+++
+++#if !defined(__NR_capget)
+++#define __NR_capget 90
+++#endif
+++
+++#if !defined(__NR_capset)
+++#define __NR_capset 91
+++#endif
+++
+++#if !defined(__NR_personality)
+++#define __NR_personality 92
+++#endif
+++
+++#if !defined(__NR_exit)
+++#define __NR_exit 93
+++#endif
+++
+++#if !defined(__NR_exit_group)
+++#define __NR_exit_group 94
+++#endif
+++
+++#if !defined(__NR_waitid)
+++#define __NR_waitid 95
+++#endif
+++
+++#if !defined(__NR_set_tid_address)
+++#define __NR_set_tid_address 96
+++#endif
+++
+++#if !defined(__NR_unshare)
+++#define __NR_unshare 97
+++#endif
+++
+++#if !defined(__NR_futex)
+++#define __NR_futex 98
+++#endif
+++
+++#if !defined(__NR_set_robust_list)
+++#define __NR_set_robust_list 99
+++#endif
+++
+++#if !defined(__NR_get_robust_list)
+++#define __NR_get_robust_list 100
+++#endif
+++
+++#if !defined(__NR_nanosleep)
+++#define __NR_nanosleep 101
+++#endif
+++
+++#if !defined(__NR_getitimer)
+++#define __NR_getitimer 102
+++#endif
+++
+++#if !defined(__NR_setitimer)
+++#define __NR_setitimer 103
+++#endif
+++
+++#if !defined(__NR_kexec_load)
+++#define __NR_kexec_load 104
+++#endif
+++
+++#if !defined(__NR_init_module)
+++#define __NR_init_module 105
+++#endif
+++
+++#if !defined(__NR_delete_module)
+++#define __NR_delete_module 106
+++#endif
+++
+++#if !defined(__NR_timer_create)
+++#define __NR_timer_create 107
+++#endif
+++
+++#if !defined(__NR_timer_gettime)
+++#define __NR_timer_gettime 108
+++#endif
+++
+++#if !defined(__NR_timer_getoverrun)
+++#define __NR_timer_getoverrun 109
+++#endif
+++
+++#if !defined(__NR_timer_settime)
+++#define __NR_timer_settime 110
+++#endif
+++
+++#if !defined(__NR_timer_delete)
+++#define __NR_timer_delete 111
+++#endif
+++
+++#if !defined(__NR_clock_settime)
+++#define __NR_clock_settime 112
+++#endif
+++
+++#if !defined(__NR_clock_gettime)
+++#define __NR_clock_gettime 113
+++#endif
+++
+++#if !defined(__NR_clock_getres)
+++#define __NR_clock_getres 114
+++#endif
+++
+++#if !defined(__NR_clock_nanosleep)
+++#define __NR_clock_nanosleep 115
+++#endif
+++
+++#if !defined(__NR_syslog)
+++#define __NR_syslog 116
+++#endif
+++
+++#if !defined(__NR_ptrace)
+++#define __NR_ptrace 117
+++#endif
+++
+++#if !defined(__NR_sched_setparam)
+++#define __NR_sched_setparam 118
+++#endif
+++
+++#if !defined(__NR_sched_setscheduler)
+++#define __NR_sched_setscheduler 119
+++#endif
+++
+++#if !defined(__NR_sched_getscheduler)
+++#define __NR_sched_getscheduler 120
+++#endif
+++
+++#if !defined(__NR_sched_getparam)
+++#define __NR_sched_getparam 121
+++#endif
+++
+++#if !defined(__NR_sched_setaffinity)
+++#define __NR_sched_setaffinity 122
+++#endif
+++
+++#if !defined(__NR_sched_getaffinity)
+++#define __NR_sched_getaffinity 123
+++#endif
+++
+++#if !defined(__NR_sched_yield)
+++#define __NR_sched_yield 124
+++#endif
+++
+++#if !defined(__NR_sched_get_priority_max)
+++#define __NR_sched_get_priority_max 125
+++#endif
+++
+++#if !defined(__NR_sched_get_priority_min)
+++#define __NR_sched_get_priority_min 126
+++#endif
+++
+++#if !defined(__NR_sched_rr_get_interval)
+++#define __NR_sched_rr_get_interval 127
+++#endif
+++
+++#if !defined(__NR_restart_syscall)
+++#define __NR_restart_syscall 128
+++#endif
+++
+++#if !defined(__NR_kill)
+++#define __NR_kill 129
+++#endif
+++
+++#if !defined(__NR_tkill)
+++#define __NR_tkill 130
+++#endif
+++
+++#if !defined(__NR_tgkill)
+++#define __NR_tgkill 131
+++#endif
+++
+++#if !defined(__NR_sigaltstack)
+++#define __NR_sigaltstack 132
+++#endif
+++
+++#if !defined(__NR_rt_sigsuspend)
+++#define __NR_rt_sigsuspend 133
+++#endif
+++
+++#if !defined(__NR_rt_sigaction)
+++#define __NR_rt_sigaction 134
+++#endif
+++
+++#if !defined(__NR_rt_sigprocmask)
+++#define __NR_rt_sigprocmask 135
+++#endif
+++
+++#if !defined(__NR_rt_sigpending)
+++#define __NR_rt_sigpending 136
+++#endif
+++
+++#if !defined(__NR_rt_sigtimedwait)
+++#define __NR_rt_sigtimedwait 137
+++#endif
+++
+++#if !defined(__NR_rt_sigqueueinfo)
+++#define __NR_rt_sigqueueinfo 138
+++#endif
+++
+++#if !defined(__NR_rt_sigreturn)
+++#define __NR_rt_sigreturn 139
+++#endif
+++
+++#if !defined(__NR_setpriority)
+++#define __NR_setpriority 140
+++#endif
+++
+++#if !defined(__NR_getpriority)
+++#define __NR_getpriority 141
+++#endif
+++
+++#if !defined(__NR_reboot)
+++#define __NR_reboot 142
+++#endif
+++
+++#if !defined(__NR_setregid)
+++#define __NR_setregid 143
+++#endif
+++
+++#if !defined(__NR_setgid)
+++#define __NR_setgid 144
+++#endif
+++
+++#if !defined(__NR_setreuid)
+++#define __NR_setreuid 145
+++#endif
+++
+++#if !defined(__NR_setuid)
+++#define __NR_setuid 146
+++#endif
+++
+++#if !defined(__NR_setresuid)
+++#define __NR_setresuid 147
+++#endif
+++
+++#if !defined(__NR_getresuid)
+++#define __NR_getresuid 148
+++#endif
+++
+++#if !defined(__NR_setresgid)
+++#define __NR_setresgid 149
+++#endif
+++
+++#if !defined(__NR_getresgid)
+++#define __NR_getresgid 150
+++#endif
+++
+++#if !defined(__NR_setfsuid)
+++#define __NR_setfsuid 151
+++#endif
+++
+++#if !defined(__NR_setfsgid)
+++#define __NR_setfsgid 152
+++#endif
+++
+++#if !defined(__NR_times)
+++#define __NR_times 153
+++#endif
+++
+++#if !defined(__NR_setpgid)
+++#define __NR_setpgid 154
+++#endif
+++
+++#if !defined(__NR_getpgid)
+++#define __NR_getpgid 155
+++#endif
+++
+++#if !defined(__NR_getsid)
+++#define __NR_getsid 156
+++#endif
+++
+++#if !defined(__NR_setsid)
+++#define __NR_setsid 157
+++#endif
+++
+++#if !defined(__NR_getgroups)
+++#define __NR_getgroups 158
+++#endif
+++
+++#if !defined(__NR_setgroups)
+++#define __NR_setgroups 159
+++#endif
+++
+++#if !defined(__NR_uname)
+++#define __NR_uname 160
+++#endif
+++
+++#if !defined(__NR_sethostname)
+++#define __NR_sethostname 161
+++#endif
+++
+++#if !defined(__NR_setdomainname)
+++#define __NR_setdomainname 162
+++#endif
+++
+++#if !defined(__NR_getrusage)
+++#define __NR_getrusage 165
+++#endif
+++
+++#if !defined(__NR_umask)
+++#define __NR_umask 166
+++#endif
+++
+++#if !defined(__NR_prctl)
+++#define __NR_prctl 167
+++#endif
+++
+++#if !defined(__NR_getcpu)
+++#define __NR_getcpu 168
+++#endif
+++
+++#if !defined(__NR_gettimeofday)
+++#define __NR_gettimeofday 169
+++#endif
+++
+++#if !defined(__NR_settimeofday)
+++#define __NR_settimeofday 170
+++#endif
+++
+++#if !defined(__NR_adjtimex)
+++#define __NR_adjtimex 171
+++#endif
+++
+++#if !defined(__NR_getpid)
+++#define __NR_getpid 172
+++#endif
+++
+++#if !defined(__NR_getppid)
+++#define __NR_getppid 173
+++#endif
+++
+++#if !defined(__NR_getuid)
+++#define __NR_getuid 174
+++#endif
+++
+++#if !defined(__NR_geteuid)
+++#define __NR_geteuid 175
+++#endif
+++
+++#if !defined(__NR_getgid)
+++#define __NR_getgid 176
+++#endif
+++
+++#if !defined(__NR_getegid)
+++#define __NR_getegid 177
+++#endif
+++
+++#if !defined(__NR_gettid)
+++#define __NR_gettid 178
+++#endif
+++
+++#if !defined(__NR_sysinfo)
+++#define __NR_sysinfo 179
+++#endif
+++
+++#if !defined(__NR_mq_open)
+++#define __NR_mq_open 180
+++#endif
+++
+++#if !defined(__NR_mq_unlink)
+++#define __NR_mq_unlink 181
+++#endif
+++
+++#if !defined(__NR_mq_timedsend)
+++#define __NR_mq_timedsend 182
+++#endif
+++
+++#if !defined(__NR_mq_timedreceive)
+++#define __NR_mq_timedreceive 183
+++#endif
+++
+++#if !defined(__NR_mq_notify)
+++#define __NR_mq_notify 184
+++#endif
+++
+++#if !defined(__NR_mq_getsetattr)
+++#define __NR_mq_getsetattr 185
+++#endif
+++
+++#if !defined(__NR_msgget)
+++#define __NR_msgget 186
+++#endif
+++
+++#if !defined(__NR_msgctl)
+++#define __NR_msgctl 187
+++#endif
+++
+++#if !defined(__NR_msgrcv)
+++#define __NR_msgrcv 188
+++#endif
+++
+++#if !defined(__NR_msgsnd)
+++#define __NR_msgsnd 189
+++#endif
+++
+++#if !defined(__NR_semget)
+++#define __NR_semget 190
+++#endif
+++
+++#if !defined(__NR_semctl)
+++#define __NR_semctl 191
+++#endif
+++
+++#if !defined(__NR_semtimedop)
+++#define __NR_semtimedop 192
+++#endif
+++
+++#if !defined(__NR_semop)
+++#define __NR_semop 193
+++#endif
+++
+++#if !defined(__NR_shmget)
+++#define __NR_shmget 194
+++#endif
+++
+++#if !defined(__NR_shmctl)
+++#define __NR_shmctl 195
+++#endif
+++
+++#if !defined(__NR_shmat)
+++#define __NR_shmat 196
+++#endif
+++
+++#if !defined(__NR_shmdt)
+++#define __NR_shmdt 197
+++#endif
+++
+++#if !defined(__NR_socket)
+++#define __NR_socket 198
+++#endif
+++
+++#if !defined(__NR_socketpair)
+++#define __NR_socketpair 199
+++#endif
+++
+++#if !defined(__NR_bind)
+++#define __NR_bind 200
+++#endif
+++
+++#if !defined(__NR_listen)
+++#define __NR_listen 201
+++#endif
+++
+++#if !defined(__NR_accept)
+++#define __NR_accept 202
+++#endif
+++
+++#if !defined(__NR_connect)
+++#define __NR_connect 203
+++#endif
+++
+++#if !defined(__NR_getsockname)
+++#define __NR_getsockname 204
+++#endif
+++
+++#if !defined(__NR_getpeername)
+++#define __NR_getpeername 205
+++#endif
+++
+++#if !defined(__NR_sendto)
+++#define __NR_sendto 206
+++#endif
+++
+++#if !defined(__NR_recvfrom)
+++#define __NR_recvfrom 207
+++#endif
+++
+++#if !defined(__NR_setsockopt)
+++#define __NR_setsockopt 208
+++#endif
+++
+++#if !defined(__NR_getsockopt)
+++#define __NR_getsockopt 209
+++#endif
+++
+++#if !defined(__NR_shutdown)
+++#define __NR_shutdown 210
+++#endif
+++
+++#if !defined(__NR_sendmsg)
+++#define __NR_sendmsg 211
+++#endif
+++
+++#if !defined(__NR_recvmsg)
+++#define __NR_recvmsg 212
+++#endif
+++
+++#if !defined(__NR_readahead)
+++#define __NR_readahead 213
+++#endif
+++
+++#if !defined(__NR_brk)
+++#define __NR_brk 214
+++#endif
+++
+++#if !defined(__NR_munmap)
+++#define __NR_munmap 215
+++#endif
+++
+++#if !defined(__NR_mremap)
+++#define __NR_mremap 216
+++#endif
+++
+++#if !defined(__NR_add_key)
+++#define __NR_add_key 217
+++#endif
+++
+++#if !defined(__NR_request_key)
+++#define __NR_request_key 218
+++#endif
+++
+++#if !defined(__NR_keyctl)
+++#define __NR_keyctl 219
+++#endif
+++
+++#if !defined(__NR_clone)
+++#define __NR_clone 220
+++#endif
+++
+++#if !defined(__NR_execve)
+++#define __NR_execve 221
+++#endif
+++
+++#if !defined(__NR_mmap)
+++#define __NR_mmap 222
+++#endif
+++
+++#if !defined(__NR_fadvise64)
+++#define __NR_fadvise64 223
+++#endif
+++
+++#if !defined(__NR_swapon)
+++#define __NR_swapon 224
+++#endif
+++
+++#if !defined(__NR_swapoff)
+++#define __NR_swapoff 225
+++#endif
+++
+++#if !defined(__NR_mprotect)
+++#define __NR_mprotect 226
+++#endif
+++
+++#if !defined(__NR_msync)
+++#define __NR_msync 227
+++#endif
+++
+++#if !defined(__NR_mlock)
+++#define __NR_mlock 228
+++#endif
+++
+++#if !defined(__NR_munlock)
+++#define __NR_munlock 229
+++#endif
+++
+++#if !defined(__NR_mlockall)
+++#define __NR_mlockall 230
+++#endif
+++
+++#if !defined(__NR_munlockall)
+++#define __NR_munlockall 231
+++#endif
+++
+++#if !defined(__NR_mincore)
+++#define __NR_mincore 232
+++#endif
+++
+++#if !defined(__NR_madvise)
+++#define __NR_madvise 233
+++#endif
+++
+++#if !defined(__NR_remap_file_pages)
+++#define __NR_remap_file_pages 234
+++#endif
+++
+++#if !defined(__NR_mbind)
+++#define __NR_mbind 235
+++#endif
+++
+++#if !defined(__NR_get_mempolicy)
+++#define __NR_get_mempolicy 236
+++#endif
+++
+++#if !defined(__NR_set_mempolicy)
+++#define __NR_set_mempolicy 237
+++#endif
+++
+++#if !defined(__NR_migrate_pages)
+++#define __NR_migrate_pages 238
+++#endif
+++
+++#if !defined(__NR_move_pages)
+++#define __NR_move_pages 239
+++#endif
+++
+++#if !defined(__NR_rt_tgsigqueueinfo)
+++#define __NR_rt_tgsigqueueinfo 240
+++#endif
+++
+++#if !defined(__NR_perf_event_open)
+++#define __NR_perf_event_open 241
+++#endif
+++
+++#if !defined(__NR_accept4)
+++#define __NR_accept4 242
+++#endif
+++
+++#if !defined(__NR_recvmmsg)
+++#define __NR_recvmmsg 243
+++#endif
+++
+++#if !defined(__NR_wait4)
+++#define __NR_wait4 260
+++#endif
+++
+++#if !defined(__NR_prlimit64)
+++#define __NR_prlimit64 261
+++#endif
+++
+++#if !defined(__NR_fanotify_init)
+++#define __NR_fanotify_init 262
+++#endif
+++
+++#if !defined(__NR_fanotify_mark)
+++#define __NR_fanotify_mark 263
+++#endif
+++
+++#if !defined(__NR_name_to_handle_at)
+++#define __NR_name_to_handle_at 264
+++#endif
+++
+++#if !defined(__NR_open_by_handle_at)
+++#define __NR_open_by_handle_at 265
+++#endif
+++
+++#if !defined(__NR_clock_adjtime)
+++#define __NR_clock_adjtime 266
+++#endif
+++
+++#if !defined(__NR_syncfs)
+++#define __NR_syncfs 267
+++#endif
+++
+++#if !defined(__NR_setns)
+++#define __NR_setns 268
+++#endif
+++
+++#if !defined(__NR_sendmmsg)
+++#define __NR_sendmmsg 269
+++#endif
+++
+++#if !defined(__NR_process_vm_readv)
+++#define __NR_process_vm_readv 270
+++#endif
+++
+++#if !defined(__NR_process_vm_writev)
+++#define __NR_process_vm_writev 271
+++#endif
+++
+++#if !defined(__NR_kcmp)
+++#define __NR_kcmp 272
+++#endif
+++
+++#if !defined(__NR_finit_module)
+++#define __NR_finit_module 273
+++#endif
+++
+++#if !defined(__NR_sched_setattr)
+++#define __NR_sched_setattr 274
+++#endif
+++
+++#if !defined(__NR_sched_getattr)
+++#define __NR_sched_getattr 275
+++#endif
+++
+++#if !defined(__NR_renameat2)
+++#define __NR_renameat2 276
+++#endif
+++
+++#if !defined(__NR_seccomp)
+++#define __NR_seccomp 277
+++#endif
+++
+++#if !defined(__NR_getrandom)
+++#define __NR_getrandom 278
+++#endif
+++
+++#if !defined(__NR_memfd_create)
+++#define __NR_memfd_create 279
+++#endif
+++
+++#if !defined(__NR_bpf)
+++#define __NR_bpf 280
+++#endif
+++
+++#if !defined(__NR_execveat)
+++#define __NR_execveat 281
+++#endif
+++
+++#if !defined(__NR_userfaultfd)
+++#define __NR_userfaultfd 282
+++#endif
+++
+++#if !defined(__NR_membarrier)
+++#define __NR_membarrier 283
+++#endif
+++
+++#if !defined(__NR_mlock2)
+++#define __NR_mlock2 284
+++#endif
+++
+++#if !defined(__NR_copy_file_range)
+++#define __NR_copy_file_range 285
+++#endif
+++
+++#if !defined(__NR_preadv2)
+++#define __NR_preadv2 286
+++#endif
+++
+++#if !defined(__NR_pwritev2)
+++#define __NR_pwritev2 287
+++#endif
+++
+++#if !defined(__NR_pkey_mprotect)
+++#define __NR_pkey_mprotect 288
+++#endif
+++
+++#if !defined(__NR_pkey_alloc)
+++#define __NR_pkey_alloc 289
+++#endif
+++
+++#if !defined(__NR_pkey_free)
+++#define __NR_pkey_free 290
+++#endif
+++
+++#if !defined(__NR_statx)
+++#define __NR_statx 291
+++#endif
+++
+++#if !defined(__NR_io_pgetevents)
+++#define __NR_io_pgetevents 292
+++#endif
+++
+++#if !defined(__NR_rseq)
+++#define __NR_rseq 293
+++#endif
+++
+++#if !defined(__NR_kexec_file_load)
+++#define __NR_kexec_file_load 294
+++#endif
+++
+++#if !defined(__NR_pidfd_send_signal)
+++#define __NR_pidfd_send_signal 424
+++#endif
+++
+++#if !defined(__NR_io_uring_setup)
+++#define __NR_io_uring_setup 425
+++#endif
+++
+++#if !defined(__NR_io_uring_enter)
+++#define __NR_io_uring_enter 426
+++#endif
+++
+++#if !defined(__NR_io_uring_register)
+++#define __NR_io_uring_register 427
+++#endif
+++
+++#if !defined(__NR_open_tree)
+++#define __NR_open_tree 428
+++#endif
+++
+++#if !defined(__NR_move_mount)
+++#define __NR_move_mount 429
+++#endif
+++
+++#if !defined(__NR_fsopen)
+++#define __NR_fsopen 430
+++#endif
+++
+++#if !defined(__NR_fsconfig)
+++#define __NR_fsconfig 431
+++#endif
+++
+++#if !defined(__NR_fsmount)
+++#define __NR_fsmount 432
+++#endif
+++
+++#if !defined(__NR_fspick)
+++#define __NR_fspick 433
+++#endif
+++
+++#if !defined(__NR_pidfd_open)
+++#define __NR_pidfd_open 434
+++#endif
+++
+++#if !defined(__NR_clone3)
+++#define __NR_clone3 435
+++#endif
+++
+++#if !defined(__NR_close_range)
+++#define __NR_close_range 436
+++#endif
+++
+++#if !defined(__NR_openat2)
+++#define __NR_openat2 437
+++#endif
+++
+++#if !defined(__NR_pidfd_getfd)
+++#define __NR_pidfd_getfd 438
+++#endif
+++
+++#if !defined(__NR_faccessat2)
+++#define __NR_faccessat2 439
+++#endif
+++
+++#if !defined(__NR_process_madvise)
+++#define __NR_process_madvise 440
+++#endif
+++
+++#if !defined(__NR_epoll_pwait2)
+++#define __NR_epoll_pwait2 441
+++#endif
+++
+++#if !defined(__NR_mount_setattr)
+++#define __NR_mount_setattr 442
+++#endif
+++
+++#if !defined(__NR_landlock_create_ruleset)
+++#define __NR_landlock_create_ruleset 444
+++#endif
+++
+++#if !defined(__NR_landlock_add_rule)
+++#define __NR_landlock_add_rule 445
+++#endif
+++
+++#if !defined(__NR_landlock_restrict_self)
+++#define __NR_landlock_restrict_self 446
+++#endif
+++
+++#endif  // SANDBOX_LINUX_SYSTEM_HEADERS_LOONG64_LINUX_SYSCALLS_H_
++diff --git a/sandbox/policy/linux/bpf_audio_policy_linux.cc b/sandbox/policy/linux/bpf_audio_policy_linux.cc
++index e1716b97e8f2148837dfee0badbc52ef5714fe5a..3ed6fc9b4d2fe52304eea8102f8dd3d35f0d5090 100644
++--- a/sandbox/policy/linux/bpf_audio_policy_linux.cc
+++++ b/sandbox/policy/linux/bpf_audio_policy_linux.cc
++@@ -85,6 +85,7 @@ ResultExpr AudioProcessPolicy::EvaluateSyscall(int system_call_number) const {
++       return Switch(op & ~(FUTEX_PRIVATE_FLAG | FUTEX_CLOCK_REALTIME))
++           .Cases({FUTEX_CMP_REQUEUE,
++                   FUTEX_LOCK_PI,
+++                  FUTEX_LOCK_PI2,
++                   FUTEX_UNLOCK_PI,
++                   FUTEX_WAIT,
++                   FUTEX_WAIT_BITSET,
++diff --git a/sandbox/policy/linux/bpf_broker_policy_linux.cc b/sandbox/policy/linux/bpf_broker_policy_linux.cc
++index 87a0cc1faf2c9c88fde470aa5538e9b18cd36bdc..3702bf91babffc6a94112a7cf7eee6caf84aea7e 100644
++--- a/sandbox/policy/linux/bpf_broker_policy_linux.cc
+++++ b/sandbox/policy/linux/bpf_broker_policy_linux.cc
++@@ -87,6 +87,12 @@ ResultExpr BrokerProcessPolicy::EvaluateSyscall(int sysno) const {
++         return Allow();
++       break;
++ #endif
+++#if defined(__NR_statx)
+++    case __NR_statx:
+++      if (allowed_command_set_.test(syscall_broker::COMMAND_STAT))
+++        return Allow();
+++      break;
+++#endif
++ #if defined(__NR_lstat)
++     case __NR_lstat:
++       if (allowed_command_set_.test(syscall_broker::COMMAND_STAT))
++diff --git a/sandbox/policy/linux/bpf_cros_amd_gpu_policy_linux.cc b/sandbox/policy/linux/bpf_cros_amd_gpu_policy_linux.cc
++index df2567f74981f947543b068e87385b52311a8634..8cabc0d20eb4b70ca75a8cd25f313f64f5ba9b77 100644
++--- a/sandbox/policy/linux/bpf_cros_amd_gpu_policy_linux.cc
+++++ b/sandbox/policy/linux/bpf_cros_amd_gpu_policy_linux.cc
++@@ -38,7 +38,7 @@ ResultExpr CrosAmdGpuProcessPolicy::EvaluateSyscall(int sysno) const {
++     case __NR_sched_setscheduler:
++     case __NR_sysinfo:
++     case __NR_uname:
++-#if !defined(__aarch64__)
+++#if !defined(__aarch64__) && !defined(__loongarch__)
++     case __NR_readlink:
++     case __NR_stat:
++ #endif
++diff --git a/sandbox/policy/linux/bpf_gpu_policy_linux.cc b/sandbox/policy/linux/bpf_gpu_policy_linux.cc
++index 35ccbb7a7f82b13164a2e30a04a35a5c0ed76138..94023dc1376e84e071179c503e06efcb64cd5ab1 100644
++--- a/sandbox/policy/linux/bpf_gpu_policy_linux.cc
+++++ b/sandbox/policy/linux/bpf_gpu_policy_linux.cc
++@@ -73,7 +73,7 @@ ResultExpr GpuProcessPolicy::EvaluateSyscall(int sysno) const {
++     (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS))
++     case __NR_ftruncate64:
++ #endif
++-#if !defined(__aarch64__)
+++#if !defined(__aarch64__) && !defined(__loongarch__)
++     case __NR_getdents:
++ #endif
++     case __NR_getdents64:
++diff --git a/sandbox/policy/linux/bpf_network_policy_linux.cc b/sandbox/policy/linux/bpf_network_policy_linux.cc
++index c2ee245dd208d4628ae4bf3e0dda8287421c8803..04584d4243019ec02b4bb1b7523f3c93cb3eb1c7 100644
++--- a/sandbox/policy/linux/bpf_network_policy_linux.cc
+++++ b/sandbox/policy/linux/bpf_network_policy_linux.cc
++@@ -260,7 +260,7 @@ ResultExpr NetworkProcessPolicy::EvaluateSyscall(int sysno) const {
++     case __NR_fdatasync:
++     case __NR_fsync:
++     case __NR_mremap:
++-#if !defined(__aarch64__)
+++#if !defined(__aarch64__) && !defined(__loongarch__)
++     case __NR_getdents:
++ #endif
++     case __NR_getdents64:
++diff --git a/sandbox/policy/linux/bpf_screen_ai_policy_linux.cc b/sandbox/policy/linux/bpf_screen_ai_policy_linux.cc
++index 2d00b768530aa481d21b059d26bcd6072a0d3079..1fce6c800e7f42d48b691e09f1e9ea6d57587a45 100644
++--- a/sandbox/policy/linux/bpf_screen_ai_policy_linux.cc
+++++ b/sandbox/policy/linux/bpf_screen_ai_policy_linux.cc
++@@ -37,7 +37,7 @@ ResultExpr ScreenAIProcessPolicy::EvaluateSyscall(
++       const Arg<int> op(1);
++       return Switch(op & FUTEX_CMD_MASK)
++           .Cases(
++-              {FUTEX_CMP_REQUEUE, FUTEX_LOCK_PI, FUTEX_UNLOCK_PI, FUTEX_WAIT,
+++              {FUTEX_CMP_REQUEUE, FUTEX_LOCK_PI, FUTEX_LOCK_PI2, FUTEX_UNLOCK_PI, FUTEX_WAIT,
++                FUTEX_WAIT_BITSET, FUTEX_WAKE},
++               Allow())
++           // Sending ENOSYS tells the Futex backend to use another approach if
++diff --git a/sandbox/policy/linux/sandbox_linux.cc b/sandbox/policy/linux/sandbox_linux.cc
++index c7313416e6183130bbbe4b89d0b4192664d01351..2ca106c1e3e077173d204dcef4b73b6999309efc 100644
++--- a/sandbox/policy/linux/sandbox_linux.cc
+++++ b/sandbox/policy/linux/sandbox_linux.cc
++@@ -595,6 +595,7 @@ bpf_dsl::ResultExpr SandboxLinux::HandleViaBroker(int sysno) const {
++   const bpf_dsl::ResultExpr handle_via_broker =
++       bpf_dsl::Trap(syscall_broker::BrokerClient::SIGSYS_Handler,
++                     broker_process_->GetBrokerClientSignalBased());
+++#if !defined(__loongarch__)
++   if (sysno == __NR_fstatat_default) {
++     // This may be an fstatat(fd, "", stat_buf, AT_EMPTY_PATH), which should be
++     // rewritten as fstat(fd, stat_buf). This should be consistent with how the
++@@ -605,6 +606,18 @@ bpf_dsl::ResultExpr SandboxLinux::HandleViaBroker(int sysno) const {
++     return bpf_dsl::If((flags & AT_EMPTY_PATH) == AT_EMPTY_PATH,
++                        RewriteFstatatSIGSYS(BPFBasePolicy::GetFSDeniedErrno()))
++         .Else(handle_via_broker);
+++#else
+++  if (sysno == __NR_statx) {
+++    // This may be a statx(fd, "", AT_EMPTY_PATH, mask, statx_buf), and we allow it.
+++    // Otherwise, we expect a statx(AT_FDCWD, path, flags, mask, statx_buf).
+++    // However, it is possible to pass a non-empty path even when AT_EMPTY_PATH
+++    // is set. But there are currently no easy way to validate the argument in
+++    // seccomp bpf.
+++    const bpf_dsl::Arg<int> flags(2);
+++    return bpf_dsl::If((flags & AT_EMPTY_PATH) == AT_EMPTY_PATH,
+++                       bpf_dsl::Allow())
+++        .Else(handle_via_broker);
+++#endif
++   } else {
++     return handle_via_broker;
++   }
++diff --git a/skia/BUILD.gn b/skia/BUILD.gn
++index f1ff9895834669095145be9a60864b10ae2b2f0c..467788b920927dfbccb02d8a97c756776a3fa5dc 100644
++--- a/skia/BUILD.gn
+++++ b/skia/BUILD.gn
++@@ -682,6 +682,14 @@ if (current_cpu == "x86" || current_cpu == "x64") {
++   }
++ }
++ 
+++if (current_cpu == "loong64") {
+++  skia_source_set("skia_opts_lasx") {
+++    sources = skia_opts.lasx_sources
+++    cflags = [ "-mlasx" ]
+++    visibility = [ ":skia_opts" ]
+++  }
+++}
+++
++ skia_source_set("skia_opts") {
++   cflags = []
++   defines = []
++@@ -720,7 +728,7 @@ skia_source_set("skia_opts") {
++   } else if (current_cpu == "riscv64") {
++     # Conditional and empty body needed to avoid assert() below.
++   } else if (current_cpu == "loong64") {
++-    # Conditional and empty body needed to avoid assert() below.
+++    deps += [ ":skia_opts_lasx" ]
++   } else {
++     assert(false, "Unknown cpu target")
++   }
++diff --git a/third_party/blink/renderer/platform/graphics/cpu/loongarch64/webgl_image_conversion_lsx.h b/third_party/blink/renderer/platform/graphics/cpu/loongarch64/webgl_image_conversion_lsx.h
++index 114f3c112e8d597ce1a026172e80c1dcc2e3e1bd..1e2096f65104c32ae60b282749053143075e60b6 100644
++--- a/third_party/blink/renderer/platform/graphics/cpu/loongarch64/webgl_image_conversion_lsx.h
+++++ b/third_party/blink/renderer/platform/graphics/cpu/loongarch64/webgl_image_conversion_lsx.h
++@@ -91,19 +91,19 @@ ALWAYS_INLINE void PackOneRowOfRGBA8LittleToRA8(const uint8_t*& source,
++   v4f32 mask_falpha = __lsx_vffint_s_w(mask_lalpha);
++   v16u8 ra_index = {0,19, 4,23, 8,27, 12,31};
++   for (unsigned i = 0; i < pixels_per_row_trunc; i += 4) {
++-    v16u8 bgra = *((__m128i*)(source));
+++    __m128i bgra = *((__m128i*)(source));
++     //if A !=0, A=0; else A=0xFF
++-    v4f32 alpha_factor = __lsx_vseq_b(bgra, mask_zero);
+++    __m128i alpha_factor = __lsx_vseq_b(bgra, mask_zero);
++     //if A!=0, A=A; else A=0xFF
++     alpha_factor = __lsx_vor_v(bgra, alpha_factor);
++     alpha_factor = __lsx_vsrli_w(alpha_factor, 24);
++-    alpha_factor = __lsx_vffint_s_w(alpha_factor);
++-    alpha_factor = __lsx_vfdiv_s(mask_falpha, alpha_factor);
+++    alpha_factor = (__m128i) __lsx_vffint_s_w(alpha_factor);
+++    alpha_factor = (__m128i) __lsx_vfdiv_s((__m128) mask_falpha, (__m128) alpha_factor);
++ 
++-    v16u8 component_r = __lsx_vand_v(bgra, mask_lalpha);
++-    component_r = __lsx_vffint_s_w(component_r);
++-    component_r = __lsx_vfmul_s(component_r, alpha_factor);
++-    component_r = __lsx_vftintrz_w_s(component_r);
+++    __m128i component_r = __lsx_vand_v(bgra, mask_lalpha);
+++    component_r = (__m128i) __lsx_vffint_s_w(component_r);
+++    component_r = (__m128i) __lsx_vfmul_s((__m128) component_r, (__m128) alpha_factor);
+++    component_r = __lsx_vftintrz_w_s((__m128) component_r);
++ 
++     v2u64 ra = __lsx_vshuf_b(bgra, component_r, ra_index);
++     __lsx_vstelm_d(ra, destination, 0, 0);
++@@ -138,19 +138,19 @@ ALWAYS_INLINE void PackOneRowOfRGBA8LittleToR8(const uint8_t*& source,
++   v4u32 mask_lalpha = __lsx_vreplgr2vr_w(0x0ff);
++   v4f32 mask_falpha = __lsx_vffint_s_w(mask_lalpha);
++   for (unsigned i = 0; i < pixels_per_row_trunc; i += 4) {
++-    v16u8 bgra = *((__m128i*)(source));
+++    __m128i bgra = *((__m128i*)(source));
++     //if A !=0, A=0; else A=0xFF
++-    v4f32 alpha_factor = __lsx_vseq_b(bgra, mask_zero);
+++    __m128i alpha_factor = __lsx_vseq_b(bgra, mask_zero);
++     //if A!=0, A=A; else A=0xFF
++     alpha_factor = __lsx_vor_v(bgra, alpha_factor);
++     alpha_factor = __lsx_vsrli_w(alpha_factor, 24);
++-    alpha_factor = __lsx_vffint_s_w(alpha_factor);
++-    alpha_factor = __lsx_vfdiv_s(mask_falpha, alpha_factor);
+++    alpha_factor = (__m128i) __lsx_vffint_s_w(alpha_factor);
+++    alpha_factor = (__m128i) __lsx_vfdiv_s((__m128) mask_falpha, (__m128) alpha_factor);
++ 
++-    v16u8 component_r = __lsx_vand_v(bgra, mask_lalpha);
++-    component_r = __lsx_vffint_s_w(component_r);
++-    component_r = __lsx_vfmul_s(component_r, alpha_factor);
++-    component_r = __lsx_vftintrz_w_s(component_r);
+++    __m128i component_r = __lsx_vand_v(bgra, mask_lalpha);
+++    component_r = (__m128i) __lsx_vffint_s_w(component_r);
+++    component_r = (__m128i) __lsx_vfmul_s((__m128) component_r, (__m128) alpha_factor);
+++    component_r = __lsx_vftintrz_w_s((__m128) component_r);
++ 
++     component_r = __lsx_vpickev_b(component_r, component_r);
++     component_r = __lsx_vpickev_b(component_r, component_r);
++@@ -172,41 +172,41 @@ ALWAYS_INLINE void PackOneRowOfRGBA8LittleToRGBA8(const uint8_t*& source,
++   v4f32 mask_falpha = __lsx_vffint_s_w(mask_lalpha);
++   v16u8 rgba_index = {0,1,2,19, 4,5,6,23, 8,9,10,27, 12,13,14,31};
++   for (unsigned i = 0; i < pixels_per_row_trunc; i += 4) {
++-    v16u8 bgra = *((__m128i*)(source));
+++    __m128i bgra = *((__m128i*)(source));
++     //if A !=0, A=0; else A=0xFF
++-    v4f32 alpha_factor = __lsx_vseq_b(bgra, mask_zero);
+++    __m128i alpha_factor = __lsx_vseq_b(bgra, mask_zero);
++     //if A!=0, A=A; else A=0xFF
++     alpha_factor = __lsx_vor_v(bgra, alpha_factor);
++     alpha_factor = __lsx_vsrli_w(alpha_factor, 24);
++-    alpha_factor = __lsx_vffint_s_w(alpha_factor);
++-    alpha_factor = __lsx_vfdiv_s(mask_falpha, alpha_factor);
+++    alpha_factor = (__m128i) __lsx_vffint_s_w(alpha_factor);
+++    alpha_factor = (__m128i) __lsx_vfdiv_s((__m128) mask_falpha, (__m128) alpha_factor);
++ 
++     v16u8 bgra_01 = __lsx_vilvl_b(mask_zero, bgra);
++     v16u8 bgra_23 = __lsx_vilvh_b(mask_zero, bgra);
++-    v16u8 bgra_0 = __lsx_vilvl_b(mask_zero, bgra_01);
++-    v16u8 bgra_1 = __lsx_vilvh_b(mask_zero, bgra_01);
++-    v16u8 bgra_2 = __lsx_vilvl_b(mask_zero, bgra_23);
++-    v16u8 bgra_3 = __lsx_vilvh_b(mask_zero, bgra_23);
++-
++-    bgra_0 = __lsx_vffint_s_w(bgra_0);
++-    bgra_1 = __lsx_vffint_s_w(bgra_1);
++-    bgra_2 = __lsx_vffint_s_w(bgra_2);
++-    bgra_3 = __lsx_vffint_s_w(bgra_3);
++-
++-    v4f32 alpha_factor_0 = __lsx_vreplvei_w(alpha_factor, 0);
++-    v4f32 alpha_factor_1 = __lsx_vreplvei_w(alpha_factor, 1);
++-    v4f32 alpha_factor_2 = __lsx_vreplvei_w(alpha_factor, 2);
++-    v4f32 alpha_factor_3 = __lsx_vreplvei_w(alpha_factor, 3);
++-
++-    bgra_0 = __lsx_vfmul_s(alpha_factor_0, bgra_0);
++-    bgra_1 = __lsx_vfmul_s(alpha_factor_1, bgra_1);
++-    bgra_2 = __lsx_vfmul_s(alpha_factor_2, bgra_2);
++-    bgra_3 = __lsx_vfmul_s(alpha_factor_3, bgra_3);
++-
++-    bgra_0 = __lsx_vftintrz_w_s(bgra_0);
++-    bgra_1 = __lsx_vftintrz_w_s(bgra_1);
++-    bgra_2 = __lsx_vftintrz_w_s(bgra_2);
++-    bgra_3 = __lsx_vftintrz_w_s(bgra_3);
+++    __m128i bgra_0 = __lsx_vilvl_b(mask_zero, bgra_01);
+++    __m128i bgra_1 = __lsx_vilvh_b(mask_zero, bgra_01);
+++    __m128i bgra_2 = __lsx_vilvl_b(mask_zero, bgra_23);
+++    __m128i bgra_3 = __lsx_vilvh_b(mask_zero, bgra_23);
+++
+++    bgra_0 = (__m128i) __lsx_vffint_s_w(bgra_0);
+++    bgra_1 = (__m128i) __lsx_vffint_s_w(bgra_1);
+++    bgra_2 = (__m128i) __lsx_vffint_s_w(bgra_2);
+++    bgra_3 = (__m128i) __lsx_vffint_s_w(bgra_3);
+++
+++    __m128i alpha_factor_0 = __lsx_vreplvei_w(alpha_factor, 0);
+++    __m128i alpha_factor_1 = __lsx_vreplvei_w(alpha_factor, 1);
+++    __m128i alpha_factor_2 = __lsx_vreplvei_w(alpha_factor, 2);
+++    __m128i alpha_factor_3 = __lsx_vreplvei_w(alpha_factor, 3);
+++
+++    bgra_0 = (__m128i) __lsx_vfmul_s((__m128) alpha_factor_0, (__m128) bgra_0);
+++    bgra_1 = (__m128i) __lsx_vfmul_s((__m128) alpha_factor_1, (__m128) bgra_1);
+++    bgra_2 = (__m128i) __lsx_vfmul_s((__m128) alpha_factor_2, (__m128) bgra_2);
+++    bgra_3 = (__m128i) __lsx_vfmul_s((__m128) alpha_factor_3, (__m128) bgra_3);
+++
+++    bgra_0 = __lsx_vftintrz_w_s((__m128) bgra_0);
+++    bgra_1 = __lsx_vftintrz_w_s((__m128) bgra_1);
+++    bgra_2 = __lsx_vftintrz_w_s((__m128) bgra_2);
+++    bgra_3 = __lsx_vftintrz_w_s((__m128) bgra_3);
++ 
++     bgra_01 = __lsx_vpickev_b(bgra_1, bgra_0);
++     bgra_23 = __lsx_vpickev_b(bgra_3, bgra_2);
++diff --git a/third_party/crashpad/crashpad/minidump/minidump_context.h b/third_party/crashpad/crashpad/minidump/minidump_context.h
++index 12413de02b6624873668f5806618ee53e7f10e01..54bf2627089dbe60a8143b0b1f3b759bf0191849 100644
++--- a/third_party/crashpad/crashpad/minidump/minidump_context.h
+++++ b/third_party/crashpad/crashpad/minidump/minidump_context.h
++@@ -687,6 +687,56 @@ struct MinidumpContextRISCV64 {
++   uint32_t fcsr;
++ };
++ 
+++//! \brief LOONG64-specifc flags for MinidumpContextLOONG64::context_flags.
+++//! Based on minidump_cpu_loong64.h from breakpad
+++enum MinidumpContextLOONG64Flags : uint32_t {
+++  //! \brief Identifies the context structure as LOONG64.
+++  kMinidumpContextLOONG64 = 0x00800000,
+++
+++  //! \brief Indicates the validity of integer registers.
+++  //!
+++  //! Registers `0`-`31`, `csr_era` are valid.
+++  kMinidumpContextLOONG64Integer = kMinidumpContextLOONG64 | 0x00000002,
+++
+++  //! \brief Indicates the validity of floating point registers.
+++  //!
+++  //! Floating point registers `0`-`31`, `fcsr` and `fcc` are valid
+++  kMinidumpContextLOONG64FloatingPoint = kMinidumpContextLOONG64 | 0x00000004,
+++
+++  //! \brief Indicates the validity of all registers.
+++  kMinidumpContextLOONG64All = kMinidumpContextLOONG64Integer |
+++                              kMinidumpContextLOONG64FloatingPoint,
+++};
+++
+++//! \brief A LOONG64 CPU context (register state) carried in a minidump file.
+++struct MinidumpContextLOONG64 {
+++  uint64_t context_flags;
+++
+++  //! \brief General purpose registers.
+++  uint64_t regs[32];
+++
+++  //! \brief csr_era registers.
+++  uint64_t csr_era;
+++
+++  //! \brief FPU registers.
+++  union {
+++    struct {
+++      float _fp_fregs;
+++      uint32_t _fp_pad;
+++    } fregs[32];
+++    double dregs[32];
+++  } fpregs;
+++
+++  //! \brief Floating-point status and control register.
+++  uint64_t fcc;
+++
+++  //! \brief Floating-point control and status register.
+++  uint32_t fcsr;
+++
+++  //! \brief padding
+++  uint32_t _pad;
+++};
+++
++ }  // namespace crashpad
++ 
++ #endif  // CRASHPAD_MINIDUMP_MINIDUMP_CONTEXT_H_
++diff --git a/third_party/crashpad/crashpad/minidump/minidump_context_writer.cc b/third_party/crashpad/crashpad/minidump/minidump_context_writer.cc
++index 4a6130b63e954d11d6778a6d1320380c7098cf60..eefd3dba5f0f6fc1fe58841563345d2968ed9b68 100644
++--- a/third_party/crashpad/crashpad/minidump/minidump_context_writer.cc
+++++ b/third_party/crashpad/crashpad/minidump/minidump_context_writer.cc
++@@ -110,6 +110,13 @@ MinidumpContextWriter::CreateFromSnapshot(const CPUContext* context_snapshot) {
++       break;
++     }
++ 
+++    case kCPUArchitectureLOONG64: {
+++      context = std::make_unique<MinidumpContextLOONG64Writer>();
+++      reinterpret_cast<MinidumpContextLOONG64Writer*>(context.get())
+++          ->InitializeFromSnapshot(context_snapshot->loong64);
+++      break;
+++    }
+++
++     default: {
++       LOG(ERROR) << "unknown context architecture "
++                  << context_snapshot->architecture;
++@@ -606,4 +613,43 @@ size_t MinidumpContextRISCV64Writer::ContextSize() const {
++   return sizeof(context_);
++ }
++ 
+++MinidumpContextLOONG64Writer::MinidumpContextLOONG64Writer()
+++    : MinidumpContextWriter(), context_() {
+++  context_.context_flags = kMinidumpContextLOONG64;
+++}
+++
+++MinidumpContextLOONG64Writer::~MinidumpContextLOONG64Writer() = default;
+++
+++void MinidumpContextLOONG64Writer::InitializeFromSnapshot(
+++    const CPUContextLOONG64* context_snapshot) {
+++  DCHECK_EQ(state(), kStateMutable);
+++  DCHECK_EQ(context_.context_flags, kMinidumpContextLOONG64);
+++
+++  context_.context_flags = kMinidumpContextLOONG64All;
+++
+++  static_assert(sizeof(context_.regs) == sizeof(context_snapshot->regs),
+++                "GPRs size mismatch");
+++  memcpy(context_.regs, context_snapshot->regs, sizeof(context_.regs));
+++  context_.csr_era = context_snapshot->csr_era;
+++
+++  static_assert(sizeof(context_.fpregs) == sizeof(context_snapshot->fpregs),
+++                "FPRs size mismatch");
+++  memcpy(context_.fpregs.dregs,
+++         context_snapshot->fpregs.dregs,
+++         sizeof(context_.fpregs.dregs));
+++  context_.fcsr = context_snapshot->fcsr;
+++  context_.fcc = context_snapshot->fcc;
+++}
+++
+++bool MinidumpContextLOONG64Writer::WriteObject(
+++    FileWriterInterface* file_writer) {
+++  DCHECK_EQ(state(), kStateWritable);
+++  return file_writer->Write(&context_, sizeof(context_));
+++}
+++
+++size_t MinidumpContextLOONG64Writer::ContextSize() const {
+++  DCHECK_GE(state(), kStateFrozen);
+++  return sizeof(context_);
+++}
+++
++ }  // namespace crashpad
++diff --git a/third_party/crashpad/crashpad/minidump/minidump_context_writer.h b/third_party/crashpad/crashpad/minidump/minidump_context_writer.h
++index 8e39c6692f2949560140f85e57f1cf482fb5f880..640d1baed84cf738403b33a76950869eff06c072 100644
++--- a/third_party/crashpad/crashpad/minidump/minidump_context_writer.h
+++++ b/third_party/crashpad/crashpad/minidump/minidump_context_writer.h
++@@ -413,6 +413,44 @@ class MinidumpContextRISCV64Writer final : public MinidumpContextWriter {
++   MinidumpContextRISCV64 context_;
++ };
++ 
+++//! \brief The writer for a MinidumpContextLOONG64 structure in a minidump file.
+++class MinidumpContextLOONG64Writer final : public MinidumpContextWriter {
+++ public:
+++  MinidumpContextLOONG64Writer();
+++  ~MinidumpContextLOONG64Writer() override;
+++
+++  //! \brief Initializes the MinidumpContextLOONGARCH based on \a context_snapshot.
+++  //!
+++  //! \param[in] context_snapshot The context snapshot to use as source data.
+++  //!
+++  //! \note Valid in #kStateMutable. No mutation of context() may be done before
+++  //!     calling this method, and it is not normally necessary to alter
+++  //!     context() after calling this method.
+++  void InitializeFromSnapshot(const CPUContextLOONG64* context_snapshot);
+++
+++  //! \brief Returns a pointer to the context structure that this object will
+++  //!     write.
+++  //!
+++  //! \attention This returns a non-`const` pointer to this object’s private
+++  //!     data so that a caller can populate the context structure directly.
+++  //!     This is done because providing setter interfaces to each field in the
+++  //!     context structure would be unwieldy and cumbersome. Care must be taken
+++  //!     to populate the context structure correctly. The context structure
+++  //!     must only be modified while this object is in the #kStateMutable
+++  //!     state.
+++  MinidumpContextLOONG64* context() { return &context_; }
+++
+++ protected:
+++  // MinidumpWritable:
+++  bool WriteObject(FileWriterInterface* file_writer) override;
+++
+++  // MinidumpContextWriter:
+++  size_t ContextSize() const override;
+++
+++ private:
+++  MinidumpContextLOONG64 context_;
+++};
+++
++ }  // namespace crashpad
++ 
++ #endif  // CRASHPAD_MINIDUMP_MINIDUMP_CONTEXT_WRITER_H_
++diff --git a/third_party/crashpad/crashpad/minidump/minidump_extensions.h b/third_party/crashpad/crashpad/minidump/minidump_extensions.h
++index a5f442bf5ebf0289cc81f512518a21d72c08de13..d981b961e7f7c9c16924dc29051e36cffe7ac821 100644
++--- a/third_party/crashpad/crashpad/minidump/minidump_extensions.h
+++++ b/third_party/crashpad/crashpad/minidump/minidump_extensions.h
++@@ -213,6 +213,9 @@ enum MinidumpCPUArchitecture : uint16_t {
++   //! \brief Used by Breakpad for 64-bit RISC-V.
++   kMinidumpCPUArchitectureRISCV64Breakpad = 0x8006,
++ 
+++  //! \brief Used by Breakpad for 64-bit LoongArch.
+++  kMinidumpCPUArchitectureLOONG64Breakpad = 0x8007,
+++
++   //! \brief Unknown CPU architecture.
++   kMinidumpCPUArchitectureUnknown = PROCESSOR_ARCHITECTURE_UNKNOWN,
++ };
++diff --git a/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc b/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc
++index 1abb46c318142d6bce7209d76b221b57864a035a..d69fcd7e07bc17db3f870a887222f2f54b8a7db6 100644
++--- a/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc
+++++ b/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc
++@@ -177,6 +177,8 @@ std::string MinidumpMiscInfoDebugBuildString() {
++   static constexpr char kCPU[] = "mips64";
++ #elif defined(ARCH_CPU_RISCV64)
++   static constexpr char kCPU[] = "riscv64";
+++#elif defined(ARCH_CPU_LOONGARCH64)
+++  static constexpr char kCPU[] = "loong64";
++ #else
++ #error define kCPU for this CPU
++ #endif
++diff --git a/third_party/crashpad/crashpad/minidump/minidump_system_info_writer.cc b/third_party/crashpad/crashpad/minidump/minidump_system_info_writer.cc
++index 9fe3ac0e6b20c4f8249ce7c1419f4a7ab9c44d07..29da4c8cd09da617d63d666f45df365fbf346b80 100644
++--- a/third_party/crashpad/crashpad/minidump/minidump_system_info_writer.cc
+++++ b/third_party/crashpad/crashpad/minidump/minidump_system_info_writer.cc
++@@ -135,6 +135,9 @@ void MinidumpSystemInfoWriter::InitializeFromSnapshot(
++     case kCPUArchitectureRISCV64:
++       cpu_architecture = kMinidumpCPUArchitectureRISCV64Breakpad;
++       break;
+++    case kCPUArchitectureLOONG64:
+++      cpu_architecture = kMinidumpCPUArchitectureLOONG64Breakpad;
+++      break;
++     default:
++       NOTREACHED_IN_MIGRATION();
++       cpu_architecture = kMinidumpCPUArchitectureUnknown;
++diff --git a/third_party/crashpad/crashpad/snapshot/capture_memory.cc b/third_party/crashpad/crashpad/snapshot/capture_memory.cc
++index f2ff5d74bb96a9e65437d5d95c7e58dd62716f33..453fe37e1c806d803375cc8a61b14c8ecf61b605 100644
++--- a/third_party/crashpad/crashpad/snapshot/capture_memory.cc
+++++ b/third_party/crashpad/crashpad/snapshot/capture_memory.cc
++@@ -123,6 +123,11 @@ void CaptureMemory::PointedToByContext(const CPUContext& context,
++   for (size_t i = 0; i < std::size(context.riscv64->regs); ++i) {
++     MaybeCaptureMemoryAround(delegate, context.riscv64->regs[i]);
++   }
+++#elif defined(ARCH_CPU_LOONGARCH64)
+++  MaybeCaptureMemoryAround(delegate, context.loong64->csr_era);
+++  for (size_t i = 0; i < std::size(context.loong64->regs); ++i) {
+++    MaybeCaptureMemoryAround(delegate, context.loong64->regs[i]);
+++  }
++ #else
++ #error Port.
++ #endif
++diff --git a/third_party/crashpad/crashpad/snapshot/cpu_architecture.h b/third_party/crashpad/crashpad/snapshot/cpu_architecture.h
++index 26d45f841229a72c0b927b2c49a2eee99713c84f..29f1398b8b0819ca97319cf4102b79993df707dd 100644
++--- a/third_party/crashpad/crashpad/snapshot/cpu_architecture.h
+++++ b/third_party/crashpad/crashpad/snapshot/cpu_architecture.h
++@@ -47,6 +47,9 @@ enum CPUArchitecture {
++ 
++   //! \brief 64-bit RISC-V.
++   kCPUArchitectureRISCV64,
+++
+++  //! \brief 64-bit LOONGARCH.
+++  kCPUArchitectureLOONG64,
++ };
++ 
++ }  // namespace crashpad
++diff --git a/third_party/crashpad/crashpad/snapshot/cpu_context.cc b/third_party/crashpad/crashpad/snapshot/cpu_context.cc
++index 71bf4ace4c6d3d9fbf27d19dbd2467c27d424645..baf21e48d7d19b9404b6e1626c51f7187c35e510 100644
++--- a/third_party/crashpad/crashpad/snapshot/cpu_context.cc
+++++ b/third_party/crashpad/crashpad/snapshot/cpu_context.cc
++@@ -173,6 +173,8 @@ uint64_t CPUContext::InstructionPointer() const {
++       return arm64->pc;
++     case kCPUArchitectureRISCV64:
++       return riscv64->pc;
+++    case kCPUArchitectureLOONG64:
+++      return loong64->csr_era;
++     default:
++       NOTREACHED_IN_MIGRATION();
++       return ~0ull;
++@@ -191,6 +193,8 @@ uint64_t CPUContext::StackPointer() const {
++       return arm64->sp;
++     case kCPUArchitectureRISCV64:
++       return riscv64->regs[1];
+++    case kCPUArchitectureLOONG64:
+++      return loong64->regs[3];
++     default:
++       NOTREACHED_IN_MIGRATION();
++       return ~0ull;
++@@ -232,6 +236,7 @@ bool CPUContext::Is64Bit() const {
++     case kCPUArchitectureARM64:
++     case kCPUArchitectureMIPS64EL:
++     case kCPUArchitectureRISCV64:
+++    case kCPUArchitectureLOONG64:
++       return true;
++     case kCPUArchitectureX86:
++     case kCPUArchitectureARM:
++diff --git a/third_party/crashpad/crashpad/snapshot/cpu_context.h b/third_party/crashpad/crashpad/snapshot/cpu_context.h
++index c3640c328c64530828d242ac1b8429c1b1649f99..54ac3716b7b35a907d4578a4816c474bbf9c2219 100644
++--- a/third_party/crashpad/crashpad/snapshot/cpu_context.h
+++++ b/third_party/crashpad/crashpad/snapshot/cpu_context.h
++@@ -371,6 +371,22 @@ struct CPUContextRISCV64 {
++   uint32_t fcsr;
++ };
++ 
+++//! \brief A context structure carrying LOONG64 CPU state.
+++struct CPUContextLOONG64 {
+++  uint64_t regs[32];
+++  uint64_t csr_era;
+++
+++  union {
+++    double dregs[32];
+++    struct {
+++      float _fp_fregs;
+++      uint32_t _fp_pad;
+++    } fregs[32];
+++  } fpregs;
+++  uint64_t fcc;
+++  uint32_t fcsr;
+++};
+++
++ //! \brief A context structure capable of carrying the context of any supported
++ //!     CPU architecture.
++ struct CPUContext {
++@@ -412,6 +428,7 @@ struct CPUContext {
++     CPUContextMIPS* mipsel;
++     CPUContextMIPS64* mips64;
++     CPUContextRISCV64* riscv64;
+++    CPUContextLOONG64* loong64;
++   };
++ };
++ 
++diff --git a/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.cc b/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.cc
++index 6c4cb3ebce6c53c6231b4c1ce2cac562ad36cbc3..b780e65f0f897a156b0f615f2bf324373aaf6373 100644
++--- a/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.cc
+++++ b/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.cc
++@@ -281,6 +281,40 @@ void InitializeCPUContextRISCV64(const ThreadContext::t64_t& thread_context,
++   context->fcsr = float_context.fcsr;
++ }
++ 
+++#elif defined(ARCH_CPU_LOONGARCH64)
+++
+++void InitializeCPUContextLOONG64_NoFloatingPoint(
+++    const ThreadContext::t64_t& thread_context,
+++    CPUContextLOONG64* context) {
+++  static_assert(sizeof(context->regs) == sizeof(thread_context.regs),
+++                "gpr context size mismtach");
+++  memcpy(context->regs, thread_context.regs, sizeof(context->regs));
+++  context->csr_era = thread_context.csr_era;
+++
+++  memset(&context->fpregs, 0, sizeof(context->fpregs));
+++  context->fcc = 0;
+++  context->fcsr = 0;
+++}
+++
+++void InitializeCPUContextLOONG64_OnlyFPU(
+++    const FloatContext::f64_t& float_context,
+++    CPUContextLOONG64* context) {
+++  static_assert(sizeof(context->fpregs) == sizeof(float_context.fpregs),
+++                "fpu context size mismatch");
+++  memcpy(&context->fpregs, &float_context.fpregs, sizeof(context->fpregs));
+++  context->fcc = float_context.fcc;
+++  context->fcsr = float_context.fcsr;
+++}
+++
+++void InitializeCPUContextLOONG64(
+++    const ThreadContext::t64_t& thread_context,
+++    const FloatContext::f64_t& float_context,
+++    CPUContextLOONG64* context) {
+++  InitializeCPUContextLOONG64_NoFloatingPoint(thread_context, context);
+++
+++  InitializeCPUContextLOONG64_OnlyFPU(float_context, context);
+++}
+++
++ #endif  // ARCH_CPU_X86_FAMILY
++ 
++ }  // namespace internal
++diff --git a/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.h b/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.h
++index 507d1b44dd0e5521872392a95aab6004242a5644..a2b72b522c66f6b983bf97122f7f5bd052a3a111 100644
++--- a/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.h
+++++ b/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.h
++@@ -188,6 +188,45 @@ void InitializeCPUContextRISCV64(const ThreadContext::t64_t& thread_context,
++ 
++ #endif  // ARCH_CPU_RISCV64 || DOXYGEN
++ 
+++#if defined(ARCH_CPU_LOONGARCH64) || DOXYGEN
+++
+++//! \brief Initializes GPR state in a CPUContextLOONG64 from a native context
+++//!     structure on Linux.
+++//!
+++//! Floating point state is initialized to zero.
+++//!
+++//! \param[in] thread_context The native thread context.
+++//! \param[out] context The CPUContextLOONG64 structure to initialize.
+++void InitializeCPUContextLOONG64_NoFloatingPoint(
+++    const ThreadContext::t64_t& thread_context,
+++    CPUContextLOONG64* context);
+++//! \brief Initializes FPU state in a CPUContextLOONG64 from a native fpu
+++//!     signal context structure on Linux.
+++//!
+++//! General purpose registers are not initialized.
+++//!
+++//! \param[in] float_context The native fpu context.
+++//! \param[out] context The CPUContextLOONG64 structure to initialize.
+++void InitializeCPUContextLOONG64_OnlyFPU(
+++    const FloatContext::f64_t& float_context,
+++    CPUContextLOONG64* context);
+++//! \brief Initializes a CPUContextLOONG64 structure from native context
+++//!     structures on Linux.
+++//!
+++//! This function has template specializations for LOONG64 architecture
+++//! contexts, using ContextTraits32 or ContextTraits64 as template parameter,
+++//! respectively.
+++//!
+++//! \param[in] thread_context The native thread context.
+++//! \param[in] float_context The native float context.
+++//! \param[out] context The CPUContextLOONG64 structure to initialize.
+++void InitializeCPUContextLOONG64(
+++    const ThreadContext::t64_t& thread_context,
+++    const FloatContext::f64_t& float_context,
+++    CPUContextLOONG64* context);
+++
+++#endif  // ARCH_CPU_LOONGARCH64 || DOXYGEN
+++
++ }  // namespace internal
++ }  // namespace crashpad
++ 
++diff --git a/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.cc b/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.cc
++index 677afdaa77362bb0ea83ad5c4fa82dd5dc27da46..0fedcc39cb1a23eee8d4f9b3b51151cb59b8ec82 100644
++--- a/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.cc
+++++ b/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.cc
++@@ -15,6 +15,7 @@
++ #include "snapshot/linux/exception_snapshot_linux.h"
++ 
++ #include <signal.h>
+++#include <cstring>
++ 
++ #include "base/logging.h"
++ #include "snapshot/linux/capture_memory_delegate_linux.h"
++@@ -367,6 +368,78 @@ bool ExceptionSnapshotLinux::ReadContext<ContextTraits64>(
++   return internal::ReadContext(reader, context_address, context_.riscv64);
++ }
++ 
+++#elif defined(ARCH_CPU_LOONGARCH64)
+++
+++static bool ReadContext(ProcessReaderLinux* reader,
+++                        LinuxVMAddress context_address,
+++                        typename ContextTraits64::CPUContext* dest_context) {
+++  const ProcessMemory* memory = reader->Memory();
+++  LinuxVMAddress mcontext_address = context_address +
+++                                 offsetof(UContext<ContextTraits64>, mcontext);
+++  ThreadContext::t64_t thread_context;
+++  ContextTraits64::MContext mcontext;
+++  if (!memory->Read(mcontext_address, sizeof(mcontext), &mcontext)) {
+++    LOG(ERROR) << "Couldn't read gregs";
+++    return false;
+++  }
+++  static_assert(sizeof(thread_context.regs) == sizeof(mcontext.gregs),
+++                "gpr context size mismtach");
+++  memcpy(thread_context.regs, mcontext.gregs, sizeof(mcontext.gregs));
+++  thread_context.csr_era = mcontext.pc;
+++  thread_context.orig_a0 = 0;
+++  thread_context.csr_badv = 0;
+++  InitializeCPUContextLOONG64_NoFloatingPoint(thread_context, dest_context);
+++
+++  LinuxVMAddress reserved_address =
+++        context_address + offsetof(UContext<ContextTraits64>, mcontext.extcontext);
+++  if ((reserved_address & 15) != 0) {
+++    LOG(ERROR) << "invalid alignment 0x" << std::hex << reserved_address;
+++    return false;
+++   }
+++  constexpr VMSize kMaxContextSpace = 4096;
+++  ProcessMemoryRange range;
+++  if (!range.Initialize(memory, true, reserved_address, kMaxContextSpace)) {
+++    return false;
+++  }
+++  do {
+++    struct sctx_info head;
+++    if (!range.Read(reserved_address, sizeof(head), &head)) {
+++      LOG(ERROR) << "missing context terminator";
+++      return false;
+++    }
+++    reserved_address += sizeof(head);
+++    switch (head.magic) {
+++      case FPU_CTX_MAGIC:
+++        if (head.size != sizeof(struct fpu_context) + sizeof(head)) {
+++          LOG(ERROR) << "unexpected fpu context size " << head.size;
+++          return false;
+++        }
+++        FloatContext::f64_t fpucontext;
+++        if (!range.Read(reserved_address, sizeof(fpucontext), &fpucontext)) {
+++          LOG(ERROR) << "Couldn't read fpu " << head.size;
+++          return false;
+++        }
+++        InitializeCPUContextLOONG64_OnlyFPU(fpucontext, dest_context);
+++        return true;
+++      case 0:
+++        return true;
+++      default:
+++        LOG(ERROR) << "invalid magic number 0x" << std::hex << head.magic;
+++        return false;
+++    }
+++  } while (true);
+++}
+++
+++template <>
+++bool ExceptionSnapshotLinux::ReadContext<ContextTraits64>(
+++    ProcessReaderLinux* reader,
+++    LinuxVMAddress context_address) {
+++  context_.architecture = kCPUArchitectureLOONG64;
+++  context_.loong64 = &context_union_.loong64;
+++
+++  return internal::ReadContext(reader, context_address, context_.loong64);
+++}
+++
++ #endif  // ARCH_CPU_X86_FAMILY
++ 
++ bool ExceptionSnapshotLinux::Initialize(
++@@ -397,7 +470,7 @@ bool ExceptionSnapshotLinux::Initialize(
++       return false;
++     }
++   } else {
++-#if !defined(ARCH_CPU_RISCV64)
+++#if !defined(ARCH_CPU_RISCV64) && !defined(ARCH_CPU_LOONGARCH64)
++     if (!ReadContext<ContextTraits32>(process_reader, context_address) ||
++         !ReadSiginfo<Traits32>(process_reader, siginfo_address)) {
++       return false;
++diff --git a/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.h b/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.h
++index f931d33002a7b55bcd6e2aa29c280fa2e3393bb8..c5acf661f829bb1371951194ba2e70fa67c88cbb 100644
++--- a/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.h
+++++ b/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.h
++@@ -91,6 +91,8 @@ class ExceptionSnapshotLinux final : public ExceptionSnapshot {
++     CPUContextMIPS64 mips64;
++ #elif defined(ARCH_CPU_RISCV64)
++     CPUContextRISCV64 riscv64;
+++#elif defined(ARCH_CPU_LOONGARCH64)
+++    CPUContextLOONG64 loong64;
++ #endif
++   } context_union_;
++   CPUContext context_;
++diff --git a/third_party/crashpad/crashpad/snapshot/linux/process_reader_linux.cc b/third_party/crashpad/crashpad/snapshot/linux/process_reader_linux.cc
++index 45713386d953e4bbf67599fd2727c602f9a5b127..3afcd51478922129731037f6d5bec720e78f6c0a 100644
++--- a/third_party/crashpad/crashpad/snapshot/linux/process_reader_linux.cc
+++++ b/third_party/crashpad/crashpad/snapshot/linux/process_reader_linux.cc
++@@ -129,6 +129,8 @@ void ProcessReaderLinux::Thread::InitializeStack(ProcessReaderLinux* reader) {
++                                     : thread_info.thread_context.t32.regs[29];
++ #elif defined(ARCH_CPU_RISCV64)
++   stack_pointer = thread_info.thread_context.t64.regs[1];
+++#elif defined(ARCH_CPU_LOONGARCH64)
+++  stack_pointer = thread_info.thread_context.t64.regs[3];
++ #else
++ #error Port.
++ #endif
++diff --git a/third_party/crashpad/crashpad/snapshot/linux/signal_context.h b/third_party/crashpad/crashpad/snapshot/linux/signal_context.h
++index 89e697a08bad013a0d91e036310b9f91b1ad3f48..ab04f3a40db2e21b401ca9002892372635e4413a 100644
++--- a/third_party/crashpad/crashpad/snapshot/linux/signal_context.h
+++++ b/third_party/crashpad/crashpad/snapshot/linux/signal_context.h
++@@ -456,6 +456,46 @@ static_assert(offsetof(UContext<ContextTraits64>, mcontext.fpregs) ==
++                   offsetof(ucontext_t, uc_mcontext.__fpregs),
++               "context offset mismatch");
++ 
+++#elif defined(ARCH_CPU_LOONGARCH64)
+++
+++// See asm/sigcontext.h
+++struct MContext64 {
+++  uint64_t pc;
+++  uint64_t gregs[32];
+++  uint32_t flags;
+++  uint32_t padding;
+++  uint64_t extcontext[0] __attribute__((__aligned__(16)));
+++};
+++
+++struct ContextTraits64 : public Traits64 {
+++  using MContext = MContext64;
+++  using SignalThreadContext = ThreadContext::t64_t;
+++  using SignalFloatContext = FloatContext::f64_t;
+++  using CPUContext = CPUContextLOONG64;
+++};
+++
+++// See asm/ucontext.h
+++template <typename Traits>
+++struct UContext {
+++  typename Traits::ULong flags;
+++  typename Traits::Address link;
+++  SignalStack<Traits> stack;
+++  Sigset<Traits> sigmask;
+++  char alignment_padding_[8];
+++  char padding[128 - sizeof(Sigset<Traits>)];
+++  MContext64 mcontext;
+++};
+++
+++static_assert(offsetof(UContext<ContextTraits64>, mcontext) ==
+++                  offsetof(ucontext_t, uc_mcontext),
+++              "context offset mismatch");
+++static_assert(offsetof(UContext<ContextTraits64>, mcontext.gregs) ==
+++                  offsetof(ucontext_t, uc_mcontext.__gregs),
+++              "context offset mismatch");
+++static_assert(offsetof(UContext<ContextTraits64>, mcontext.extcontext) ==
+++                  offsetof(ucontext_t, uc_mcontext.__extcontext),
+++              "context offset mismatch");
+++
++ #else
++ #error Port.
++ #endif  // ARCH_CPU_X86_FAMILY
++diff --git a/third_party/crashpad/crashpad/snapshot/linux/system_snapshot_linux.cc b/third_party/crashpad/crashpad/snapshot/linux/system_snapshot_linux.cc
++index ce360e60f188dc3f28b34dc6fac74fc64e90b07f..2b2ff28c1bdad359e7d0474149be96c6f7b79fd8 100644
++--- a/third_party/crashpad/crashpad/snapshot/linux/system_snapshot_linux.cc
+++++ b/third_party/crashpad/crashpad/snapshot/linux/system_snapshot_linux.cc
++@@ -208,6 +208,8 @@ CPUArchitecture SystemSnapshotLinux::GetCPUArchitecture() const {
++                                     : kCPUArchitectureMIPSEL;
++ #elif defined(ARCH_CPU_RISCV64)
++   return kCPUArchitectureRISCV64;
+++#elif defined(ARCH_CPU_LOONGARCH64)
+++  return kCPUArchitectureLOONG64;
++ #else
++ #error port to your architecture
++ #endif
++@@ -226,6 +228,9 @@ uint32_t SystemSnapshotLinux::CPURevision() const {
++ #elif defined(ARCH_CPU_RISCV64)
++   // Not implemented
++   return 0;
+++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
+++  // Not implemented
+++  return 0;
++ #else
++ #error port to your architecture
++ #endif
++@@ -249,6 +254,9 @@ std::string SystemSnapshotLinux::CPUVendor() const {
++ #elif defined(ARCH_CPU_RISCV64)
++   // Not implemented
++   return std::string();
+++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
+++  // Not implemented
+++  return std::string();
++ #else
++ #error port to your architecture
++ #endif
++@@ -385,6 +393,9 @@ bool SystemSnapshotLinux::NXEnabled() const {
++ #elif defined(ARCH_CPU_RISCV64)
++   // Not implemented
++   return false;
+++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
+++  // Not implemented
+++  return false;
++ #else
++ #error Port.
++ #endif  // ARCH_CPU_X86_FAMILY
++diff --git a/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.cc b/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.cc
++index 85882e8ee464f77fe398371c15919940407724a6..2f0ad4f3cbc3d426f6ad9b2905fd657ac25e2fa8 100644
++--- a/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.cc
+++++ b/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.cc
++@@ -196,6 +196,12 @@ bool ThreadSnapshotLinux::Initialize(
++   InitializeCPUContextRISCV64(thread.thread_info.thread_context.t64,
++                               thread.thread_info.float_context.f64,
++                               context_.riscv64);
+++#elif defined(ARCH_CPU_LOONGARCH64)
+++  context_.architecture = kCPUArchitectureLOONG64;
+++  context_.loong64 = &context_union_.loong64;
+++  InitializeCPUContextLOONG64(thread.thread_info.thread_context.t64,
+++                              thread.thread_info.float_context.f64,
+++                              context_.loong64);
++ #else
++ #error Port.
++ #endif
++diff --git a/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.h b/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.h
++index 5795bfb985a2512310e1785c06d7ae3567f9aef8..78f14e1208481889261cfdbd1f71b144bb5b9d32 100644
++--- a/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.h
+++++ b/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.h
++@@ -76,6 +76,8 @@ class ThreadSnapshotLinux final : public ThreadSnapshot {
++     CPUContextMIPS64 mips64;
++ #elif defined(ARCH_CPU_RISCV64)
++     CPUContextRISCV64 riscv64;
+++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
+++    CPUContextLOONG64 loong64;
++ #else
++ #error Port.
++ #endif  // ARCH_CPU_X86_FAMILY
++diff --git a/third_party/crashpad/crashpad/snapshot/minidump/minidump_context_converter.cc b/third_party/crashpad/crashpad/snapshot/minidump/minidump_context_converter.cc
++index ec02dff1266785d98dc119a9cfa9e3980a02d84f..92d9c6f78a915427ee993b35f33a4b00b8f6f020 100644
++--- a/third_party/crashpad/crashpad/snapshot/minidump/minidump_context_converter.cc
+++++ b/third_party/crashpad/crashpad/snapshot/minidump/minidump_context_converter.cc
++@@ -293,6 +293,30 @@ bool MinidumpContextConverter::Initialize(
++     memcpy(&context_.riscv64->fpregs, &src->fpregs, sizeof(src->fpregs));
++ 
++     context_.riscv64->fcsr = src->fcsr;
+++  } else if (context_.architecture ==
+++             CPUArchitecture::kCPUArchitectureLOONG64) {
+++    context_memory_.resize(sizeof(CPUContextLOONG64));
+++    context_.loong64 =
+++        reinterpret_cast<CPUContextLOONG64*>(context_memory_.data());
+++    const MinidumpContextLOONG64* src =
+++        reinterpret_cast<const MinidumpContextLOONG64*>(minidump_context.data());
+++    if (minidump_context.size() < sizeof(MinidumpContextLOONG64)) {
+++      return false;
+++    }
+++
+++    if (!(src->context_flags & kMinidumpContextLOONG64)) {
+++      return false;
+++    }
+++
+++    for (size_t i = 0; i < std::size(src->regs); i++) {
+++      context_.loong64->regs[i] = src->regs[i];
+++    }
+++
+++    context_.loong64->csr_era = src->csr_era;
+++    context_.loong64->fcsr = src->fcsr;
+++    context_.loong64->fcc = src->fcc;
+++
+++    memcpy(&context_.loong64->fpregs, &src->fpregs, sizeof(src->fpregs));
++   } else {
++     // Architecture is listed as "unknown".
++     DLOG(ERROR) << "Unknown architecture";
++diff --git a/third_party/crashpad/crashpad/snapshot/minidump/system_snapshot_minidump.cc b/third_party/crashpad/crashpad/snapshot/minidump/system_snapshot_minidump.cc
++index cfdedadf2d81f690b956d4b3b8389fc6e2083afa..82ba77033c5e6770d8a2a51ba83ab6d58d3355e2 100644
++--- a/third_party/crashpad/crashpad/snapshot/minidump/system_snapshot_minidump.cc
+++++ b/third_party/crashpad/crashpad/snapshot/minidump/system_snapshot_minidump.cc
++@@ -70,6 +70,8 @@ CPUArchitecture SystemSnapshotMinidump::GetCPUArchitecture() const {
++     // No word on how MIPS64 is signalled
++     case kMinidumpCPUArchitectureRISCV64Breakpad:
++       return kCPUArchitectureRISCV64;
+++    case kMinidumpCPUArchitectureLOONG64Breakpad:
+++      return kCPUArchitectureLOONG64;
++ 
++     default:
++       return CPUArchitecture::kCPUArchitectureUnknown;
++diff --git a/third_party/crashpad/crashpad/util/linux/ptracer.cc b/third_party/crashpad/crashpad/util/linux/ptracer.cc
++index a985cb1d1ff976ccf68840957f968677efe44a4b..f4375a88928a185c62c0eefa16a2ca2f6f574d41 100644
++--- a/third_party/crashpad/crashpad/util/linux/ptracer.cc
+++++ b/third_party/crashpad/crashpad/util/linux/ptracer.cc
++@@ -430,6 +430,37 @@ bool GetThreadArea64(pid_t tid,
++   return true;
++ }
++ 
+++#elif defined(ARCH_CPU_LOONGARCH64)
+++
+++bool GetFloatingPointRegisters64(pid_t tid,
+++                                 FloatContext* context,
+++                                 bool can_log) {
+++  iovec iov;
+++  iov.iov_base = context;
+++  iov.iov_len = sizeof(*context);
+++  if (ptrace(
+++          PTRACE_GETREGSET, tid, reinterpret_cast<void*>(NT_PRFPREG), &iov) !=
+++      0) {
+++    PLOG_IF(ERROR, can_log) << "ptrace";
+++    return false;
+++  }
+++  if (iov.iov_len != sizeof(context->f64)) {
+++    LOG_IF(ERROR, can_log) << "Unexpected registers size " << iov.iov_len
+++                           << " != " << sizeof(context->f64);
+++    return false;
+++  }
+++  return true;
+++}
+++
+++bool GetThreadArea64(pid_t tid,
+++                     const ThreadContext& context,
+++                     LinuxVMAddress* address,
+++                     bool can_log) {
+++  // Thread pointer register
+++  *address = context.t64.regs[2];
+++  return true;
+++}
+++
++ #else
++ #error Port.
++ #endif  // ARCH_CPU_X86_FAMILY
++@@ -534,7 +565,7 @@ bool Ptracer::GetThreadInfo(pid_t tid, ThreadInfo* info) {
++                            can_log_);
++   }
++ 
++-#if !defined(ARCH_CPU_RISCV64)
+++#if !defined(ARCH_CPU_RISCV64) && !defined(ARCH_CPU_LOONGARCH64)
++   return GetGeneralPurposeRegisters32(tid, &info->thread_context, can_log_) &&
++          GetFloatingPointRegisters32(tid, &info->float_context, can_log_) &&
++          GetThreadArea32(tid,
++diff --git a/third_party/crashpad/crashpad/util/linux/thread_info.h b/third_party/crashpad/crashpad/util/linux/thread_info.h
++index 808b35a3affa2a0c1b1c96e436841c6e828837ff..e3ad411981c19814034f82481a107b49260df615 100644
++--- a/third_party/crashpad/crashpad/util/linux/thread_info.h
+++++ b/third_party/crashpad/crashpad/util/linux/thread_info.h
++@@ -87,6 +87,8 @@ union ThreadContext {
++     uint32_t padding1_;
++ #elif defined(ARCH_CPU_RISCV64)
++     // 32 bit RISC-V not supported
+++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
+++    // 32 bit LoongArch not supported
++ #else
++ #error Port.
++ #endif  // ARCH_CPU_X86_FAMILY
++@@ -144,13 +146,20 @@ union ThreadContext {
++     // Reflects user_regs_struct in asm/ptrace.h.
++     uint64_t pc;
++     uint64_t regs[31];
+++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
+++    // Reflects user_regs_struct in sys/user.h.
+++    uint64_t regs[32];
+++    uint64_t orig_a0;
+++    uint64_t csr_era;
+++    uint64_t csr_badv;
+++    uint64_t reserved[10];
++ #else
++ #error Port.
++ #endif  // ARCH_CPU_X86_FAMILY
++   } t64;
++ 
++ #if defined(ARCH_CPU_X86_FAMILY) || defined(ARCH_CPU_ARM64) || \
++-    defined(ARCH_CPU_RISCV64)
+++    defined(ARCH_CPU_RISCV64) || defined(ARCH_CPU_LOONGARCH_FAMILY)
++   using NativeThreadContext = user_regs_struct;
++ #elif defined(ARCH_CPU_ARMEL)
++   using NativeThreadContext = user_regs;
++@@ -233,6 +242,8 @@ union FloatContext {
++     uint32_t fpu_id;
++ #elif defined(ARCH_CPU_RISCV64)
++     // 32 bit RISC-V not supported
+++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
+++    // 32 bit LoongArch not supported
++ #else
++ #error Port.
++ #endif  // ARCH_CPU_X86_FAMILY
++@@ -271,6 +282,11 @@ union FloatContext {
++     // Reflects __riscv_d_ext_state in asm/ptrace.h
++     uint64_t fpregs[32];
++     uint64_t fcsr;
+++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
+++    // Reflects user_fp_struct in sys/user.h
+++    uint64_t fpregs[32];
+++    uint64_t fcc;
+++    uint32_t fcsr;
++ #else
++ #error Port.
++ #endif  // ARCH_CPU_X86_FAMILY
++@@ -302,6 +318,8 @@ union FloatContext {
++ // No appropriate floating point context native type for available MIPS.
++ #elif defined(ARCH_CPU_RISCV64)
++   static_assert(sizeof(f64) == sizeof(__riscv_d_ext_state), "Size mismatch");
+++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
+++  static_assert(sizeof(f64) == sizeof(user_fp_struct), "Size mismatch");
++ #else
++ #error Port.
++ #endif  // ARCH_CPU_X86
++diff --git a/third_party/crashpad/crashpad/util/misc/capture_context_linux.S b/third_party/crashpad/crashpad/util/misc/capture_context_linux.S
++index cfad85738e572d9cb99221b22d0e9b6d877f5e17..715c86205662cab17b6efcd8af5800dfc6b4c546 100644
++--- a/third_party/crashpad/crashpad/util/misc/capture_context_linux.S
+++++ b/third_party/crashpad/crashpad/util/misc/capture_context_linux.S
++@@ -510,4 +510,49 @@ CAPTURECONTEXT_SYMBOL2:
++ 
++   ret
++ 
+++#elif defined(__loongarch_lp64)
+++
+++#define MCONTEXT_GREG_SIZE 8
+++#define MCONTEXT_PC_OFFSET 176
+++#define MCONTEXT_GREGS_OFFSET 184
+++
+++#define STORE_GPR(X) st.d $r##X, $a0, MCONTEXT_GREGS_OFFSET + X * MCONTEXT_GREG_SIZE
+++#define STORE_PC st.d $ra, $a0, MCONTEXT_PC_OFFSET
+++
+++  STORE_PC
+++  STORE_GPR(0)
+++  STORE_GPR(1)
+++  STORE_GPR(2)
+++  STORE_GPR(3)
+++  STORE_GPR(4)
+++  STORE_GPR(5)
+++  STORE_GPR(6)
+++  STORE_GPR(7)
+++  STORE_GPR(8)
+++  STORE_GPR(9)
+++  STORE_GPR(10)
+++  STORE_GPR(11)
+++  STORE_GPR(12)
+++  STORE_GPR(13)
+++  STORE_GPR(14)
+++  STORE_GPR(15)
+++  STORE_GPR(16)
+++  STORE_GPR(17)
+++  STORE_GPR(18)
+++  STORE_GPR(19)
+++  STORE_GPR(20)
+++  STORE_GPR(21)
+++  STORE_GPR(22)
+++  STORE_GPR(23)
+++  STORE_GPR(24)
+++  STORE_GPR(25)
+++  STORE_GPR(26)
+++  STORE_GPR(27)
+++  STORE_GPR(28)
+++  STORE_GPR(29)
+++  STORE_GPR(30)
+++  STORE_GPR(31)
+++
+++  jirl $zero, $ra, 0
+++
++ #endif  // __i386__
++diff --git a/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc b/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc
++index df63a77296d045975884c132a9657e9c1d57d4d2..1f7d652441ea7821ee1bb68f35469f06d8b15730 100644
++--- a/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc
+++++ b/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc
++@@ -239,6 +239,8 @@ std::string UserAgent() {
++ #endif
++ #elif defined (ARCH_CPU_RISCV64)
++     static constexpr char arch[] = "riscv64";
+++#elif defined (ARCH_CPU_LOONGARCH64)
+++    static constexpr char arch[] = "loong64";
++ #else
++ #error Port
++ #endif
++diff --git a/third_party/dav1d/config/linux/loong64/config.h b/third_party/dav1d/config/linux/loong64/config.h
++new file mode 100644
++index 0000000000000000000000000000000000000000..44c60eb528119aafb00871cb15218f70797e2efe
++--- /dev/null
+++++ b/third_party/dav1d/config/linux/loong64/config.h
++@@ -0,0 +1,45 @@
+++/*
+++ * Autogenerated by the Meson build system.
+++ * Do not edit, your changes will be lost.
+++ */
+++
+++#pragma once
+++
+++#define ARCH_AARCH64 0
+++
+++#define ARCH_ARM 0
+++
+++#define ARCH_PPC64LE 0
+++
+++#define ARCH_X86 0
+++
+++#define ARCH_X86_32 0
+++
+++#define ARCH_X86_64 0
+++
+++#define CONFIG_16BPC 1
+++
+++#define CONFIG_8BPC 1
+++
+++// #define CONFIG_LOG 1 -- Logging is controlled by Chromium
+++
+++#define ENDIANNESS_BIG 0
+++
+++#define HAVE_ASM 0
+++
+++#define HAVE_C11_GENERIC 1
+++
+++#define HAVE_CLOCK_GETTIME 1
+++
+++#define HAVE_DLSYM 1
+++
+++#define HAVE_POSIX_MEMALIGN 1
+++
+++// #define HAVE_PTHREAD_GETAFFINITY_NP 1 -- Controlled by Chomium
+++
+++// #define HAVE_PTHREAD_SETAFFINITY_NP 1 -- Controlled by Chomium
+++
+++#define HAVE_UNISTD_H 1
+++
+++#define TRIM_DSP_FUNCTIONS 1
+++
+diff --git a/patches/config.json b/patches/config.json
+index 60cfd3ff8e..66470126fe 100644
+--- a/patches/config.json
++++ b/patches/config.json
+@@ -13,5 +13,7 @@
+   { "patch_dir": "src/electron/patches/webrtc", "repo": "src/third_party/webrtc" },
+   { "patch_dir": "src/electron/patches/reclient-configs", "repo": "src/third_party/engflow-reclient-configs" },
+   { "patch_dir": "src/electron/patches/skia", "repo": "src/third_party/skia" },
+-  { "patch_dir": "src/electron/patches/dawn", "repo": "src/third_party/dawn" }
++  { "patch_dir": "src/electron/patches/dawn", "repo": "src/third_party/dawn" },
++  { "patch_dir": "src/electron/patches/swiftshader", "repo": "src/third_party/swiftshader" },
++  { "patch_dir": "src/electron/patches/breakpad", "repo": "src/third_party/breakpad/breakpad" }
+ ]
+diff --git a/patches/devtools_frontend/.patches b/patches/devtools_frontend/.patches
+index 3cf8d9fc4a..13c1c128d6 100644
+--- a/patches/devtools_frontend/.patches
++++ b/patches/devtools_frontend/.patches
+@@ -1 +1,3 @@
+ chore_expose_ui_to_allow_electron_to_set_dock_side.patch
++loong64_support.patch
++patch_esbuild_version_for_loong64.patch
+diff --git a/patches/devtools_frontend/loong64_support.patch b/patches/devtools_frontend/loong64_support.patch
+new file mode 100644
+index 0000000000..2e7f3fafb1
+--- /dev/null
++++ b/patches/devtools_frontend/loong64_support.patch
+@@ -0,0 +1,20 @@
++From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
++From: darkyzhou <me@zqy.io>
++Date: Mon, 18 Nov 2024 16:34:13 +0000
++Subject: loong64 support
++
++Co-authored-by: Jiajie Chen <c@jia.je>
++
++diff --git a/scripts/build/rollup.config.js b/scripts/build/rollup.config.js
++index fd01fabf108341d086a2529d5b1d43613683bb86..f6bc03cc61bdf87e0c6da017d9a6235750e52a18 100644
++--- a/scripts/build/rollup.config.js
+++++ b/scripts/build/rollup.config.js
++@@ -19,7 +19,7 @@ export default commandLineArgs => ({
++     sourcemap: Boolean(commandLineArgs.configSourcemaps),
++   }],
++   plugins: [
++-    terser(),
+++    // terser(),
++     {
++       name: 'devtools-plugin',
++       resolveId(source, importer) {
+diff --git a/patches/devtools_frontend/patch_esbuild_version_for_loong64.patch b/patches/devtools_frontend/patch_esbuild_version_for_loong64.patch
+new file mode 100644
+index 0000000000..cd0282d95a
+--- /dev/null
++++ b/patches/devtools_frontend/patch_esbuild_version_for_loong64.patch
+@@ -0,0 +1,66 @@
++From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
++From: darkyzhou <me@zqy.io>
++Date: Tue, 19 Nov 2024 01:37:50 +0000
++Subject: patch esbuild version for loong64
++
++
++diff --git a/node_modules/esbuild/lib/main.js b/node_modules/esbuild/lib/main.js
++index c0f1a991084741cae1644ca089c20ecc01470f2e..c641aad69883d9ccf52d0bb5b86c90b7ab5e5573 100644
++--- a/node_modules/esbuild/lib/main.js
+++++ b/node_modules/esbuild/lib/main.js
++@@ -717,8 +717,8 @@ function createChannel(streamIn) {
++     if (isFirstPacket) {
++       isFirstPacket = false;
++       let binaryVersion = String.fromCharCode(...bytes);
++-      if (binaryVersion !== "0.14.13") {
++-        throw new Error(`Cannot start service: Host version "${"0.14.13"}" does not match binary version ${JSON.stringify(binaryVersion)}`);
+++      if (binaryVersion !== "0.14.54") {
+++        throw new Error(`Cannot start service: Host version "${"0.14.54"}" does not match binary version ${JSON.stringify(binaryVersion)}`);
++       }
++       return;
++     }
++@@ -1804,7 +1804,7 @@ if (process.env.ESBUILD_WORKER_THREADS !== "0") {
++   }
++ }
++ var _a;
++-var isInternalWorkerThread = ((_a = worker_threads == null ? void 0 : worker_threads.workerData) == null ? void 0 : _a.esbuildVersion) === "0.14.13";
+++var isInternalWorkerThread = ((_a = worker_threads == null ? void 0 : worker_threads.workerData) == null ? void 0 : _a.esbuildVersion) === "0.14.54";
++ var esbuildCommandAndArgs = () => {
++   if ((!ESBUILD_BINARY_PATH || false) && (path2.basename(__filename) !== "main.js" || path2.basename(__dirname) !== "lib")) {
++     throw new Error(`The esbuild JavaScript API cannot be bundled. Please mark the "esbuild" package as external so it's not included in the bundle.
++@@ -1863,7 +1863,7 @@ var fsAsync = {
++     }
++   }
++ };
++-var version = "0.14.13";
+++var version = "0.14.54";
++ var build = (options) => ensureServiceIsRunning().build(options);
++ var serve = (serveOptions, buildOptions) => ensureServiceIsRunning().serve(serveOptions, buildOptions);
++ var transform = (input, options) => ensureServiceIsRunning().transform(input, options);
++@@ -1972,7 +1972,7 @@ var ensureServiceIsRunning = () => {
++   if (longLivedService)
++     return longLivedService;
++   let [command, args] = esbuildCommandAndArgs();
++-  let child = child_process.spawn(command, args.concat(`--service=${"0.14.13"}`, "--ping"), {
+++  let child = child_process.spawn(command, args.concat(`--service=${"0.14.54"}`, "--ping"), {
++     windowsHide: true,
++     stdio: ["pipe", "pipe", "inherit"],
++     cwd: defaultWD
++@@ -2081,7 +2081,7 @@ var runServiceSync = (callback) => {
++     esbuild: node_exports
++   });
++   callback(service);
++-  let stdout = child_process.execFileSync(command, args.concat(`--service=${"0.14.13"}`), {
+++  let stdout = child_process.execFileSync(command, args.concat(`--service=${"0.14.54"}`), {
++     cwd: defaultWD,
++     windowsHide: true,
++     input: stdin,
++@@ -2097,7 +2097,7 @@ var workerThreadService = null;
++ var startWorkerThreadService = (worker_threads2) => {
++   let { port1: mainPort, port2: workerPort } = new worker_threads2.MessageChannel();
++   let worker = new worker_threads2.Worker(__filename, {
++-    workerData: { workerPort, defaultWD, esbuildVersion: "0.14.13" },
+++    workerData: { workerPort, defaultWD, esbuildVersion: "0.14.54" },
++     transferList: [workerPort],
++     execArgv: []
++   });
+diff --git a/patches/ffmpeg/.patches b/patches/ffmpeg/.patches
+index 31dc878c5b..f96d1acc1d 100644
+--- a/patches/ffmpeg/.patches
++++ b/patches/ffmpeg/.patches
+@@ -1 +1,2 @@
+ link_with_loader_path.patch
++loong64_support.patch
+diff --git a/patches/ffmpeg/loong64_support.patch b/patches/ffmpeg/loong64_support.patch
+new file mode 100644
+index 0000000000..511b644116
+--- /dev/null
++++ b/patches/ffmpeg/loong64_support.patch
+@@ -0,0 +1,6238 @@
++From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
++From: darkyzhou <me@zqy.io>
++Date: Mon, 18 Nov 2024 16:17:26 +0000
++Subject: loong64 support
++
++Co-authored-by: Jiajie Chen <c@jia.je>
++
++diff --git a/chromium/config/Chrome/linux/loong64/config.h b/chromium/config/Chrome/linux/loong64/config.h
++new file mode 100644
++index 0000000000000000000000000000000000000000..a7a0368837fbbb0ba844e25b2a49480f7304c10c
++--- /dev/null
+++++ b/chromium/config/Chrome/linux/loong64/config.h
++@@ -0,0 +1,772 @@
+++/* Automatically generated by configure - do not modify! */
+++#ifndef FFMPEG_CONFIG_H
+++#define FFMPEG_CONFIG_H
+++/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-lsx --disable-lasx --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --disable-linux-perf --x86asmexe=nasm --optflags='\\\\\"-O2\\\\\"' --cc=clang --cxx=clang++ --ld=clang --enable-decoder='aac,h264' --enable-demuxer=aac --enable-parser='aac,h264'" */
+++#define FFMPEG_LICENSE "LGPL version 2.1 or later"
+++#define CONFIG_THIS_YEAR 2024
+++#define FFMPEG_DATADIR "/usr/local/share/ffmpeg"
+++#define AVCONV_DATADIR "/usr/local/share/ffmpeg"
+++#define CC_IDENT "clang version 17.0.6"
+++#define OS_NAME linux
+++#define av_restrict restrict
+++#define EXTERN_PREFIX ""
+++#define EXTERN_ASM 
+++#define BUILDSUF ""
+++#define SLIBSUF ".so"
+++#define SWS_MAX_FILTER_SIZE 256
+++#define ARCH_AARCH64 0
+++#define ARCH_ALPHA 0
+++#define ARCH_ARM 0
+++#define ARCH_AVR32 0
+++#define ARCH_AVR32_AP 0
+++#define ARCH_AVR32_UC 0
+++#define ARCH_BFIN 0
+++#define ARCH_IA64 0
+++#define ARCH_LOONGARCH 1
+++#define ARCH_LOONGARCH32 0
+++#define ARCH_LOONGARCH64 1
+++#define ARCH_M68K 0
+++#define ARCH_MIPS 0
+++#define ARCH_MIPS64 0
+++#define ARCH_PARISC 0
+++#define ARCH_PPC 0
+++#define ARCH_PPC64 0
+++#define ARCH_RISCV 0
+++#define ARCH_S390 0
+++#define ARCH_SH4 0
+++#define ARCH_SPARC 0
+++#define ARCH_SPARC64 0
+++#define ARCH_TILEGX 0
+++#define ARCH_TILEPRO 0
+++#define ARCH_X86 0
+++#define ARCH_X86_32 0
+++#define ARCH_X86_64 0
+++#define HAVE_ARMV5TE 0
+++#define HAVE_ARMV6 0
+++#define HAVE_ARMV6T2 0
+++#define HAVE_ARMV8 0
+++#define HAVE_DOTPROD 0
+++#define HAVE_I8MM 0
+++#define HAVE_NEON 0
+++#define HAVE_VFP 0
+++#define HAVE_VFPV3 0
+++#define HAVE_SETEND 0
+++#define HAVE_ALTIVEC 0
+++#define HAVE_DCBZL 0
+++#define HAVE_LDBRX 0
+++#define HAVE_POWER8 0
+++#define HAVE_PPC4XX 0
+++#define HAVE_VSX 0
+++#define HAVE_RV 0
+++#define HAVE_RVV 0
+++#define HAVE_AESNI 0
+++#define HAVE_AMD3DNOW 0
+++#define HAVE_AMD3DNOWEXT 0
+++#define HAVE_AVX 0
+++#define HAVE_AVX2 0
+++#define HAVE_AVX512 0
+++#define HAVE_AVX512ICL 0
+++#define HAVE_FMA3 0
+++#define HAVE_FMA4 0
+++#define HAVE_MMX 0
+++#define HAVE_MMXEXT 0
+++#define HAVE_SSE 0
+++#define HAVE_SSE2 0
+++#define HAVE_SSE3 0
+++#define HAVE_SSE4 0
+++#define HAVE_SSE42 0
+++#define HAVE_SSSE3 0
+++#define HAVE_XOP 0
+++#define HAVE_CPUNOP 0
+++#define HAVE_I686 0
+++#define HAVE_MIPSFPU 0
+++#define HAVE_MIPS32R2 0
+++#define HAVE_MIPS32R5 0
+++#define HAVE_MIPS64R2 0
+++#define HAVE_MIPS32R6 0
+++#define HAVE_MIPS64R6 0
+++#define HAVE_MIPSDSP 0
+++#define HAVE_MIPSDSPR2 0
+++#define HAVE_MSA 0
+++#define HAVE_LOONGSON2 0
+++#define HAVE_LOONGSON3 0
+++#define HAVE_MMI 0
+++#define HAVE_LSX 0
+++#define HAVE_LASX 0
+++#define HAVE_ARMV5TE_EXTERNAL 0
+++#define HAVE_ARMV6_EXTERNAL 0
+++#define HAVE_ARMV6T2_EXTERNAL 0
+++#define HAVE_ARMV8_EXTERNAL 0
+++#define HAVE_DOTPROD_EXTERNAL 0
+++#define HAVE_I8MM_EXTERNAL 0
+++#define HAVE_NEON_EXTERNAL 0
+++#define HAVE_VFP_EXTERNAL 0
+++#define HAVE_VFPV3_EXTERNAL 0
+++#define HAVE_SETEND_EXTERNAL 0
+++#define HAVE_ALTIVEC_EXTERNAL 0
+++#define HAVE_DCBZL_EXTERNAL 0
+++#define HAVE_LDBRX_EXTERNAL 0
+++#define HAVE_POWER8_EXTERNAL 0
+++#define HAVE_PPC4XX_EXTERNAL 0
+++#define HAVE_VSX_EXTERNAL 0
+++#define HAVE_RV_EXTERNAL 0
+++#define HAVE_RVV_EXTERNAL 0
+++#define HAVE_AESNI_EXTERNAL 0
+++#define HAVE_AMD3DNOW_EXTERNAL 0
+++#define HAVE_AMD3DNOWEXT_EXTERNAL 0
+++#define HAVE_AVX_EXTERNAL 0
+++#define HAVE_AVX2_EXTERNAL 0
+++#define HAVE_AVX512_EXTERNAL 0
+++#define HAVE_AVX512ICL_EXTERNAL 0
+++#define HAVE_FMA3_EXTERNAL 0
+++#define HAVE_FMA4_EXTERNAL 0
+++#define HAVE_MMX_EXTERNAL 0
+++#define HAVE_MMXEXT_EXTERNAL 0
+++#define HAVE_SSE_EXTERNAL 0
+++#define HAVE_SSE2_EXTERNAL 0
+++#define HAVE_SSE3_EXTERNAL 0
+++#define HAVE_SSE4_EXTERNAL 0
+++#define HAVE_SSE42_EXTERNAL 0
+++#define HAVE_SSSE3_EXTERNAL 0
+++#define HAVE_XOP_EXTERNAL 0
+++#define HAVE_CPUNOP_EXTERNAL 0
+++#define HAVE_I686_EXTERNAL 0
+++#define HAVE_MIPSFPU_EXTERNAL 0
+++#define HAVE_MIPS32R2_EXTERNAL 0
+++#define HAVE_MIPS32R5_EXTERNAL 0
+++#define HAVE_MIPS64R2_EXTERNAL 0
+++#define HAVE_MIPS32R6_EXTERNAL 0
+++#define HAVE_MIPS64R6_EXTERNAL 0
+++#define HAVE_MIPSDSP_EXTERNAL 0
+++#define HAVE_MIPSDSPR2_EXTERNAL 0
+++#define HAVE_MSA_EXTERNAL 0
+++#define HAVE_LOONGSON2_EXTERNAL 0
+++#define HAVE_LOONGSON3_EXTERNAL 0
+++#define HAVE_MMI_EXTERNAL 0
+++#define HAVE_LSX_EXTERNAL 0
+++#define HAVE_LASX_EXTERNAL 0
+++#define HAVE_ARMV5TE_INLINE 0
+++#define HAVE_ARMV6_INLINE 0
+++#define HAVE_ARMV6T2_INLINE 0
+++#define HAVE_ARMV8_INLINE 0
+++#define HAVE_DOTPROD_INLINE 0
+++#define HAVE_I8MM_INLINE 0
+++#define HAVE_NEON_INLINE 0
+++#define HAVE_VFP_INLINE 0
+++#define HAVE_VFPV3_INLINE 0
+++#define HAVE_SETEND_INLINE 0
+++#define HAVE_ALTIVEC_INLINE 0
+++#define HAVE_DCBZL_INLINE 0
+++#define HAVE_LDBRX_INLINE 0
+++#define HAVE_POWER8_INLINE 0
+++#define HAVE_PPC4XX_INLINE 0
+++#define HAVE_VSX_INLINE 0
+++#define HAVE_RV_INLINE 0
+++#define HAVE_RVV_INLINE 0
+++#define HAVE_AESNI_INLINE 0
+++#define HAVE_AMD3DNOW_INLINE 0
+++#define HAVE_AMD3DNOWEXT_INLINE 0
+++#define HAVE_AVX_INLINE 0
+++#define HAVE_AVX2_INLINE 0
+++#define HAVE_AVX512_INLINE 0
+++#define HAVE_AVX512ICL_INLINE 0
+++#define HAVE_FMA3_INLINE 0
+++#define HAVE_FMA4_INLINE 0
+++#define HAVE_MMX_INLINE 0
+++#define HAVE_MMXEXT_INLINE 0
+++#define HAVE_SSE_INLINE 0
+++#define HAVE_SSE2_INLINE 0
+++#define HAVE_SSE3_INLINE 0
+++#define HAVE_SSE4_INLINE 0
+++#define HAVE_SSE42_INLINE 0
+++#define HAVE_SSSE3_INLINE 0
+++#define HAVE_XOP_INLINE 0
+++#define HAVE_CPUNOP_INLINE 0
+++#define HAVE_I686_INLINE 0
+++#define HAVE_MIPSFPU_INLINE 0
+++#define HAVE_MIPS32R2_INLINE 0
+++#define HAVE_MIPS32R5_INLINE 0
+++#define HAVE_MIPS64R2_INLINE 0
+++#define HAVE_MIPS32R6_INLINE 0
+++#define HAVE_MIPS64R6_INLINE 0
+++#define HAVE_MIPSDSP_INLINE 0
+++#define HAVE_MIPSDSPR2_INLINE 0
+++#define HAVE_MSA_INLINE 0
+++#define HAVE_LOONGSON2_INLINE 0
+++#define HAVE_LOONGSON3_INLINE 0
+++#define HAVE_MMI_INLINE 0
+++#define HAVE_LSX_INLINE 0
+++#define HAVE_LASX_INLINE 0
+++#define HAVE_ALIGNED_STACK 0
+++#define HAVE_FAST_64BIT 1
+++#define HAVE_FAST_CLZ 1
+++#define HAVE_FAST_CMOV 0
+++#define HAVE_FAST_FLOAT16 0
+++#define HAVE_LOCAL_ALIGNED 1
+++#define HAVE_SIMD_ALIGN_16 0
+++#define HAVE_SIMD_ALIGN_32 1
+++#define HAVE_SIMD_ALIGN_64 0
+++#define HAVE_ATOMIC_CAS_PTR 0
+++#define HAVE_MACHINE_RW_BARRIER 0
+++#define HAVE_MEMORYBARRIER 0
+++#define HAVE_MM_EMPTY 0
+++#define HAVE_RDTSC 0
+++#define HAVE_SEM_TIMEDWAIT 1
+++#define HAVE_SYNC_VAL_COMPARE_AND_SWAP 1
+++#define HAVE_INLINE_ASM 1
+++#define HAVE_SYMVER 0
+++#define HAVE_X86ASM 0
+++#define HAVE_BIGENDIAN 0
+++#define HAVE_FAST_UNALIGNED 1
+++#define HAVE_ARPA_INET_H 0
+++#define HAVE_ASM_TYPES_H 1
+++#define HAVE_CDIO_PARANOIA_H 0
+++#define HAVE_CDIO_PARANOIA_PARANOIA_H 0
+++#define HAVE_CUDA_H 0
+++#define HAVE_DISPATCH_DISPATCH_H 0
+++#define HAVE_DEV_BKTR_IOCTL_BT848_H 0
+++#define HAVE_DEV_BKTR_IOCTL_METEOR_H 0
+++#define HAVE_DEV_IC_BT8XX_H 0
+++#define HAVE_DEV_VIDEO_BKTR_IOCTL_BT848_H 0
+++#define HAVE_DEV_VIDEO_METEOR_IOCTL_METEOR_H 0
+++#define HAVE_DIRECT_H 0
+++#define HAVE_DIRENT_H 1
+++#define HAVE_DXGIDEBUG_H 0
+++#define HAVE_DXVA_H 0
+++#define HAVE_ES2_GL_H 0
+++#define HAVE_GSM_H 0
+++#define HAVE_IO_H 0
+++#define HAVE_LINUX_DMA_BUF_H 0
+++#define HAVE_LINUX_PERF_EVENT_H 1
+++#define HAVE_MACHINE_IOCTL_BT848_H 0
+++#define HAVE_MACHINE_IOCTL_METEOR_H 0
+++#define HAVE_MALLOC_H 1
+++#define HAVE_OPENCV2_CORE_CORE_C_H 0
+++#define HAVE_OPENGL_GL3_H 0
+++#define HAVE_POLL_H 1
+++#define HAVE_PTHREAD_NP_H 0
+++#define HAVE_SYS_PARAM_H 1
+++#define HAVE_SYS_RESOURCE_H 1
+++#define HAVE_SYS_SELECT_H 1
+++#define HAVE_SYS_SOUNDCARD_H 1
+++#define HAVE_SYS_TIME_H 1
+++#define HAVE_SYS_UN_H 1
+++#define HAVE_SYS_VIDEOIO_H 0
+++#define HAVE_TERMIOS_H 1
+++#define HAVE_UDPLITE_H 0
+++#define HAVE_UNISTD_H 1
+++#define HAVE_VALGRIND_VALGRIND_H 0
+++#define HAVE_WINDOWS_H 0
+++#define HAVE_WINSOCK2_H 0
+++#define HAVE_INTRINSICS_NEON 0
+++#define HAVE_ATANF 1
+++#define HAVE_ATAN2F 1
+++#define HAVE_CBRT 1
+++#define HAVE_CBRTF 1
+++#define HAVE_COPYSIGN 1
+++#define HAVE_COSF 1
+++#define HAVE_ERF 1
+++#define HAVE_EXP2 1
+++#define HAVE_EXP2F 1
+++#define HAVE_EXPF 1
+++#define HAVE_HYPOT 1
+++#define HAVE_ISFINITE 1
+++#define HAVE_ISINF 1
+++#define HAVE_ISNAN 1
+++#define HAVE_LDEXPF 1
+++#define HAVE_LLRINT 1
+++#define HAVE_LLRINTF 1
+++#define HAVE_LOG2 1
+++#define HAVE_LOG2F 1
+++#define HAVE_LOG10F 1
+++#define HAVE_LRINT 1
+++#define HAVE_LRINTF 1
+++#define HAVE_POWF 1
+++#define HAVE_RINT 1
+++#define HAVE_ROUND 1
+++#define HAVE_ROUNDF 1
+++#define HAVE_SINF 1
+++#define HAVE_TRUNC 1
+++#define HAVE_TRUNCF 1
+++#define HAVE_DOS_PATHS 0
+++#define HAVE_LIBC_MSVCRT 0
+++#define HAVE_MMAL_PARAMETER_VIDEO_MAX_NUM_CALLBACKS 0
+++#define HAVE_SECTION_DATA_REL_RO 1
+++#define HAVE_THREADS 1
+++#define HAVE_UWP 0
+++#define HAVE_WINRT 0
+++#define HAVE_ACCESS 1
+++#define HAVE_ALIGNED_MALLOC 0
+++#define HAVE_ARC4RANDOM_BUF 0
+++#define HAVE_CLOCK_GETTIME 1
+++#define HAVE_CLOSESOCKET 0
+++#define HAVE_COMMANDLINETOARGVW 0
+++#define HAVE_FCNTL 1
+++#define HAVE_GETADDRINFO 0
+++#define HAVE_GETAUXVAL 1
+++#define HAVE_GETENV 1
+++#define HAVE_GETHRTIME 0
+++#define HAVE_GETOPT 1
+++#define HAVE_GETMODULEHANDLE 0
+++#define HAVE_GETPROCESSAFFINITYMASK 0
+++#define HAVE_GETPROCESSMEMORYINFO 0
+++#define HAVE_GETPROCESSTIMES 0
+++#define HAVE_GETRUSAGE 1
+++#define HAVE_GETSTDHANDLE 0
+++#define HAVE_GETSYSTEMTIMEASFILETIME 0
+++#define HAVE_GETTIMEOFDAY 1
+++#define HAVE_GLOB 1
+++#define HAVE_GLXGETPROCADDRESS 0
+++#define HAVE_GMTIME_R 1
+++#define HAVE_INET_ATON 0
+++#define HAVE_ISATTY 1
+++#define HAVE_KBHIT 0
+++#define HAVE_LOCALTIME_R 1
+++#define HAVE_LSTAT 1
+++#define HAVE_LZO1X_999_COMPRESS 0
+++#define HAVE_MACH_ABSOLUTE_TIME 0
+++#define HAVE_MAPVIEWOFFILE 0
+++#define HAVE_MEMALIGN 1
+++#define HAVE_MKSTEMP 1
+++#define HAVE_MMAP 1
+++#define HAVE_MPROTECT 1
+++#define HAVE_NANOSLEEP 1
+++#define HAVE_PEEKNAMEDPIPE 0
+++#define HAVE_POSIX_MEMALIGN 1
+++#define HAVE_PRCTL 1
+++#define HAVE_PTHREAD_CANCEL 1
+++#define HAVE_PTHREAD_SET_NAME_NP 0
+++#define HAVE_PTHREAD_SETNAME_NP 0
+++#define HAVE_SCHED_GETAFFINITY 1
+++#define HAVE_SECITEMIMPORT 0
+++#define HAVE_SETCONSOLETEXTATTRIBUTE 0
+++#define HAVE_SETCONSOLECTRLHANDLER 0
+++#define HAVE_SETDLLDIRECTORY 0
+++#define HAVE_SETMODE 0
+++#define HAVE_SETRLIMIT 1
+++#define HAVE_SLEEP 0
+++#define HAVE_STRERROR_R 1
+++#define HAVE_SYSCONF 1
+++#define HAVE_SYSCTL 0
+++#define HAVE_SYSCTLBYNAME 0
+++#define HAVE_USLEEP 1
+++#define HAVE_UTGETOSTYPEFROMSTRING 0
+++#define HAVE_VIRTUALALLOC 0
+++#define HAVE_WGLGETPROCADDRESS 0
+++#define HAVE_BCRYPT 0
+++#define HAVE_VAAPI_DRM 0
+++#define HAVE_VAAPI_X11 0
+++#define HAVE_VAAPI_WIN32 0
+++#define HAVE_VDPAU_X11 0
+++#define HAVE_PTHREADS 1
+++#define HAVE_OS2THREADS 0
+++#define HAVE_W32THREADS 0
+++#define HAVE_AS_ARCH_DIRECTIVE 0
+++#define HAVE_AS_ARCHEXT_DOTPROD_DIRECTIVE 0
+++#define HAVE_AS_ARCHEXT_I8MM_DIRECTIVE 0
+++#define HAVE_AS_DN_DIRECTIVE 0
+++#define HAVE_AS_FPU_DIRECTIVE 0
+++#define HAVE_AS_FUNC 0
+++#define HAVE_AS_OBJECT_ARCH 0
+++#define HAVE_ASM_MOD_Q 0
+++#define HAVE_BLOCKS_EXTENSION 0
+++#define HAVE_EBP_AVAILABLE 0
+++#define HAVE_EBX_AVAILABLE 0
+++#define HAVE_GNU_AS 0
+++#define HAVE_GNU_WINDRES 0
+++#define HAVE_IBM_ASM 0
+++#define HAVE_INLINE_ASM_DIRECT_SYMBOL_REFS 0
+++#define HAVE_INLINE_ASM_LABELS 1
+++#define HAVE_INLINE_ASM_NONLOCAL_LABELS 1
+++#define HAVE_PRAGMA_DEPRECATED 1
+++#define HAVE_RSYNC_CONTIMEOUT 1
+++#define HAVE_SYMVER_ASM_LABEL 1
+++#define HAVE_SYMVER_GNU_ASM 1
+++#define HAVE_VFP_ARGS 0
+++#define HAVE_XFORM_ASM 0
+++#define HAVE_XMM_CLOBBERS 0
+++#define HAVE_DPI_AWARENESS_CONTEXT 0
+++#define HAVE_IDXGIOUTPUT5 0
+++#define HAVE_KCMVIDEOCODECTYPE_HEVC 0
+++#define HAVE_KCMVIDEOCODECTYPE_HEVCWITHALPHA 0
+++#define HAVE_KCMVIDEOCODECTYPE_VP9 0
+++#define HAVE_KCVPIXELFORMATTYPE_420YPCBCR10BIPLANARVIDEORANGE 0
+++#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR8BIPLANARVIDEORANGE 0
+++#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR10BIPLANARVIDEORANGE 0
+++#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR16BIPLANARVIDEORANGE 0
+++#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR8BIPLANARVIDEORANGE 0
+++#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR10BIPLANARVIDEORANGE 0
+++#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR16BIPLANARVIDEORANGE 0
+++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_2084_PQ 0
+++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2100_HLG 0
+++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_LINEAR 0
+++#define HAVE_KCVIMAGEBUFFERYCBCRMATRIX_ITU_R_2020 0
+++#define HAVE_KCVIMAGEBUFFERCOLORPRIMARIES_ITU_R_2020 0
+++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2020 0
+++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_428_1 0
+++#define HAVE_SOCKLEN_T 0
+++#define HAVE_STRUCT_ADDRINFO 0
+++#define HAVE_STRUCT_GROUP_SOURCE_REQ 0
+++#define HAVE_STRUCT_IP_MREQ_SOURCE 0
+++#define HAVE_STRUCT_IPV6_MREQ 0
+++#define HAVE_STRUCT_MSGHDR_MSG_FLAGS 0
+++#define HAVE_STRUCT_POLLFD 0
+++#define HAVE_STRUCT_RUSAGE_RU_MAXRSS 1
+++#define HAVE_STRUCT_SCTP_EVENT_SUBSCRIBE 0
+++#define HAVE_STRUCT_SOCKADDR_IN6 0
+++#define HAVE_STRUCT_SOCKADDR_SA_LEN 0
+++#define HAVE_STRUCT_SOCKADDR_STORAGE 0
+++#define HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC 1
+++#define HAVE_STRUCT_V4L2_FRMIVALENUM_DISCRETE 0
+++#define HAVE_GZIP 1
+++#define HAVE_LIBDRM_GETFB2 0
+++#define HAVE_MAKEINFO 1
+++#define HAVE_MAKEINFO_HTML 1
+++#define HAVE_OPENCL_D3D11 0
+++#define HAVE_OPENCL_DRM_ARM 0
+++#define HAVE_OPENCL_DRM_BEIGNET 0
+++#define HAVE_OPENCL_DXVA2 0
+++#define HAVE_OPENCL_VAAPI_BEIGNET 0
+++#define HAVE_OPENCL_VAAPI_INTEL_MEDIA 0
+++#define HAVE_PERL 1
+++#define HAVE_POD2MAN 1
+++#define HAVE_TEXI2HTML 0
+++#define HAVE_XMLLINT 1
+++#define HAVE_ZLIB_GZIP 0
+++#define HAVE_OPENVINO2 0
+++#define CONFIG_DOC 0
+++#define CONFIG_HTMLPAGES 0
+++#define CONFIG_MANPAGES 0
+++#define CONFIG_PODPAGES 0
+++#define CONFIG_TXTPAGES 0
+++#define CONFIG_AVIO_HTTP_SERVE_FILES_EXAMPLE 1
+++#define CONFIG_AVIO_LIST_DIR_EXAMPLE 1
+++#define CONFIG_AVIO_READ_CALLBACK_EXAMPLE 1
+++#define CONFIG_DECODE_AUDIO_EXAMPLE 1
+++#define CONFIG_DECODE_FILTER_AUDIO_EXAMPLE 0
+++#define CONFIG_DECODE_FILTER_VIDEO_EXAMPLE 0
+++#define CONFIG_DECODE_VIDEO_EXAMPLE 1
+++#define CONFIG_DEMUX_DECODE_EXAMPLE 1
+++#define CONFIG_ENCODE_AUDIO_EXAMPLE 1
+++#define CONFIG_ENCODE_VIDEO_EXAMPLE 1
+++#define CONFIG_EXTRACT_MVS_EXAMPLE 1
+++#define CONFIG_FILTER_AUDIO_EXAMPLE 0
+++#define CONFIG_HW_DECODE_EXAMPLE 1
+++#define CONFIG_MUX_EXAMPLE 0
+++#define CONFIG_QSV_DECODE_EXAMPLE 0
+++#define CONFIG_REMUX_EXAMPLE 1
+++#define CONFIG_RESAMPLE_AUDIO_EXAMPLE 0
+++#define CONFIG_SCALE_VIDEO_EXAMPLE 0
+++#define CONFIG_SHOW_METADATA_EXAMPLE 1
+++#define CONFIG_TRANSCODE_AAC_EXAMPLE 0
+++#define CONFIG_TRANSCODE_EXAMPLE 0
+++#define CONFIG_VAAPI_ENCODE_EXAMPLE 0
+++#define CONFIG_VAAPI_TRANSCODE_EXAMPLE 0
+++#define CONFIG_QSV_TRANSCODE_EXAMPLE 0
+++#define CONFIG_AVISYNTH 0
+++#define CONFIG_FREI0R 0
+++#define CONFIG_LIBCDIO 0
+++#define CONFIG_LIBDAVS2 0
+++#define CONFIG_LIBRUBBERBAND 0
+++#define CONFIG_LIBVIDSTAB 0
+++#define CONFIG_LIBX264 0
+++#define CONFIG_LIBX265 0
+++#define CONFIG_LIBXAVS 0
+++#define CONFIG_LIBXAVS2 0
+++#define CONFIG_LIBXVID 0
+++#define CONFIG_DECKLINK 0
+++#define CONFIG_LIBFDK_AAC 0
+++#define CONFIG_LIBTLS 0
+++#define CONFIG_GMP 0
+++#define CONFIG_LIBARIBB24 0
+++#define CONFIG_LIBLENSFUN 0
+++#define CONFIG_LIBOPENCORE_AMRNB 0
+++#define CONFIG_LIBOPENCORE_AMRWB 0
+++#define CONFIG_LIBVO_AMRWBENC 0
+++#define CONFIG_MBEDTLS 0
+++#define CONFIG_RKMPP 0
+++#define CONFIG_LIBSMBCLIENT 0
+++#define CONFIG_CHROMAPRINT 0
+++#define CONFIG_GCRYPT 0
+++#define CONFIG_GNUTLS 0
+++#define CONFIG_JNI 0
+++#define CONFIG_LADSPA 0
+++#define CONFIG_LCMS2 0
+++#define CONFIG_LIBAOM 0
+++#define CONFIG_LIBARIBCAPTION 0
+++#define CONFIG_LIBASS 0
+++#define CONFIG_LIBBLURAY 0
+++#define CONFIG_LIBBS2B 0
+++#define CONFIG_LIBCACA 0
+++#define CONFIG_LIBCELT 0
+++#define CONFIG_LIBCODEC2 0
+++#define CONFIG_LIBDAV1D 0
+++#define CONFIG_LIBDC1394 0
+++#define CONFIG_LIBFLITE 0
+++#define CONFIG_LIBFONTCONFIG 0
+++#define CONFIG_LIBFREETYPE 0
+++#define CONFIG_LIBFRIBIDI 0
+++#define CONFIG_LIBHARFBUZZ 0
+++#define CONFIG_LIBGLSLANG 0
+++#define CONFIG_LIBGME 0
+++#define CONFIG_LIBGSM 0
+++#define CONFIG_LIBIEC61883 0
+++#define CONFIG_LIBILBC 0
+++#define CONFIG_LIBJACK 0
+++#define CONFIG_LIBJXL 0
+++#define CONFIG_LIBKLVANC 0
+++#define CONFIG_LIBKVAZAAR 0
+++#define CONFIG_LIBMODPLUG 0
+++#define CONFIG_LIBMP3LAME 0
+++#define CONFIG_LIBMYSOFA 0
+++#define CONFIG_LIBOPENCV 0
+++#define CONFIG_LIBOPENH264 0
+++#define CONFIG_LIBOPENJPEG 0
+++#define CONFIG_LIBOPENMPT 0
+++#define CONFIG_LIBOPENVINO 0
+++#define CONFIG_LIBOPUS 1
+++#define CONFIG_LIBPLACEBO 0
+++#define CONFIG_LIBPULSE 0
+++#define CONFIG_LIBQRENCODE 0
+++#define CONFIG_LIBQUIRC 0
+++#define CONFIG_LIBRABBITMQ 0
+++#define CONFIG_LIBRAV1E 0
+++#define CONFIG_LIBRIST 0
+++#define CONFIG_LIBRSVG 0
+++#define CONFIG_LIBRTMP 0
+++#define CONFIG_LIBSHADERC 0
+++#define CONFIG_LIBSHINE 0
+++#define CONFIG_LIBSMBCLIENT 0
+++#define CONFIG_LIBSNAPPY 0
+++#define CONFIG_LIBSOXR 0
+++#define CONFIG_LIBSPEEX 0
+++#define CONFIG_LIBSRT 0
+++#define CONFIG_LIBSSH 0
+++#define CONFIG_LIBSVTAV1 0
+++#define CONFIG_LIBTENSORFLOW 0
+++#define CONFIG_LIBTESSERACT 0
+++#define CONFIG_LIBTHEORA 0
+++#define CONFIG_LIBTWOLAME 0
+++#define CONFIG_LIBUAVS3D 0
+++#define CONFIG_LIBV4L2 0
+++#define CONFIG_LIBVMAF 0
+++#define CONFIG_LIBVORBIS 0
+++#define CONFIG_LIBVPX 0
+++#define CONFIG_LIBWEBP 0
+++#define CONFIG_LIBXEVD 0
+++#define CONFIG_LIBXEVE 0
+++#define CONFIG_LIBXML2 0
+++#define CONFIG_LIBZIMG 0
+++#define CONFIG_LIBZMQ 0
+++#define CONFIG_LIBZVBI 0
+++#define CONFIG_LV2 0
+++#define CONFIG_MEDIACODEC 0
+++#define CONFIG_OPENAL 0
+++#define CONFIG_OPENGL 0
+++#define CONFIG_OPENSSL 0
+++#define CONFIG_POCKETSPHINX 0
+++#define CONFIG_VAPOURSYNTH 0
+++#define CONFIG_ALSA 0
+++#define CONFIG_APPKIT 0
+++#define CONFIG_AVFOUNDATION 0
+++#define CONFIG_BZLIB 0
+++#define CONFIG_COREIMAGE 0
+++#define CONFIG_ICONV 0
+++#define CONFIG_LIBXCB 0
+++#define CONFIG_LIBXCB_SHM 0
+++#define CONFIG_LIBXCB_SHAPE 0
+++#define CONFIG_LIBXCB_XFIXES 0
+++#define CONFIG_LZMA 0
+++#define CONFIG_MEDIAFOUNDATION 0
+++#define CONFIG_METAL 0
+++#define CONFIG_SCHANNEL 0
+++#define CONFIG_SDL2 0
+++#define CONFIG_SECURETRANSPORT 0
+++#define CONFIG_SNDIO 0
+++#define CONFIG_XLIB 0
+++#define CONFIG_ZLIB 0
+++#define CONFIG_CUDA_NVCC 0
+++#define CONFIG_CUDA_SDK 0
+++#define CONFIG_LIBNPP 0
+++#define CONFIG_LIBMFX 0
+++#define CONFIG_LIBVPL 0
+++#define CONFIG_MMAL 0
+++#define CONFIG_OMX 0
+++#define CONFIG_OPENCL 0
+++#define CONFIG_AMF 0
+++#define CONFIG_AUDIOTOOLBOX 0
+++#define CONFIG_CRYSTALHD 0
+++#define CONFIG_CUDA 0
+++#define CONFIG_CUDA_LLVM 0
+++#define CONFIG_CUVID 0
+++#define CONFIG_D3D11VA 0
+++#define CONFIG_D3D12VA 0
+++#define CONFIG_DXVA2 0
+++#define CONFIG_FFNVCODEC 0
+++#define CONFIG_LIBDRM 0
+++#define CONFIG_NVDEC 0
+++#define CONFIG_NVENC 0
+++#define CONFIG_VAAPI 0
+++#define CONFIG_VDPAU 0
+++#define CONFIG_VIDEOTOOLBOX 0
+++#define CONFIG_VULKAN 0
+++#define CONFIG_V4L2_M2M 0
+++#define CONFIG_FTRAPV 0
+++#define CONFIG_GRAY 0
+++#define CONFIG_HARDCODED_TABLES 0
+++#define CONFIG_OMX_RPI 0
+++#define CONFIG_RUNTIME_CPUDETECT 1
+++#define CONFIG_SAFE_BITSTREAM_READER 1
+++#define CONFIG_SHARED 0
+++#define CONFIG_SMALL 0
+++#define CONFIG_STATIC 1
+++#define CONFIG_SWSCALE_ALPHA 1
+++#define CONFIG_GPL 0
+++#define CONFIG_NONFREE 0
+++#define CONFIG_VERSION3 0
+++#define CONFIG_AVDEVICE 0
+++#define CONFIG_AVFILTER 0
+++#define CONFIG_SWSCALE 0
+++#define CONFIG_POSTPROC 0
+++#define CONFIG_AVFORMAT 1
+++#define CONFIG_AVCODEC 1
+++#define CONFIG_SWRESAMPLE 0
+++#define CONFIG_AVUTIL 1
+++#define CONFIG_FFPLAY 0
+++#define CONFIG_FFPROBE 0
+++#define CONFIG_FFMPEG 0
+++#define CONFIG_DWT 0
+++#define CONFIG_ERROR_RESILIENCE 0
+++#define CONFIG_FAAN 0
+++#define CONFIG_FAST_UNALIGNED 1
+++#define CONFIG_LSP 0
+++#define CONFIG_PIXELUTILS 0
+++#define CONFIG_NETWORK 0
+++#define CONFIG_AUTODETECT 0
+++#define CONFIG_FONTCONFIG 0
+++#define CONFIG_LARGE_TESTS 1
+++#define CONFIG_LINUX_PERF 0
+++#define CONFIG_MACOS_KPERF 0
+++#define CONFIG_MEMORY_POISONING 0
+++#define CONFIG_NEON_CLOBBER_TEST 0
+++#define CONFIG_OSSFUZZ 0
+++#define CONFIG_PIC 1
+++#define CONFIG_PTX_COMPRESSION 0
+++#define CONFIG_THUMB 0
+++#define CONFIG_VALGRIND_BACKTRACE 0
+++#define CONFIG_XMM_CLOBBER_TEST 0
+++#define CONFIG_BSFS 0
+++#define CONFIG_DECODERS 1
+++#define CONFIG_ENCODERS 0
+++#define CONFIG_HWACCELS 0
+++#define CONFIG_PARSERS 1
+++#define CONFIG_INDEVS 0
+++#define CONFIG_OUTDEVS 0
+++#define CONFIG_FILTERS 0
+++#define CONFIG_DEMUXERS 1
+++#define CONFIG_MUXERS 0
+++#define CONFIG_PROTOCOLS 0
+++#define CONFIG_AANDCTTABLES 0
+++#define CONFIG_AC3DSP 0
+++#define CONFIG_ADTS_HEADER 1
+++#define CONFIG_ATSC_A53 1
+++#define CONFIG_AUDIO_FRAME_QUEUE 0
+++#define CONFIG_AUDIODSP 0
+++#define CONFIG_BLOCKDSP 0
+++#define CONFIG_BSWAPDSP 0
+++#define CONFIG_CABAC 1
+++#define CONFIG_CBS 0
+++#define CONFIG_CBS_AV1 0
+++#define CONFIG_CBS_H264 0
+++#define CONFIG_CBS_H265 0
+++#define CONFIG_CBS_H266 0
+++#define CONFIG_CBS_JPEG 0
+++#define CONFIG_CBS_MPEG2 0
+++#define CONFIG_CBS_VP8 0
+++#define CONFIG_CBS_VP9 0
+++#define CONFIG_DEFLATE_WRAPPER 0
+++#define CONFIG_DIRAC_PARSE 1
+++#define CONFIG_DNN 0
+++#define CONFIG_DOVI_RPU 0
+++#define CONFIG_DVPROFILE 0
+++#define CONFIG_EVCPARSE 0
+++#define CONFIG_EXIF 0
+++#define CONFIG_FAANDCT 0
+++#define CONFIG_FAANIDCT 0
+++#define CONFIG_FDCTDSP 0
+++#define CONFIG_FMTCONVERT 0
+++#define CONFIG_FRAME_THREAD_ENCODER 0
+++#define CONFIG_G722DSP 0
+++#define CONFIG_GOLOMB 1
+++#define CONFIG_GPLV3 0
+++#define CONFIG_H263DSP 0
+++#define CONFIG_H264CHROMA 1
+++#define CONFIG_H264DSP 1
+++#define CONFIG_H264PARSE 1
+++#define CONFIG_H264PRED 1
+++#define CONFIG_H264QPEL 1
+++#define CONFIG_H264_SEI 1
+++#define CONFIG_HEVCPARSE 0
+++#define CONFIG_HEVC_SEI 0
+++#define CONFIG_HPELDSP 0
+++#define CONFIG_HUFFMAN 0
+++#define CONFIG_HUFFYUVDSP 0
+++#define CONFIG_HUFFYUVENCDSP 0
+++#define CONFIG_IAMFDEC 0
+++#define CONFIG_IAMFENC 0
+++#define CONFIG_IDCTDSP 0
+++#define CONFIG_IIRFILTER 0
+++#define CONFIG_INFLATE_WRAPPER 0
+++#define CONFIG_INTRAX8 0
+++#define CONFIG_ISO_MEDIA 1
+++#define CONFIG_IVIDSP 0
+++#define CONFIG_JPEGTABLES 0
+++#define CONFIG_LGPLV3 0
+++#define CONFIG_LIBX262 0
+++#define CONFIG_LLAUDDSP 0
+++#define CONFIG_LLVIDDSP 0
+++#define CONFIG_LLVIDENCDSP 0
+++#define CONFIG_LPC 0
+++#define CONFIG_LZF 0
+++#define CONFIG_ME_CMP 0
+++#define CONFIG_MPEG_ER 0
+++#define CONFIG_MPEGAUDIO 1
+++#define CONFIG_MPEGAUDIODSP 1
+++#define CONFIG_MPEGAUDIOHEADER 1
+++#define CONFIG_MPEG4AUDIO 1
+++#define CONFIG_MPEGVIDEO 0
+++#define CONFIG_MPEGVIDEODEC 0
+++#define CONFIG_MPEGVIDEOENC 0
+++#define CONFIG_MSMPEG4DEC 0
+++#define CONFIG_MSMPEG4ENC 0
+++#define CONFIG_MSS34DSP 0
+++#define CONFIG_PIXBLOCKDSP 0
+++#define CONFIG_QPELDSP 0
+++#define CONFIG_QSV 0
+++#define CONFIG_QSVDEC 0
+++#define CONFIG_QSVENC 0
+++#define CONFIG_QSVVPP 0
+++#define CONFIG_RANGECODER 0
+++#define CONFIG_RIFFDEC 1
+++#define CONFIG_RIFFENC 0
+++#define CONFIG_RTPDEC 0
+++#define CONFIG_RTPENC_CHAIN 0
+++#define CONFIG_RV34DSP 0
+++#define CONFIG_SCENE_SAD 0
+++#define CONFIG_SINEWIN 1
+++#define CONFIG_SNAPPY 0
+++#define CONFIG_SRTP 0
+++#define CONFIG_STARTCODE 1
+++#define CONFIG_TEXTUREDSP 0
+++#define CONFIG_TEXTUREDSPENC 0
+++#define CONFIG_TPELDSP 0
+++#define CONFIG_VAAPI_1 0
+++#define CONFIG_VAAPI_ENCODE 0
+++#define CONFIG_VC1DSP 0
+++#define CONFIG_VIDEODSP 1
+++#define CONFIG_VP3DSP 0
+++#define CONFIG_VP56DSP 0
+++#define CONFIG_VP8DSP 0
+++#define CONFIG_WMA_FREQS 0
+++#define CONFIG_WMV2DSP 0
+++#endif /* FFMPEG_CONFIG_H */
++diff --git a/chromium/config/Chrome/linux/loong64/config_components.h b/chromium/config/Chrome/linux/loong64/config_components.h
++new file mode 100644
++index 0000000000000000000000000000000000000000..78ba358a2718ac4bf6e7171cf036b27fff68d909
++--- /dev/null
+++++ b/chromium/config/Chrome/linux/loong64/config_components.h
++@@ -0,0 +1,2218 @@
+++/* Automatically generated by configure - do not modify! */
+++#ifndef FFMPEG_CONFIG_COMPONENTS_H
+++#define FFMPEG_CONFIG_COMPONENTS_H
+++#define CONFIG_AAC_ADTSTOASC_BSF 0
+++#define CONFIG_AV1_FRAME_MERGE_BSF 0
+++#define CONFIG_AV1_FRAME_SPLIT_BSF 0
+++#define CONFIG_AV1_METADATA_BSF 0
+++#define CONFIG_CHOMP_BSF 0
+++#define CONFIG_DUMP_EXTRADATA_BSF 0
+++#define CONFIG_DCA_CORE_BSF 0
+++#define CONFIG_DTS2PTS_BSF 0
+++#define CONFIG_DV_ERROR_MARKER_BSF 0
+++#define CONFIG_EAC3_CORE_BSF 0
+++#define CONFIG_EXTRACT_EXTRADATA_BSF 0
+++#define CONFIG_FILTER_UNITS_BSF 0
+++#define CONFIG_H264_METADATA_BSF 0
+++#define CONFIG_H264_MP4TOANNEXB_BSF 0
+++#define CONFIG_H264_REDUNDANT_PPS_BSF 0
+++#define CONFIG_HAPQA_EXTRACT_BSF 0
+++#define CONFIG_HEVC_METADATA_BSF 0
+++#define CONFIG_HEVC_MP4TOANNEXB_BSF 0
+++#define CONFIG_IMX_DUMP_HEADER_BSF 0
+++#define CONFIG_MEDIA100_TO_MJPEGB_BSF 0
+++#define CONFIG_MJPEG2JPEG_BSF 0
+++#define CONFIG_MJPEGA_DUMP_HEADER_BSF 0
+++#define CONFIG_MP3_HEADER_DECOMPRESS_BSF 0
+++#define CONFIG_MPEG2_METADATA_BSF 0
+++#define CONFIG_MPEG4_UNPACK_BFRAMES_BSF 0
+++#define CONFIG_MOV2TEXTSUB_BSF 0
+++#define CONFIG_NOISE_BSF 0
+++#define CONFIG_NULL_BSF 0
+++#define CONFIG_OPUS_METADATA_BSF 0
+++#define CONFIG_PCM_RECHUNK_BSF 0
+++#define CONFIG_PGS_FRAME_MERGE_BSF 0
+++#define CONFIG_PRORES_METADATA_BSF 0
+++#define CONFIG_REMOVE_EXTRADATA_BSF 0
+++#define CONFIG_SETTS_BSF 0
+++#define CONFIG_SHOWINFO_BSF 0
+++#define CONFIG_TEXT2MOVSUB_BSF 0
+++#define CONFIG_TRACE_HEADERS_BSF 0
+++#define CONFIG_TRUEHD_CORE_BSF 0
+++#define CONFIG_VP9_METADATA_BSF 0
+++#define CONFIG_VP9_RAW_REORDER_BSF 0
+++#define CONFIG_VP9_SUPERFRAME_BSF 0
+++#define CONFIG_VP9_SUPERFRAME_SPLIT_BSF 0
+++#define CONFIG_VVC_METADATA_BSF 0
+++#define CONFIG_VVC_MP4TOANNEXB_BSF 0
+++#define CONFIG_EVC_FRAME_MERGE_BSF 0
+++#define CONFIG_AASC_DECODER 0
+++#define CONFIG_AIC_DECODER 0
+++#define CONFIG_ALIAS_PIX_DECODER 0
+++#define CONFIG_AGM_DECODER 0
+++#define CONFIG_AMV_DECODER 0
+++#define CONFIG_ANM_DECODER 0
+++#define CONFIG_ANSI_DECODER 0
+++#define CONFIG_APNG_DECODER 0
+++#define CONFIG_ARBC_DECODER 0
+++#define CONFIG_ARGO_DECODER 0
+++#define CONFIG_ASV1_DECODER 0
+++#define CONFIG_ASV2_DECODER 0
+++#define CONFIG_AURA_DECODER 0
+++#define CONFIG_AURA2_DECODER 0
+++#define CONFIG_AVRP_DECODER 0
+++#define CONFIG_AVRN_DECODER 0
+++#define CONFIG_AVS_DECODER 0
+++#define CONFIG_AVUI_DECODER 0
+++#define CONFIG_AYUV_DECODER 0
+++#define CONFIG_BETHSOFTVID_DECODER 0
+++#define CONFIG_BFI_DECODER 0
+++#define CONFIG_BINK_DECODER 0
+++#define CONFIG_BITPACKED_DECODER 0
+++#define CONFIG_BMP_DECODER 0
+++#define CONFIG_BMV_VIDEO_DECODER 0
+++#define CONFIG_BRENDER_PIX_DECODER 0
+++#define CONFIG_C93_DECODER 0
+++#define CONFIG_CAVS_DECODER 0
+++#define CONFIG_CDGRAPHICS_DECODER 0
+++#define CONFIG_CDTOONS_DECODER 0
+++#define CONFIG_CDXL_DECODER 0
+++#define CONFIG_CFHD_DECODER 0
+++#define CONFIG_CINEPAK_DECODER 0
+++#define CONFIG_CLEARVIDEO_DECODER 0
+++#define CONFIG_CLJR_DECODER 0
+++#define CONFIG_CLLC_DECODER 0
+++#define CONFIG_COMFORTNOISE_DECODER 0
+++#define CONFIG_CPIA_DECODER 0
+++#define CONFIG_CRI_DECODER 0
+++#define CONFIG_CSCD_DECODER 0
+++#define CONFIG_CYUV_DECODER 0
+++#define CONFIG_DDS_DECODER 0
+++#define CONFIG_DFA_DECODER 0
+++#define CONFIG_DIRAC_DECODER 0
+++#define CONFIG_DNXHD_DECODER 0
+++#define CONFIG_DPX_DECODER 0
+++#define CONFIG_DSICINVIDEO_DECODER 0
+++#define CONFIG_DVAUDIO_DECODER 0
+++#define CONFIG_DVVIDEO_DECODER 0
+++#define CONFIG_DXA_DECODER 0
+++#define CONFIG_DXTORY_DECODER 0
+++#define CONFIG_DXV_DECODER 0
+++#define CONFIG_EACMV_DECODER 0
+++#define CONFIG_EAMAD_DECODER 0
+++#define CONFIG_EATGQ_DECODER 0
+++#define CONFIG_EATGV_DECODER 0
+++#define CONFIG_EATQI_DECODER 0
+++#define CONFIG_EIGHTBPS_DECODER 0
+++#define CONFIG_EIGHTSVX_EXP_DECODER 0
+++#define CONFIG_EIGHTSVX_FIB_DECODER 0
+++#define CONFIG_ESCAPE124_DECODER 0
+++#define CONFIG_ESCAPE130_DECODER 0
+++#define CONFIG_EXR_DECODER 0
+++#define CONFIG_FFV1_DECODER 0
+++#define CONFIG_FFVHUFF_DECODER 0
+++#define CONFIG_FIC_DECODER 0
+++#define CONFIG_FITS_DECODER 0
+++#define CONFIG_FLASHSV_DECODER 0
+++#define CONFIG_FLASHSV2_DECODER 0
+++#define CONFIG_FLIC_DECODER 0
+++#define CONFIG_FLV_DECODER 0
+++#define CONFIG_FMVC_DECODER 0
+++#define CONFIG_FOURXM_DECODER 0
+++#define CONFIG_FRAPS_DECODER 0
+++#define CONFIG_FRWU_DECODER 0
+++#define CONFIG_G2M_DECODER 0
+++#define CONFIG_GDV_DECODER 0
+++#define CONFIG_GEM_DECODER 0
+++#define CONFIG_GIF_DECODER 0
+++#define CONFIG_H261_DECODER 0
+++#define CONFIG_H263_DECODER 0
+++#define CONFIG_H263I_DECODER 0
+++#define CONFIG_H263P_DECODER 0
+++#define CONFIG_H263_V4L2M2M_DECODER 0
+++#define CONFIG_H264_DECODER 1
+++#define CONFIG_H264_CRYSTALHD_DECODER 0
+++#define CONFIG_H264_V4L2M2M_DECODER 0
+++#define CONFIG_H264_MEDIACODEC_DECODER 0
+++#define CONFIG_H264_MMAL_DECODER 0
+++#define CONFIG_H264_QSV_DECODER 0
+++#define CONFIG_H264_RKMPP_DECODER 0
+++#define CONFIG_HAP_DECODER 0
+++#define CONFIG_HEVC_DECODER 0
+++#define CONFIG_HEVC_QSV_DECODER 0
+++#define CONFIG_HEVC_RKMPP_DECODER 0
+++#define CONFIG_HEVC_V4L2M2M_DECODER 0
+++#define CONFIG_HNM4_VIDEO_DECODER 0
+++#define CONFIG_HQ_HQA_DECODER 0
+++#define CONFIG_HQX_DECODER 0
+++#define CONFIG_HUFFYUV_DECODER 0
+++#define CONFIG_HYMT_DECODER 0
+++#define CONFIG_IDCIN_DECODER 0
+++#define CONFIG_IFF_ILBM_DECODER 0
+++#define CONFIG_IMM4_DECODER 0
+++#define CONFIG_IMM5_DECODER 0
+++#define CONFIG_INDEO2_DECODER 0
+++#define CONFIG_INDEO3_DECODER 0
+++#define CONFIG_INDEO4_DECODER 0
+++#define CONFIG_INDEO5_DECODER 0
+++#define CONFIG_INTERPLAY_VIDEO_DECODER 0
+++#define CONFIG_IPU_DECODER 0
+++#define CONFIG_JPEG2000_DECODER 0
+++#define CONFIG_JPEGLS_DECODER 0
+++#define CONFIG_JV_DECODER 0
+++#define CONFIG_KGV1_DECODER 0
+++#define CONFIG_KMVC_DECODER 0
+++#define CONFIG_LAGARITH_DECODER 0
+++#define CONFIG_LEAD_DECODER 0
+++#define CONFIG_LOCO_DECODER 0
+++#define CONFIG_LSCR_DECODER 0
+++#define CONFIG_M101_DECODER 0
+++#define CONFIG_MAGICYUV_DECODER 0
+++#define CONFIG_MDEC_DECODER 0
+++#define CONFIG_MEDIA100_DECODER 0
+++#define CONFIG_MIMIC_DECODER 0
+++#define CONFIG_MJPEG_DECODER 0
+++#define CONFIG_MJPEGB_DECODER 0
+++#define CONFIG_MMVIDEO_DECODER 0
+++#define CONFIG_MOBICLIP_DECODER 0
+++#define CONFIG_MOTIONPIXELS_DECODER 0
+++#define CONFIG_MPEG1VIDEO_DECODER 0
+++#define CONFIG_MPEG2VIDEO_DECODER 0
+++#define CONFIG_MPEG4_DECODER 0
+++#define CONFIG_MPEG4_CRYSTALHD_DECODER 0
+++#define CONFIG_MPEG4_V4L2M2M_DECODER 0
+++#define CONFIG_MPEG4_MMAL_DECODER 0
+++#define CONFIG_MPEGVIDEO_DECODER 0
+++#define CONFIG_MPEG1_V4L2M2M_DECODER 0
+++#define CONFIG_MPEG2_MMAL_DECODER 0
+++#define CONFIG_MPEG2_CRYSTALHD_DECODER 0
+++#define CONFIG_MPEG2_V4L2M2M_DECODER 0
+++#define CONFIG_MPEG2_QSV_DECODER 0
+++#define CONFIG_MPEG2_MEDIACODEC_DECODER 0
+++#define CONFIG_MSA1_DECODER 0
+++#define CONFIG_MSCC_DECODER 0
+++#define CONFIG_MSMPEG4V1_DECODER 0
+++#define CONFIG_MSMPEG4V2_DECODER 0
+++#define CONFIG_MSMPEG4V3_DECODER 0
+++#define CONFIG_MSMPEG4_CRYSTALHD_DECODER 0
+++#define CONFIG_MSP2_DECODER 0
+++#define CONFIG_MSRLE_DECODER 0
+++#define CONFIG_MSS1_DECODER 0
+++#define CONFIG_MSS2_DECODER 0
+++#define CONFIG_MSVIDEO1_DECODER 0
+++#define CONFIG_MSZH_DECODER 0
+++#define CONFIG_MTS2_DECODER 0
+++#define CONFIG_MV30_DECODER 0
+++#define CONFIG_MVC1_DECODER 0
+++#define CONFIG_MVC2_DECODER 0
+++#define CONFIG_MVDV_DECODER 0
+++#define CONFIG_MVHA_DECODER 0
+++#define CONFIG_MWSC_DECODER 0
+++#define CONFIG_MXPEG_DECODER 0
+++#define CONFIG_NOTCHLC_DECODER 0
+++#define CONFIG_NUV_DECODER 0
+++#define CONFIG_PAF_VIDEO_DECODER 0
+++#define CONFIG_PAM_DECODER 0
+++#define CONFIG_PBM_DECODER 0
+++#define CONFIG_PCX_DECODER 0
+++#define CONFIG_PDV_DECODER 0
+++#define CONFIG_PFM_DECODER 0
+++#define CONFIG_PGM_DECODER 0
+++#define CONFIG_PGMYUV_DECODER 0
+++#define CONFIG_PGX_DECODER 0
+++#define CONFIG_PHM_DECODER 0
+++#define CONFIG_PHOTOCD_DECODER 0
+++#define CONFIG_PICTOR_DECODER 0
+++#define CONFIG_PIXLET_DECODER 0
+++#define CONFIG_PNG_DECODER 0
+++#define CONFIG_PPM_DECODER 0
+++#define CONFIG_PRORES_DECODER 0
+++#define CONFIG_PROSUMER_DECODER 0
+++#define CONFIG_PSD_DECODER 0
+++#define CONFIG_PTX_DECODER 0
+++#define CONFIG_QDRAW_DECODER 0
+++#define CONFIG_QOI_DECODER 0
+++#define CONFIG_QPEG_DECODER 0
+++#define CONFIG_QTRLE_DECODER 0
+++#define CONFIG_R10K_DECODER 0
+++#define CONFIG_R210_DECODER 0
+++#define CONFIG_RASC_DECODER 0
+++#define CONFIG_RAWVIDEO_DECODER 0
+++#define CONFIG_RKA_DECODER 0
+++#define CONFIG_RL2_DECODER 0
+++#define CONFIG_ROQ_DECODER 0
+++#define CONFIG_RPZA_DECODER 0
+++#define CONFIG_RSCC_DECODER 0
+++#define CONFIG_RTV1_DECODER 0
+++#define CONFIG_RV10_DECODER 0
+++#define CONFIG_RV20_DECODER 0
+++#define CONFIG_RV30_DECODER 0
+++#define CONFIG_RV40_DECODER 0
+++#define CONFIG_S302M_DECODER 0
+++#define CONFIG_SANM_DECODER 0
+++#define CONFIG_SCPR_DECODER 0
+++#define CONFIG_SCREENPRESSO_DECODER 0
+++#define CONFIG_SGA_DECODER 0
+++#define CONFIG_SGI_DECODER 0
+++#define CONFIG_SGIRLE_DECODER 0
+++#define CONFIG_SHEERVIDEO_DECODER 0
+++#define CONFIG_SIMBIOSIS_IMX_DECODER 0
+++#define CONFIG_SMACKER_DECODER 0
+++#define CONFIG_SMC_DECODER 0
+++#define CONFIG_SMVJPEG_DECODER 0
+++#define CONFIG_SNOW_DECODER 0
+++#define CONFIG_SP5X_DECODER 0
+++#define CONFIG_SPEEDHQ_DECODER 0
+++#define CONFIG_SPEEX_DECODER 0
+++#define CONFIG_SRGC_DECODER 0
+++#define CONFIG_SUNRAST_DECODER 0
+++#define CONFIG_SVQ1_DECODER 0
+++#define CONFIG_SVQ3_DECODER 0
+++#define CONFIG_TARGA_DECODER 0
+++#define CONFIG_TARGA_Y216_DECODER 0
+++#define CONFIG_TDSC_DECODER 0
+++#define CONFIG_THEORA_DECODER 0
+++#define CONFIG_THP_DECODER 0
+++#define CONFIG_TIERTEXSEQVIDEO_DECODER 0
+++#define CONFIG_TIFF_DECODER 0
+++#define CONFIG_TMV_DECODER 0
+++#define CONFIG_TRUEMOTION1_DECODER 0
+++#define CONFIG_TRUEMOTION2_DECODER 0
+++#define CONFIG_TRUEMOTION2RT_DECODER 0
+++#define CONFIG_TSCC_DECODER 0
+++#define CONFIG_TSCC2_DECODER 0
+++#define CONFIG_TXD_DECODER 0
+++#define CONFIG_ULTI_DECODER 0
+++#define CONFIG_UTVIDEO_DECODER 0
+++#define CONFIG_V210_DECODER 0
+++#define CONFIG_V210X_DECODER 0
+++#define CONFIG_V308_DECODER 0
+++#define CONFIG_V408_DECODER 0
+++#define CONFIG_V410_DECODER 0
+++#define CONFIG_VB_DECODER 0
+++#define CONFIG_VBN_DECODER 0
+++#define CONFIG_VBLE_DECODER 0
+++#define CONFIG_VC1_DECODER 0
+++#define CONFIG_VC1_CRYSTALHD_DECODER 0
+++#define CONFIG_VC1IMAGE_DECODER 0
+++#define CONFIG_VC1_MMAL_DECODER 0
+++#define CONFIG_VC1_QSV_DECODER 0
+++#define CONFIG_VC1_V4L2M2M_DECODER 0
+++#define CONFIG_VCR1_DECODER 0
+++#define CONFIG_VMDVIDEO_DECODER 0
+++#define CONFIG_VMIX_DECODER 0
+++#define CONFIG_VMNC_DECODER 0
+++#define CONFIG_VP3_DECODER 0
+++#define CONFIG_VP4_DECODER 0
+++#define CONFIG_VP5_DECODER 0
+++#define CONFIG_VP6_DECODER 0
+++#define CONFIG_VP6A_DECODER 0
+++#define CONFIG_VP6F_DECODER 0
+++#define CONFIG_VP7_DECODER 0
+++#define CONFIG_VP8_DECODER 0
+++#define CONFIG_VP8_RKMPP_DECODER 0
+++#define CONFIG_VP8_V4L2M2M_DECODER 0
+++#define CONFIG_VP9_DECODER 0
+++#define CONFIG_VP9_RKMPP_DECODER 0
+++#define CONFIG_VP9_V4L2M2M_DECODER 0
+++#define CONFIG_VQA_DECODER 0
+++#define CONFIG_VQC_DECODER 0
+++#define CONFIG_VVC_DECODER 0
+++#define CONFIG_WBMP_DECODER 0
+++#define CONFIG_WEBP_DECODER 0
+++#define CONFIG_WCMV_DECODER 0
+++#define CONFIG_WRAPPED_AVFRAME_DECODER 0
+++#define CONFIG_WMV1_DECODER 0
+++#define CONFIG_WMV2_DECODER 0
+++#define CONFIG_WMV3_DECODER 0
+++#define CONFIG_WMV3_CRYSTALHD_DECODER 0
+++#define CONFIG_WMV3IMAGE_DECODER 0
+++#define CONFIG_WNV1_DECODER 0
+++#define CONFIG_XAN_WC3_DECODER 0
+++#define CONFIG_XAN_WC4_DECODER 0
+++#define CONFIG_XBM_DECODER 0
+++#define CONFIG_XFACE_DECODER 0
+++#define CONFIG_XL_DECODER 0
+++#define CONFIG_XPM_DECODER 0
+++#define CONFIG_XWD_DECODER 0
+++#define CONFIG_Y41P_DECODER 0
+++#define CONFIG_YLC_DECODER 0
+++#define CONFIG_YOP_DECODER 0
+++#define CONFIG_YUV4_DECODER 0
+++#define CONFIG_ZERO12V_DECODER 0
+++#define CONFIG_ZEROCODEC_DECODER 0
+++#define CONFIG_ZLIB_DECODER 0
+++#define CONFIG_ZMBV_DECODER 0
+++#define CONFIG_AAC_DECODER 1
+++#define CONFIG_AAC_FIXED_DECODER 0
+++#define CONFIG_AAC_LATM_DECODER 0
+++#define CONFIG_AC3_DECODER 0
+++#define CONFIG_AC3_FIXED_DECODER 0
+++#define CONFIG_ACELP_KELVIN_DECODER 0
+++#define CONFIG_ALAC_DECODER 0
+++#define CONFIG_ALS_DECODER 0
+++#define CONFIG_AMRNB_DECODER 0
+++#define CONFIG_AMRWB_DECODER 0
+++#define CONFIG_APAC_DECODER 0
+++#define CONFIG_APE_DECODER 0
+++#define CONFIG_APTX_DECODER 0
+++#define CONFIG_APTX_HD_DECODER 0
+++#define CONFIG_ATRAC1_DECODER 0
+++#define CONFIG_ATRAC3_DECODER 0
+++#define CONFIG_ATRAC3AL_DECODER 0
+++#define CONFIG_ATRAC3P_DECODER 0
+++#define CONFIG_ATRAC3PAL_DECODER 0
+++#define CONFIG_ATRAC9_DECODER 0
+++#define CONFIG_BINKAUDIO_DCT_DECODER 0
+++#define CONFIG_BINKAUDIO_RDFT_DECODER 0
+++#define CONFIG_BMV_AUDIO_DECODER 0
+++#define CONFIG_BONK_DECODER 0
+++#define CONFIG_COOK_DECODER 0
+++#define CONFIG_DCA_DECODER 0
+++#define CONFIG_DFPWM_DECODER 0
+++#define CONFIG_DOLBY_E_DECODER 0
+++#define CONFIG_DSD_LSBF_DECODER 0
+++#define CONFIG_DSD_MSBF_DECODER 0
+++#define CONFIG_DSD_LSBF_PLANAR_DECODER 0
+++#define CONFIG_DSD_MSBF_PLANAR_DECODER 0
+++#define CONFIG_DSICINAUDIO_DECODER 0
+++#define CONFIG_DSS_SP_DECODER 0
+++#define CONFIG_DST_DECODER 0
+++#define CONFIG_EAC3_DECODER 0
+++#define CONFIG_EVRC_DECODER 0
+++#define CONFIG_FASTAUDIO_DECODER 0
+++#define CONFIG_FFWAVESYNTH_DECODER 0
+++#define CONFIG_FLAC_DECODER 1
+++#define CONFIG_FTR_DECODER 0
+++#define CONFIG_G723_1_DECODER 0
+++#define CONFIG_G729_DECODER 0
+++#define CONFIG_GSM_DECODER 0
+++#define CONFIG_GSM_MS_DECODER 0
+++#define CONFIG_HCA_DECODER 0
+++#define CONFIG_HCOM_DECODER 0
+++#define CONFIG_HDR_DECODER 0
+++#define CONFIG_IAC_DECODER 0
+++#define CONFIG_ILBC_DECODER 0
+++#define CONFIG_IMC_DECODER 0
+++#define CONFIG_INTERPLAY_ACM_DECODER 0
+++#define CONFIG_MACE3_DECODER 0
+++#define CONFIG_MACE6_DECODER 0
+++#define CONFIG_METASOUND_DECODER 0
+++#define CONFIG_MISC4_DECODER 0
+++#define CONFIG_MLP_DECODER 0
+++#define CONFIG_MP1_DECODER 0
+++#define CONFIG_MP1FLOAT_DECODER 0
+++#define CONFIG_MP2_DECODER 0
+++#define CONFIG_MP2FLOAT_DECODER 0
+++#define CONFIG_MP3FLOAT_DECODER 0
+++#define CONFIG_MP3_DECODER 1
+++#define CONFIG_MP3ADUFLOAT_DECODER 0
+++#define CONFIG_MP3ADU_DECODER 0
+++#define CONFIG_MP3ON4FLOAT_DECODER 0
+++#define CONFIG_MP3ON4_DECODER 0
+++#define CONFIG_MPC7_DECODER 0
+++#define CONFIG_MPC8_DECODER 0
+++#define CONFIG_MSNSIREN_DECODER 0
+++#define CONFIG_NELLYMOSER_DECODER 0
+++#define CONFIG_ON2AVC_DECODER 0
+++#define CONFIG_OPUS_DECODER 0
+++#define CONFIG_OSQ_DECODER 0
+++#define CONFIG_PAF_AUDIO_DECODER 0
+++#define CONFIG_QCELP_DECODER 0
+++#define CONFIG_QDM2_DECODER 0
+++#define CONFIG_QDMC_DECODER 0
+++#define CONFIG_QOA_DECODER 0
+++#define CONFIG_RA_144_DECODER 0
+++#define CONFIG_RA_288_DECODER 0
+++#define CONFIG_RALF_DECODER 0
+++#define CONFIG_SBC_DECODER 0
+++#define CONFIG_SHORTEN_DECODER 0
+++#define CONFIG_SIPR_DECODER 0
+++#define CONFIG_SIREN_DECODER 0
+++#define CONFIG_SMACKAUD_DECODER 0
+++#define CONFIG_SONIC_DECODER 0
+++#define CONFIG_TAK_DECODER 0
+++#define CONFIG_TRUEHD_DECODER 0
+++#define CONFIG_TRUESPEECH_DECODER 0
+++#define CONFIG_TTA_DECODER 0
+++#define CONFIG_TWINVQ_DECODER 0
+++#define CONFIG_VMDAUDIO_DECODER 0
+++#define CONFIG_VORBIS_DECODER 1
+++#define CONFIG_WAVARC_DECODER 0
+++#define CONFIG_WAVPACK_DECODER 0
+++#define CONFIG_WMALOSSLESS_DECODER 0
+++#define CONFIG_WMAPRO_DECODER 0
+++#define CONFIG_WMAV1_DECODER 0
+++#define CONFIG_WMAV2_DECODER 0
+++#define CONFIG_WMAVOICE_DECODER 0
+++#define CONFIG_WS_SND1_DECODER 0
+++#define CONFIG_XMA1_DECODER 0
+++#define CONFIG_XMA2_DECODER 0
+++#define CONFIG_PCM_ALAW_DECODER 1
+++#define CONFIG_PCM_BLURAY_DECODER 0
+++#define CONFIG_PCM_DVD_DECODER 0
+++#define CONFIG_PCM_F16LE_DECODER 0
+++#define CONFIG_PCM_F24LE_DECODER 0
+++#define CONFIG_PCM_F32BE_DECODER 0
+++#define CONFIG_PCM_F32LE_DECODER 1
+++#define CONFIG_PCM_F64BE_DECODER 0
+++#define CONFIG_PCM_F64LE_DECODER 0
+++#define CONFIG_PCM_LXF_DECODER 0
+++#define CONFIG_PCM_MULAW_DECODER 1
+++#define CONFIG_PCM_S8_DECODER 0
+++#define CONFIG_PCM_S8_PLANAR_DECODER 0
+++#define CONFIG_PCM_S16BE_DECODER 1
+++#define CONFIG_PCM_S16BE_PLANAR_DECODER 0
+++#define CONFIG_PCM_S16LE_DECODER 1
+++#define CONFIG_PCM_S16LE_PLANAR_DECODER 0
+++#define CONFIG_PCM_S24BE_DECODER 1
+++#define CONFIG_PCM_S24DAUD_DECODER 0
+++#define CONFIG_PCM_S24LE_DECODER 1
+++#define CONFIG_PCM_S24LE_PLANAR_DECODER 0
+++#define CONFIG_PCM_S32BE_DECODER 0
+++#define CONFIG_PCM_S32LE_DECODER 1
+++#define CONFIG_PCM_S32LE_PLANAR_DECODER 0
+++#define CONFIG_PCM_S64BE_DECODER 0
+++#define CONFIG_PCM_S64LE_DECODER 0
+++#define CONFIG_PCM_SGA_DECODER 0
+++#define CONFIG_PCM_U8_DECODER 1
+++#define CONFIG_PCM_U16BE_DECODER 0
+++#define CONFIG_PCM_U16LE_DECODER 0
+++#define CONFIG_PCM_U24BE_DECODER 0
+++#define CONFIG_PCM_U24LE_DECODER 0
+++#define CONFIG_PCM_U32BE_DECODER 0
+++#define CONFIG_PCM_U32LE_DECODER 0
+++#define CONFIG_PCM_VIDC_DECODER 0
+++#define CONFIG_CBD2_DPCM_DECODER 0
+++#define CONFIG_DERF_DPCM_DECODER 0
+++#define CONFIG_GREMLIN_DPCM_DECODER 0
+++#define CONFIG_INTERPLAY_DPCM_DECODER 0
+++#define CONFIG_ROQ_DPCM_DECODER 0
+++#define CONFIG_SDX2_DPCM_DECODER 0
+++#define CONFIG_SOL_DPCM_DECODER 0
+++#define CONFIG_XAN_DPCM_DECODER 0
+++#define CONFIG_WADY_DPCM_DECODER 0
+++#define CONFIG_ADPCM_4XM_DECODER 0
+++#define CONFIG_ADPCM_ADX_DECODER 0
+++#define CONFIG_ADPCM_AFC_DECODER 0
+++#define CONFIG_ADPCM_AGM_DECODER 0
+++#define CONFIG_ADPCM_AICA_DECODER 0
+++#define CONFIG_ADPCM_ARGO_DECODER 0
+++#define CONFIG_ADPCM_CT_DECODER 0
+++#define CONFIG_ADPCM_DTK_DECODER 0
+++#define CONFIG_ADPCM_EA_DECODER 0
+++#define CONFIG_ADPCM_EA_MAXIS_XA_DECODER 0
+++#define CONFIG_ADPCM_EA_R1_DECODER 0
+++#define CONFIG_ADPCM_EA_R2_DECODER 0
+++#define CONFIG_ADPCM_EA_R3_DECODER 0
+++#define CONFIG_ADPCM_EA_XAS_DECODER 0
+++#define CONFIG_ADPCM_G722_DECODER 0
+++#define CONFIG_ADPCM_G726_DECODER 0
+++#define CONFIG_ADPCM_G726LE_DECODER 0
+++#define CONFIG_ADPCM_IMA_ACORN_DECODER 0
+++#define CONFIG_ADPCM_IMA_AMV_DECODER 0
+++#define CONFIG_ADPCM_IMA_ALP_DECODER 0
+++#define CONFIG_ADPCM_IMA_APC_DECODER 0
+++#define CONFIG_ADPCM_IMA_APM_DECODER 0
+++#define CONFIG_ADPCM_IMA_CUNNING_DECODER 0
+++#define CONFIG_ADPCM_IMA_DAT4_DECODER 0
+++#define CONFIG_ADPCM_IMA_DK3_DECODER 0
+++#define CONFIG_ADPCM_IMA_DK4_DECODER 0
+++#define CONFIG_ADPCM_IMA_EA_EACS_DECODER 0
+++#define CONFIG_ADPCM_IMA_EA_SEAD_DECODER 0
+++#define CONFIG_ADPCM_IMA_ISS_DECODER 0
+++#define CONFIG_ADPCM_IMA_MOFLEX_DECODER 0
+++#define CONFIG_ADPCM_IMA_MTF_DECODER 0
+++#define CONFIG_ADPCM_IMA_OKI_DECODER 0
+++#define CONFIG_ADPCM_IMA_QT_DECODER 0
+++#define CONFIG_ADPCM_IMA_RAD_DECODER 0
+++#define CONFIG_ADPCM_IMA_SSI_DECODER 0
+++#define CONFIG_ADPCM_IMA_SMJPEG_DECODER 0
+++#define CONFIG_ADPCM_IMA_WAV_DECODER 0
+++#define CONFIG_ADPCM_IMA_WS_DECODER 0
+++#define CONFIG_ADPCM_MS_DECODER 0
+++#define CONFIG_ADPCM_MTAF_DECODER 0
+++#define CONFIG_ADPCM_PSX_DECODER 0
+++#define CONFIG_ADPCM_SBPRO_2_DECODER 0
+++#define CONFIG_ADPCM_SBPRO_3_DECODER 0
+++#define CONFIG_ADPCM_SBPRO_4_DECODER 0
+++#define CONFIG_ADPCM_SWF_DECODER 0
+++#define CONFIG_ADPCM_THP_DECODER 0
+++#define CONFIG_ADPCM_THP_LE_DECODER 0
+++#define CONFIG_ADPCM_VIMA_DECODER 0
+++#define CONFIG_ADPCM_XA_DECODER 0
+++#define CONFIG_ADPCM_XMD_DECODER 0
+++#define CONFIG_ADPCM_YAMAHA_DECODER 0
+++#define CONFIG_ADPCM_ZORK_DECODER 0
+++#define CONFIG_SSA_DECODER 0
+++#define CONFIG_ASS_DECODER 0
+++#define CONFIG_CCAPTION_DECODER 0
+++#define CONFIG_DVBSUB_DECODER 0
+++#define CONFIG_DVDSUB_DECODER 0
+++#define CONFIG_JACOSUB_DECODER 0
+++#define CONFIG_MICRODVD_DECODER 0
+++#define CONFIG_MOVTEXT_DECODER 0
+++#define CONFIG_MPL2_DECODER 0
+++#define CONFIG_PGSSUB_DECODER 0
+++#define CONFIG_PJS_DECODER 0
+++#define CONFIG_REALTEXT_DECODER 0
+++#define CONFIG_SAMI_DECODER 0
+++#define CONFIG_SRT_DECODER 0
+++#define CONFIG_STL_DECODER 0
+++#define CONFIG_SUBRIP_DECODER 0
+++#define CONFIG_SUBVIEWER_DECODER 0
+++#define CONFIG_SUBVIEWER1_DECODER 0
+++#define CONFIG_TEXT_DECODER 0
+++#define CONFIG_VPLAYER_DECODER 0
+++#define CONFIG_WEBVTT_DECODER 0
+++#define CONFIG_XSUB_DECODER 0
+++#define CONFIG_AAC_AT_DECODER 0
+++#define CONFIG_AC3_AT_DECODER 0
+++#define CONFIG_ADPCM_IMA_QT_AT_DECODER 0
+++#define CONFIG_ALAC_AT_DECODER 0
+++#define CONFIG_AMR_NB_AT_DECODER 0
+++#define CONFIG_EAC3_AT_DECODER 0
+++#define CONFIG_GSM_MS_AT_DECODER 0
+++#define CONFIG_ILBC_AT_DECODER 0
+++#define CONFIG_MP1_AT_DECODER 0
+++#define CONFIG_MP2_AT_DECODER 0
+++#define CONFIG_MP3_AT_DECODER 0
+++#define CONFIG_PCM_ALAW_AT_DECODER 0
+++#define CONFIG_PCM_MULAW_AT_DECODER 0
+++#define CONFIG_QDMC_AT_DECODER 0
+++#define CONFIG_QDM2_AT_DECODER 0
+++#define CONFIG_LIBARIBCAPTION_DECODER 0
+++#define CONFIG_LIBARIBB24_DECODER 0
+++#define CONFIG_LIBCELT_DECODER 0
+++#define CONFIG_LIBCODEC2_DECODER 0
+++#define CONFIG_LIBDAV1D_DECODER 0
+++#define CONFIG_LIBDAVS2_DECODER 0
+++#define CONFIG_LIBFDK_AAC_DECODER 0
+++#define CONFIG_LIBGSM_DECODER 0
+++#define CONFIG_LIBGSM_MS_DECODER 0
+++#define CONFIG_LIBILBC_DECODER 0
+++#define CONFIG_LIBJXL_DECODER 0
+++#define CONFIG_LIBOPENCORE_AMRNB_DECODER 0
+++#define CONFIG_LIBOPENCORE_AMRWB_DECODER 0
+++#define CONFIG_LIBOPUS_DECODER 1
+++#define CONFIG_LIBRSVG_DECODER 0
+++#define CONFIG_LIBSPEEX_DECODER 0
+++#define CONFIG_LIBUAVS3D_DECODER 0
+++#define CONFIG_LIBVORBIS_DECODER 0
+++#define CONFIG_LIBVPX_VP8_DECODER 0
+++#define CONFIG_LIBVPX_VP9_DECODER 0
+++#define CONFIG_LIBXEVD_DECODER 0
+++#define CONFIG_LIBZVBI_TELETEXT_DECODER 0
+++#define CONFIG_BINTEXT_DECODER 0
+++#define CONFIG_XBIN_DECODER 0
+++#define CONFIG_IDF_DECODER 0
+++#define CONFIG_LIBAOM_AV1_DECODER 0
+++#define CONFIG_AV1_DECODER 0
+++#define CONFIG_AV1_CUVID_DECODER 0
+++#define CONFIG_AV1_MEDIACODEC_DECODER 0
+++#define CONFIG_AV1_QSV_DECODER 0
+++#define CONFIG_LIBOPENH264_DECODER 0
+++#define CONFIG_H264_CUVID_DECODER 0
+++#define CONFIG_HEVC_CUVID_DECODER 0
+++#define CONFIG_HEVC_MEDIACODEC_DECODER 0
+++#define CONFIG_MJPEG_CUVID_DECODER 0
+++#define CONFIG_MJPEG_QSV_DECODER 0
+++#define CONFIG_MPEG1_CUVID_DECODER 0
+++#define CONFIG_MPEG2_CUVID_DECODER 0
+++#define CONFIG_MPEG4_CUVID_DECODER 0
+++#define CONFIG_MPEG4_MEDIACODEC_DECODER 0
+++#define CONFIG_VC1_CUVID_DECODER 0
+++#define CONFIG_VP8_CUVID_DECODER 0
+++#define CONFIG_VP8_MEDIACODEC_DECODER 0
+++#define CONFIG_VP8_QSV_DECODER 0
+++#define CONFIG_VP9_CUVID_DECODER 0
+++#define CONFIG_VP9_MEDIACODEC_DECODER 0
+++#define CONFIG_VP9_QSV_DECODER 0
+++#define CONFIG_VNULL_DECODER 0
+++#define CONFIG_ANULL_DECODER 0
+++#define CONFIG_A64MULTI_ENCODER 0
+++#define CONFIG_A64MULTI5_ENCODER 0
+++#define CONFIG_ALIAS_PIX_ENCODER 0
+++#define CONFIG_AMV_ENCODER 0
+++#define CONFIG_APNG_ENCODER 0
+++#define CONFIG_ASV1_ENCODER 0
+++#define CONFIG_ASV2_ENCODER 0
+++#define CONFIG_AVRP_ENCODER 0
+++#define CONFIG_AVUI_ENCODER 0
+++#define CONFIG_AYUV_ENCODER 0
+++#define CONFIG_BITPACKED_ENCODER 0
+++#define CONFIG_BMP_ENCODER 0
+++#define CONFIG_CFHD_ENCODER 0
+++#define CONFIG_CINEPAK_ENCODER 0
+++#define CONFIG_CLJR_ENCODER 0
+++#define CONFIG_COMFORTNOISE_ENCODER 0
+++#define CONFIG_DNXHD_ENCODER 0
+++#define CONFIG_DPX_ENCODER 0
+++#define CONFIG_DVVIDEO_ENCODER 0
+++#define CONFIG_DXV_ENCODER 0
+++#define CONFIG_EXR_ENCODER 0
+++#define CONFIG_FFV1_ENCODER 0
+++#define CONFIG_FFVHUFF_ENCODER 0
+++#define CONFIG_FITS_ENCODER 0
+++#define CONFIG_FLASHSV_ENCODER 0
+++#define CONFIG_FLASHSV2_ENCODER 0
+++#define CONFIG_FLV_ENCODER 0
+++#define CONFIG_GIF_ENCODER 0
+++#define CONFIG_H261_ENCODER 0
+++#define CONFIG_H263_ENCODER 0
+++#define CONFIG_H263P_ENCODER 0
+++#define CONFIG_H264_MEDIACODEC_ENCODER 0
+++#define CONFIG_HAP_ENCODER 0
+++#define CONFIG_HUFFYUV_ENCODER 0
+++#define CONFIG_JPEG2000_ENCODER 0
+++#define CONFIG_JPEGLS_ENCODER 0
+++#define CONFIG_LJPEG_ENCODER 0
+++#define CONFIG_MAGICYUV_ENCODER 0
+++#define CONFIG_MJPEG_ENCODER 0
+++#define CONFIG_MPEG1VIDEO_ENCODER 0
+++#define CONFIG_MPEG2VIDEO_ENCODER 0
+++#define CONFIG_MPEG4_ENCODER 0
+++#define CONFIG_MSMPEG4V2_ENCODER 0
+++#define CONFIG_MSMPEG4V3_ENCODER 0
+++#define CONFIG_MSRLE_ENCODER 0
+++#define CONFIG_MSVIDEO1_ENCODER 0
+++#define CONFIG_PAM_ENCODER 0
+++#define CONFIG_PBM_ENCODER 0
+++#define CONFIG_PCX_ENCODER 0
+++#define CONFIG_PFM_ENCODER 0
+++#define CONFIG_PGM_ENCODER 0
+++#define CONFIG_PGMYUV_ENCODER 0
+++#define CONFIG_PHM_ENCODER 0
+++#define CONFIG_PNG_ENCODER 0
+++#define CONFIG_PPM_ENCODER 0
+++#define CONFIG_PRORES_ENCODER 0
+++#define CONFIG_PRORES_AW_ENCODER 0
+++#define CONFIG_PRORES_KS_ENCODER 0
+++#define CONFIG_QOI_ENCODER 0
+++#define CONFIG_QTRLE_ENCODER 0
+++#define CONFIG_R10K_ENCODER 0
+++#define CONFIG_R210_ENCODER 0
+++#define CONFIG_RAWVIDEO_ENCODER 0
+++#define CONFIG_ROQ_ENCODER 0
+++#define CONFIG_RPZA_ENCODER 0
+++#define CONFIG_RV10_ENCODER 0
+++#define CONFIG_RV20_ENCODER 0
+++#define CONFIG_S302M_ENCODER 0
+++#define CONFIG_SGI_ENCODER 0
+++#define CONFIG_SMC_ENCODER 0
+++#define CONFIG_SNOW_ENCODER 0
+++#define CONFIG_SPEEDHQ_ENCODER 0
+++#define CONFIG_SUNRAST_ENCODER 0
+++#define CONFIG_SVQ1_ENCODER 0
+++#define CONFIG_TARGA_ENCODER 0
+++#define CONFIG_TIFF_ENCODER 0
+++#define CONFIG_UTVIDEO_ENCODER 0
+++#define CONFIG_V210_ENCODER 0
+++#define CONFIG_V308_ENCODER 0
+++#define CONFIG_V408_ENCODER 0
+++#define CONFIG_V410_ENCODER 0
+++#define CONFIG_VBN_ENCODER 0
+++#define CONFIG_VC2_ENCODER 0
+++#define CONFIG_WBMP_ENCODER 0
+++#define CONFIG_WRAPPED_AVFRAME_ENCODER 0
+++#define CONFIG_WMV1_ENCODER 0
+++#define CONFIG_WMV2_ENCODER 0
+++#define CONFIG_XBM_ENCODER 0
+++#define CONFIG_XFACE_ENCODER 0
+++#define CONFIG_XWD_ENCODER 0
+++#define CONFIG_Y41P_ENCODER 0
+++#define CONFIG_YUV4_ENCODER 0
+++#define CONFIG_ZLIB_ENCODER 0
+++#define CONFIG_ZMBV_ENCODER 0
+++#define CONFIG_AAC_ENCODER 0
+++#define CONFIG_AC3_ENCODER 0
+++#define CONFIG_AC3_FIXED_ENCODER 0
+++#define CONFIG_ALAC_ENCODER 0
+++#define CONFIG_APTX_ENCODER 0
+++#define CONFIG_APTX_HD_ENCODER 0
+++#define CONFIG_DCA_ENCODER 0
+++#define CONFIG_DFPWM_ENCODER 0
+++#define CONFIG_EAC3_ENCODER 0
+++#define CONFIG_FLAC_ENCODER 0
+++#define CONFIG_G723_1_ENCODER 0
+++#define CONFIG_HDR_ENCODER 0
+++#define CONFIG_MLP_ENCODER 0
+++#define CONFIG_MP2_ENCODER 0
+++#define CONFIG_MP2FIXED_ENCODER 0
+++#define CONFIG_NELLYMOSER_ENCODER 0
+++#define CONFIG_OPUS_ENCODER 0
+++#define CONFIG_RA_144_ENCODER 0
+++#define CONFIG_SBC_ENCODER 0
+++#define CONFIG_SONIC_ENCODER 0
+++#define CONFIG_SONIC_LS_ENCODER 0
+++#define CONFIG_TRUEHD_ENCODER 0
+++#define CONFIG_TTA_ENCODER 0
+++#define CONFIG_VORBIS_ENCODER 0
+++#define CONFIG_WAVPACK_ENCODER 0
+++#define CONFIG_WMAV1_ENCODER 0
+++#define CONFIG_WMAV2_ENCODER 0
+++#define CONFIG_PCM_ALAW_ENCODER 0
+++#define CONFIG_PCM_BLURAY_ENCODER 0
+++#define CONFIG_PCM_DVD_ENCODER 0
+++#define CONFIG_PCM_F32BE_ENCODER 0
+++#define CONFIG_PCM_F32LE_ENCODER 0
+++#define CONFIG_PCM_F64BE_ENCODER 0
+++#define CONFIG_PCM_F64LE_ENCODER 0
+++#define CONFIG_PCM_MULAW_ENCODER 0
+++#define CONFIG_PCM_S8_ENCODER 0
+++#define CONFIG_PCM_S8_PLANAR_ENCODER 0
+++#define CONFIG_PCM_S16BE_ENCODER 0
+++#define CONFIG_PCM_S16BE_PLANAR_ENCODER 0
+++#define CONFIG_PCM_S16LE_ENCODER 0
+++#define CONFIG_PCM_S16LE_PLANAR_ENCODER 0
+++#define CONFIG_PCM_S24BE_ENCODER 0
+++#define CONFIG_PCM_S24DAUD_ENCODER 0
+++#define CONFIG_PCM_S24LE_ENCODER 0
+++#define CONFIG_PCM_S24LE_PLANAR_ENCODER 0
+++#define CONFIG_PCM_S32BE_ENCODER 0
+++#define CONFIG_PCM_S32LE_ENCODER 0
+++#define CONFIG_PCM_S32LE_PLANAR_ENCODER 0
+++#define CONFIG_PCM_S64BE_ENCODER 0
+++#define CONFIG_PCM_S64LE_ENCODER 0
+++#define CONFIG_PCM_U8_ENCODER 0
+++#define CONFIG_PCM_U16BE_ENCODER 0
+++#define CONFIG_PCM_U16LE_ENCODER 0
+++#define CONFIG_PCM_U24BE_ENCODER 0
+++#define CONFIG_PCM_U24LE_ENCODER 0
+++#define CONFIG_PCM_U32BE_ENCODER 0
+++#define CONFIG_PCM_U32LE_ENCODER 0
+++#define CONFIG_PCM_VIDC_ENCODER 0
+++#define CONFIG_ROQ_DPCM_ENCODER 0
+++#define CONFIG_ADPCM_ADX_ENCODER 0
+++#define CONFIG_ADPCM_ARGO_ENCODER 0
+++#define CONFIG_ADPCM_G722_ENCODER 0
+++#define CONFIG_ADPCM_G726_ENCODER 0
+++#define CONFIG_ADPCM_G726LE_ENCODER 0
+++#define CONFIG_ADPCM_IMA_AMV_ENCODER 0
+++#define CONFIG_ADPCM_IMA_ALP_ENCODER 0
+++#define CONFIG_ADPCM_IMA_APM_ENCODER 0
+++#define CONFIG_ADPCM_IMA_QT_ENCODER 0
+++#define CONFIG_ADPCM_IMA_SSI_ENCODER 0
+++#define CONFIG_ADPCM_IMA_WAV_ENCODER 0
+++#define CONFIG_ADPCM_IMA_WS_ENCODER 0
+++#define CONFIG_ADPCM_MS_ENCODER 0
+++#define CONFIG_ADPCM_SWF_ENCODER 0
+++#define CONFIG_ADPCM_YAMAHA_ENCODER 0
+++#define CONFIG_SSA_ENCODER 0
+++#define CONFIG_ASS_ENCODER 0
+++#define CONFIG_DVBSUB_ENCODER 0
+++#define CONFIG_DVDSUB_ENCODER 0
+++#define CONFIG_MOVTEXT_ENCODER 0
+++#define CONFIG_SRT_ENCODER 0
+++#define CONFIG_SUBRIP_ENCODER 0
+++#define CONFIG_TEXT_ENCODER 0
+++#define CONFIG_TTML_ENCODER 0
+++#define CONFIG_WEBVTT_ENCODER 0
+++#define CONFIG_XSUB_ENCODER 0
+++#define CONFIG_AAC_AT_ENCODER 0
+++#define CONFIG_ALAC_AT_ENCODER 0
+++#define CONFIG_ILBC_AT_ENCODER 0
+++#define CONFIG_PCM_ALAW_AT_ENCODER 0
+++#define CONFIG_PCM_MULAW_AT_ENCODER 0
+++#define CONFIG_LIBAOM_AV1_ENCODER 0
+++#define CONFIG_LIBCODEC2_ENCODER 0
+++#define CONFIG_LIBFDK_AAC_ENCODER 0
+++#define CONFIG_LIBGSM_ENCODER 0
+++#define CONFIG_LIBGSM_MS_ENCODER 0
+++#define CONFIG_LIBILBC_ENCODER 0
+++#define CONFIG_LIBJXL_ENCODER 0
+++#define CONFIG_LIBMP3LAME_ENCODER 0
+++#define CONFIG_LIBOPENCORE_AMRNB_ENCODER 0
+++#define CONFIG_LIBOPENJPEG_ENCODER 0
+++#define CONFIG_LIBOPUS_ENCODER 0
+++#define CONFIG_LIBRAV1E_ENCODER 0
+++#define CONFIG_LIBSHINE_ENCODER 0
+++#define CONFIG_LIBSPEEX_ENCODER 0
+++#define CONFIG_LIBSVTAV1_ENCODER 0
+++#define CONFIG_LIBTHEORA_ENCODER 0
+++#define CONFIG_LIBTWOLAME_ENCODER 0
+++#define CONFIG_LIBVO_AMRWBENC_ENCODER 0
+++#define CONFIG_LIBVORBIS_ENCODER 0
+++#define CONFIG_LIBVPX_VP8_ENCODER 0
+++#define CONFIG_LIBVPX_VP9_ENCODER 0
+++#define CONFIG_LIBWEBP_ANIM_ENCODER 0
+++#define CONFIG_LIBWEBP_ENCODER 0
+++#define CONFIG_LIBX262_ENCODER 0
+++#define CONFIG_LIBX264_ENCODER 0
+++#define CONFIG_LIBX264RGB_ENCODER 0
+++#define CONFIG_LIBX265_ENCODER 0
+++#define CONFIG_LIBXEVE_ENCODER 0
+++#define CONFIG_LIBXAVS_ENCODER 0
+++#define CONFIG_LIBXAVS2_ENCODER 0
+++#define CONFIG_LIBXVID_ENCODER 0
+++#define CONFIG_AAC_MF_ENCODER 0
+++#define CONFIG_AC3_MF_ENCODER 0
+++#define CONFIG_H263_V4L2M2M_ENCODER 0
+++#define CONFIG_AV1_MEDIACODEC_ENCODER 0
+++#define CONFIG_AV1_NVENC_ENCODER 0
+++#define CONFIG_AV1_QSV_ENCODER 0
+++#define CONFIG_AV1_AMF_ENCODER 0
+++#define CONFIG_AV1_VAAPI_ENCODER 0
+++#define CONFIG_LIBOPENH264_ENCODER 0
+++#define CONFIG_H264_AMF_ENCODER 0
+++#define CONFIG_H264_MF_ENCODER 0
+++#define CONFIG_H264_NVENC_ENCODER 0
+++#define CONFIG_H264_OMX_ENCODER 0
+++#define CONFIG_H264_QSV_ENCODER 0
+++#define CONFIG_H264_V4L2M2M_ENCODER 0
+++#define CONFIG_H264_VAAPI_ENCODER 0
+++#define CONFIG_H264_VIDEOTOOLBOX_ENCODER 0
+++#define CONFIG_HEVC_AMF_ENCODER 0
+++#define CONFIG_HEVC_MEDIACODEC_ENCODER 0
+++#define CONFIG_HEVC_MF_ENCODER 0
+++#define CONFIG_HEVC_NVENC_ENCODER 0
+++#define CONFIG_HEVC_QSV_ENCODER 0
+++#define CONFIG_HEVC_V4L2M2M_ENCODER 0
+++#define CONFIG_HEVC_VAAPI_ENCODER 0
+++#define CONFIG_HEVC_VIDEOTOOLBOX_ENCODER 0
+++#define CONFIG_LIBKVAZAAR_ENCODER 0
+++#define CONFIG_MJPEG_QSV_ENCODER 0
+++#define CONFIG_MJPEG_VAAPI_ENCODER 0
+++#define CONFIG_MP3_MF_ENCODER 0
+++#define CONFIG_MPEG2_QSV_ENCODER 0
+++#define CONFIG_MPEG2_VAAPI_ENCODER 0
+++#define CONFIG_MPEG4_MEDIACODEC_ENCODER 0
+++#define CONFIG_MPEG4_OMX_ENCODER 0
+++#define CONFIG_MPEG4_V4L2M2M_ENCODER 0
+++#define CONFIG_PRORES_VIDEOTOOLBOX_ENCODER 0
+++#define CONFIG_VP8_MEDIACODEC_ENCODER 0
+++#define CONFIG_VP8_V4L2M2M_ENCODER 0
+++#define CONFIG_VP8_VAAPI_ENCODER 0
+++#define CONFIG_VP9_MEDIACODEC_ENCODER 0
+++#define CONFIG_VP9_VAAPI_ENCODER 0
+++#define CONFIG_VP9_QSV_ENCODER 0
+++#define CONFIG_VNULL_ENCODER 0
+++#define CONFIG_ANULL_ENCODER 0
+++#define CONFIG_AV1_D3D11VA_HWACCEL 0
+++#define CONFIG_AV1_D3D11VA2_HWACCEL 0
+++#define CONFIG_AV1_D3D12VA_HWACCEL 0
+++#define CONFIG_AV1_DXVA2_HWACCEL 0
+++#define CONFIG_AV1_NVDEC_HWACCEL 0
+++#define CONFIG_AV1_VAAPI_HWACCEL 0
+++#define CONFIG_AV1_VDPAU_HWACCEL 0
+++#define CONFIG_AV1_VULKAN_HWACCEL 0
+++#define CONFIG_H263_VAAPI_HWACCEL 0
+++#define CONFIG_H263_VIDEOTOOLBOX_HWACCEL 0
+++#define CONFIG_H264_D3D11VA_HWACCEL 0
+++#define CONFIG_H264_D3D11VA2_HWACCEL 0
+++#define CONFIG_H264_D3D12VA_HWACCEL 0
+++#define CONFIG_H264_DXVA2_HWACCEL 0
+++#define CONFIG_H264_NVDEC_HWACCEL 0
+++#define CONFIG_H264_VAAPI_HWACCEL 0
+++#define CONFIG_H264_VDPAU_HWACCEL 0
+++#define CONFIG_H264_VIDEOTOOLBOX_HWACCEL 0
+++#define CONFIG_H264_VULKAN_HWACCEL 0
+++#define CONFIG_HEVC_D3D11VA_HWACCEL 0
+++#define CONFIG_HEVC_D3D11VA2_HWACCEL 0
+++#define CONFIG_HEVC_D3D12VA_HWACCEL 0
+++#define CONFIG_HEVC_DXVA2_HWACCEL 0
+++#define CONFIG_HEVC_NVDEC_HWACCEL 0
+++#define CONFIG_HEVC_VAAPI_HWACCEL 0
+++#define CONFIG_HEVC_VDPAU_HWACCEL 0
+++#define CONFIG_HEVC_VIDEOTOOLBOX_HWACCEL 0
+++#define CONFIG_HEVC_VULKAN_HWACCEL 0
+++#define CONFIG_MJPEG_NVDEC_HWACCEL 0
+++#define CONFIG_MJPEG_VAAPI_HWACCEL 0
+++#define CONFIG_MPEG1_NVDEC_HWACCEL 0
+++#define CONFIG_MPEG1_VDPAU_HWACCEL 0
+++#define CONFIG_MPEG1_VIDEOTOOLBOX_HWACCEL 0
+++#define CONFIG_MPEG2_D3D11VA_HWACCEL 0
+++#define CONFIG_MPEG2_D3D11VA2_HWACCEL 0
+++#define CONFIG_MPEG2_D3D12VA_HWACCEL 0
+++#define CONFIG_MPEG2_DXVA2_HWACCEL 0
+++#define CONFIG_MPEG2_NVDEC_HWACCEL 0
+++#define CONFIG_MPEG2_VAAPI_HWACCEL 0
+++#define CONFIG_MPEG2_VDPAU_HWACCEL 0
+++#define CONFIG_MPEG2_VIDEOTOOLBOX_HWACCEL 0
+++#define CONFIG_MPEG4_NVDEC_HWACCEL 0
+++#define CONFIG_MPEG4_VAAPI_HWACCEL 0
+++#define CONFIG_MPEG4_VDPAU_HWACCEL 0
+++#define CONFIG_MPEG4_VIDEOTOOLBOX_HWACCEL 0
+++#define CONFIG_PRORES_VIDEOTOOLBOX_HWACCEL 0
+++#define CONFIG_VC1_D3D11VA_HWACCEL 0
+++#define CONFIG_VC1_D3D11VA2_HWACCEL 0
+++#define CONFIG_VC1_D3D12VA_HWACCEL 0
+++#define CONFIG_VC1_DXVA2_HWACCEL 0
+++#define CONFIG_VC1_NVDEC_HWACCEL 0
+++#define CONFIG_VC1_VAAPI_HWACCEL 0
+++#define CONFIG_VC1_VDPAU_HWACCEL 0
+++#define CONFIG_VP8_NVDEC_HWACCEL 0
+++#define CONFIG_VP8_VAAPI_HWACCEL 0
+++#define CONFIG_VP9_D3D11VA_HWACCEL 0
+++#define CONFIG_VP9_D3D11VA2_HWACCEL 0
+++#define CONFIG_VP9_D3D12VA_HWACCEL 0
+++#define CONFIG_VP9_DXVA2_HWACCEL 0
+++#define CONFIG_VP9_NVDEC_HWACCEL 0
+++#define CONFIG_VP9_VAAPI_HWACCEL 0
+++#define CONFIG_VP9_VDPAU_HWACCEL 0
+++#define CONFIG_VP9_VIDEOTOOLBOX_HWACCEL 0
+++#define CONFIG_WMV3_D3D11VA_HWACCEL 0
+++#define CONFIG_WMV3_D3D11VA2_HWACCEL 0
+++#define CONFIG_WMV3_D3D12VA_HWACCEL 0
+++#define CONFIG_WMV3_DXVA2_HWACCEL 0
+++#define CONFIG_WMV3_NVDEC_HWACCEL 0
+++#define CONFIG_WMV3_VAAPI_HWACCEL 0
+++#define CONFIG_WMV3_VDPAU_HWACCEL 0
+++#define CONFIG_AAC_PARSER 1
+++#define CONFIG_AAC_LATM_PARSER 0
+++#define CONFIG_AC3_PARSER 0
+++#define CONFIG_ADX_PARSER 0
+++#define CONFIG_AMR_PARSER 0
+++#define CONFIG_AV1_PARSER 0
+++#define CONFIG_AVS2_PARSER 0
+++#define CONFIG_AVS3_PARSER 0
+++#define CONFIG_BMP_PARSER 0
+++#define CONFIG_CAVSVIDEO_PARSER 0
+++#define CONFIG_COOK_PARSER 0
+++#define CONFIG_CRI_PARSER 0
+++#define CONFIG_DCA_PARSER 0
+++#define CONFIG_DIRAC_PARSER 0
+++#define CONFIG_DNXHD_PARSER 0
+++#define CONFIG_DOLBY_E_PARSER 0
+++#define CONFIG_DPX_PARSER 0
+++#define CONFIG_DVAUDIO_PARSER 0
+++#define CONFIG_DVBSUB_PARSER 0
+++#define CONFIG_DVDSUB_PARSER 0
+++#define CONFIG_DVD_NAV_PARSER 0
+++#define CONFIG_EVC_PARSER 0
+++#define CONFIG_FLAC_PARSER 1
+++#define CONFIG_FTR_PARSER 0
+++#define CONFIG_G723_1_PARSER 0
+++#define CONFIG_G729_PARSER 0
+++#define CONFIG_GIF_PARSER 0
+++#define CONFIG_GSM_PARSER 0
+++#define CONFIG_H261_PARSER 0
+++#define CONFIG_H263_PARSER 0
+++#define CONFIG_H264_PARSER 1
+++#define CONFIG_HEVC_PARSER 0
+++#define CONFIG_HDR_PARSER 0
+++#define CONFIG_IPU_PARSER 0
+++#define CONFIG_JPEG2000_PARSER 0
+++#define CONFIG_JPEGXL_PARSER 0
+++#define CONFIG_MISC4_PARSER 0
+++#define CONFIG_MJPEG_PARSER 0
+++#define CONFIG_MLP_PARSER 0
+++#define CONFIG_MPEG4VIDEO_PARSER 0
+++#define CONFIG_MPEGAUDIO_PARSER 1
+++#define CONFIG_MPEGVIDEO_PARSER 0
+++#define CONFIG_OPUS_PARSER 1
+++#define CONFIG_PNG_PARSER 0
+++#define CONFIG_PNM_PARSER 0
+++#define CONFIG_QOI_PARSER 0
+++#define CONFIG_RV34_PARSER 0
+++#define CONFIG_SBC_PARSER 0
+++#define CONFIG_SIPR_PARSER 0
+++#define CONFIG_TAK_PARSER 0
+++#define CONFIG_VC1_PARSER 0
+++#define CONFIG_VORBIS_PARSER 1
+++#define CONFIG_VP3_PARSER 0
+++#define CONFIG_VP8_PARSER 0
+++#define CONFIG_VP9_PARSER 1
+++#define CONFIG_VVC_PARSER 0
+++#define CONFIG_WEBP_PARSER 0
+++#define CONFIG_XBM_PARSER 0
+++#define CONFIG_XMA_PARSER 0
+++#define CONFIG_XWD_PARSER 0
+++#define CONFIG_ALSA_INDEV 0
+++#define CONFIG_ANDROID_CAMERA_INDEV 0
+++#define CONFIG_AVFOUNDATION_INDEV 0
+++#define CONFIG_BKTR_INDEV 0
+++#define CONFIG_DECKLINK_INDEV 0
+++#define CONFIG_DSHOW_INDEV 0
+++#define CONFIG_FBDEV_INDEV 0
+++#define CONFIG_GDIGRAB_INDEV 0
+++#define CONFIG_IEC61883_INDEV 0
+++#define CONFIG_JACK_INDEV 0
+++#define CONFIG_KMSGRAB_INDEV 0
+++#define CONFIG_LAVFI_INDEV 0
+++#define CONFIG_OPENAL_INDEV 0
+++#define CONFIG_OSS_INDEV 0
+++#define CONFIG_PULSE_INDEV 0
+++#define CONFIG_SNDIO_INDEV 0
+++#define CONFIG_V4L2_INDEV 0
+++#define CONFIG_VFWCAP_INDEV 0
+++#define CONFIG_XCBGRAB_INDEV 0
+++#define CONFIG_LIBCDIO_INDEV 0
+++#define CONFIG_LIBDC1394_INDEV 0
+++#define CONFIG_ALSA_OUTDEV 0
+++#define CONFIG_AUDIOTOOLBOX_OUTDEV 0
+++#define CONFIG_CACA_OUTDEV 0
+++#define CONFIG_DECKLINK_OUTDEV 0
+++#define CONFIG_FBDEV_OUTDEV 0
+++#define CONFIG_OPENGL_OUTDEV 0
+++#define CONFIG_OSS_OUTDEV 0
+++#define CONFIG_PULSE_OUTDEV 0
+++#define CONFIG_SDL2_OUTDEV 0
+++#define CONFIG_SNDIO_OUTDEV 0
+++#define CONFIG_V4L2_OUTDEV 0
+++#define CONFIG_XV_OUTDEV 0
+++#define CONFIG_AAP_FILTER 0
+++#define CONFIG_ABENCH_FILTER 0
+++#define CONFIG_ACOMPRESSOR_FILTER 0
+++#define CONFIG_ACONTRAST_FILTER 0
+++#define CONFIG_ACOPY_FILTER 0
+++#define CONFIG_ACUE_FILTER 0
+++#define CONFIG_ACROSSFADE_FILTER 0
+++#define CONFIG_ACROSSOVER_FILTER 0
+++#define CONFIG_ACRUSHER_FILTER 0
+++#define CONFIG_ADECLICK_FILTER 0
+++#define CONFIG_ADECLIP_FILTER 0
+++#define CONFIG_ADECORRELATE_FILTER 0
+++#define CONFIG_ADELAY_FILTER 0
+++#define CONFIG_ADENORM_FILTER 0
+++#define CONFIG_ADERIVATIVE_FILTER 0
+++#define CONFIG_ADRC_FILTER 0
+++#define CONFIG_ADYNAMICEQUALIZER_FILTER 0
+++#define CONFIG_ADYNAMICSMOOTH_FILTER 0
+++#define CONFIG_AECHO_FILTER 0
+++#define CONFIG_AEMPHASIS_FILTER 0
+++#define CONFIG_AEVAL_FILTER 0
+++#define CONFIG_AEXCITER_FILTER 0
+++#define CONFIG_AFADE_FILTER 0
+++#define CONFIG_AFFTDN_FILTER 0
+++#define CONFIG_AFFTFILT_FILTER 0
+++#define CONFIG_AFIR_FILTER 0
+++#define CONFIG_AFORMAT_FILTER 0
+++#define CONFIG_AFREQSHIFT_FILTER 0
+++#define CONFIG_AFWTDN_FILTER 0
+++#define CONFIG_AGATE_FILTER 0
+++#define CONFIG_AIIR_FILTER 0
+++#define CONFIG_AINTEGRAL_FILTER 0
+++#define CONFIG_AINTERLEAVE_FILTER 0
+++#define CONFIG_ALATENCY_FILTER 0
+++#define CONFIG_ALIMITER_FILTER 0
+++#define CONFIG_ALLPASS_FILTER 0
+++#define CONFIG_ALOOP_FILTER 0
+++#define CONFIG_AMERGE_FILTER 0
+++#define CONFIG_AMETADATA_FILTER 0
+++#define CONFIG_AMIX_FILTER 0
+++#define CONFIG_AMULTIPLY_FILTER 0
+++#define CONFIG_ANEQUALIZER_FILTER 0
+++#define CONFIG_ANLMDN_FILTER 0
+++#define CONFIG_ANLMF_FILTER 0
+++#define CONFIG_ANLMS_FILTER 0
+++#define CONFIG_ANULL_FILTER 0
+++#define CONFIG_APAD_FILTER 0
+++#define CONFIG_APERMS_FILTER 0
+++#define CONFIG_APHASER_FILTER 0
+++#define CONFIG_APHASESHIFT_FILTER 0
+++#define CONFIG_APSNR_FILTER 0
+++#define CONFIG_APSYCLIP_FILTER 0
+++#define CONFIG_APULSATOR_FILTER 0
+++#define CONFIG_AREALTIME_FILTER 0
+++#define CONFIG_ARESAMPLE_FILTER 0
+++#define CONFIG_AREVERSE_FILTER 0
+++#define CONFIG_ARLS_FILTER 0
+++#define CONFIG_ARNNDN_FILTER 0
+++#define CONFIG_ASDR_FILTER 0
+++#define CONFIG_ASEGMENT_FILTER 0
+++#define CONFIG_ASELECT_FILTER 0
+++#define CONFIG_ASENDCMD_FILTER 0
+++#define CONFIG_ASETNSAMPLES_FILTER 0
+++#define CONFIG_ASETPTS_FILTER 0
+++#define CONFIG_ASETRATE_FILTER 0
+++#define CONFIG_ASETTB_FILTER 0
+++#define CONFIG_ASHOWINFO_FILTER 0
+++#define CONFIG_ASIDEDATA_FILTER 0
+++#define CONFIG_ASISDR_FILTER 0
+++#define CONFIG_ASOFTCLIP_FILTER 0
+++#define CONFIG_ASPECTRALSTATS_FILTER 0
+++#define CONFIG_ASPLIT_FILTER 0
+++#define CONFIG_ASR_FILTER 0
+++#define CONFIG_ASTATS_FILTER 0
+++#define CONFIG_ASTREAMSELECT_FILTER 0
+++#define CONFIG_ASUBBOOST_FILTER 0
+++#define CONFIG_ASUBCUT_FILTER 0
+++#define CONFIG_ASUPERCUT_FILTER 0
+++#define CONFIG_ASUPERPASS_FILTER 0
+++#define CONFIG_ASUPERSTOP_FILTER 0
+++#define CONFIG_ATEMPO_FILTER 0
+++#define CONFIG_ATILT_FILTER 0
+++#define CONFIG_ATRIM_FILTER 0
+++#define CONFIG_AXCORRELATE_FILTER 0
+++#define CONFIG_AZMQ_FILTER 0
+++#define CONFIG_BANDPASS_FILTER 0
+++#define CONFIG_BANDREJECT_FILTER 0
+++#define CONFIG_BASS_FILTER 0
+++#define CONFIG_BIQUAD_FILTER 0
+++#define CONFIG_BS2B_FILTER 0
+++#define CONFIG_CHANNELMAP_FILTER 0
+++#define CONFIG_CHANNELSPLIT_FILTER 0
+++#define CONFIG_CHORUS_FILTER 0
+++#define CONFIG_COMPAND_FILTER 0
+++#define CONFIG_COMPENSATIONDELAY_FILTER 0
+++#define CONFIG_CROSSFEED_FILTER 0
+++#define CONFIG_CRYSTALIZER_FILTER 0
+++#define CONFIG_DCSHIFT_FILTER 0
+++#define CONFIG_DEESSER_FILTER 0
+++#define CONFIG_DIALOGUENHANCE_FILTER 0
+++#define CONFIG_DRMETER_FILTER 0
+++#define CONFIG_DYNAUDNORM_FILTER 0
+++#define CONFIG_EARWAX_FILTER 0
+++#define CONFIG_EBUR128_FILTER 0
+++#define CONFIG_EQUALIZER_FILTER 0
+++#define CONFIG_EXTRASTEREO_FILTER 0
+++#define CONFIG_FIREQUALIZER_FILTER 0
+++#define CONFIG_FLANGER_FILTER 0
+++#define CONFIG_HAAS_FILTER 0
+++#define CONFIG_HDCD_FILTER 0
+++#define CONFIG_HEADPHONE_FILTER 0
+++#define CONFIG_HIGHPASS_FILTER 0
+++#define CONFIG_HIGHSHELF_FILTER 0
+++#define CONFIG_JOIN_FILTER 0
+++#define CONFIG_LADSPA_FILTER 0
+++#define CONFIG_LOUDNORM_FILTER 0
+++#define CONFIG_LOWPASS_FILTER 0
+++#define CONFIG_LOWSHELF_FILTER 0
+++#define CONFIG_LV2_FILTER 0
+++#define CONFIG_MCOMPAND_FILTER 0
+++#define CONFIG_PAN_FILTER 0
+++#define CONFIG_REPLAYGAIN_FILTER 0
+++#define CONFIG_RUBBERBAND_FILTER 0
+++#define CONFIG_SIDECHAINCOMPRESS_FILTER 0
+++#define CONFIG_SIDECHAINGATE_FILTER 0
+++#define CONFIG_SILENCEDETECT_FILTER 0
+++#define CONFIG_SILENCEREMOVE_FILTER 0
+++#define CONFIG_SOFALIZER_FILTER 0
+++#define CONFIG_SPEECHNORM_FILTER 0
+++#define CONFIG_STEREOTOOLS_FILTER 0
+++#define CONFIG_STEREOWIDEN_FILTER 0
+++#define CONFIG_SUPEREQUALIZER_FILTER 0
+++#define CONFIG_SURROUND_FILTER 0
+++#define CONFIG_TILTSHELF_FILTER 0
+++#define CONFIG_TREBLE_FILTER 0
+++#define CONFIG_TREMOLO_FILTER 0
+++#define CONFIG_VIBRATO_FILTER 0
+++#define CONFIG_VIRTUALBASS_FILTER 0
+++#define CONFIG_VOLUME_FILTER 0
+++#define CONFIG_VOLUMEDETECT_FILTER 0
+++#define CONFIG_AEVALSRC_FILTER 0
+++#define CONFIG_AFDELAYSRC_FILTER 0
+++#define CONFIG_AFIREQSRC_FILTER 0
+++#define CONFIG_AFIRSRC_FILTER 0
+++#define CONFIG_ANOISESRC_FILTER 0
+++#define CONFIG_ANULLSRC_FILTER 0
+++#define CONFIG_FLITE_FILTER 0
+++#define CONFIG_HILBERT_FILTER 0
+++#define CONFIG_SINC_FILTER 0
+++#define CONFIG_SINE_FILTER 0
+++#define CONFIG_ANULLSINK_FILTER 0
+++#define CONFIG_ADDROI_FILTER 0
+++#define CONFIG_ALPHAEXTRACT_FILTER 0
+++#define CONFIG_ALPHAMERGE_FILTER 0
+++#define CONFIG_AMPLIFY_FILTER 0
+++#define CONFIG_ASS_FILTER 0
+++#define CONFIG_ATADENOISE_FILTER 0
+++#define CONFIG_AVGBLUR_FILTER 0
+++#define CONFIG_AVGBLUR_OPENCL_FILTER 0
+++#define CONFIG_AVGBLUR_VULKAN_FILTER 0
+++#define CONFIG_BACKGROUNDKEY_FILTER 0
+++#define CONFIG_BBOX_FILTER 0
+++#define CONFIG_BENCH_FILTER 0
+++#define CONFIG_BILATERAL_FILTER 0
+++#define CONFIG_BILATERAL_CUDA_FILTER 0
+++#define CONFIG_BITPLANENOISE_FILTER 0
+++#define CONFIG_BLACKDETECT_FILTER 0
+++#define CONFIG_BLACKFRAME_FILTER 0
+++#define CONFIG_BLEND_FILTER 0
+++#define CONFIG_BLEND_VULKAN_FILTER 0
+++#define CONFIG_BLOCKDETECT_FILTER 0
+++#define CONFIG_BLURDETECT_FILTER 0
+++#define CONFIG_BM3D_FILTER 0
+++#define CONFIG_BOXBLUR_FILTER 0
+++#define CONFIG_BOXBLUR_OPENCL_FILTER 0
+++#define CONFIG_BWDIF_FILTER 0
+++#define CONFIG_BWDIF_CUDA_FILTER 0
+++#define CONFIG_BWDIF_VULKAN_FILTER 0
+++#define CONFIG_CAS_FILTER 0
+++#define CONFIG_CCREPACK_FILTER 0
+++#define CONFIG_CHROMABER_VULKAN_FILTER 0
+++#define CONFIG_CHROMAHOLD_FILTER 0
+++#define CONFIG_CHROMAKEY_FILTER 0
+++#define CONFIG_CHROMAKEY_CUDA_FILTER 0
+++#define CONFIG_CHROMANR_FILTER 0
+++#define CONFIG_CHROMASHIFT_FILTER 0
+++#define CONFIG_CIESCOPE_FILTER 0
+++#define CONFIG_CODECVIEW_FILTER 0
+++#define CONFIG_COLORBALANCE_FILTER 0
+++#define CONFIG_COLORCHANNELMIXER_FILTER 0
+++#define CONFIG_COLORCONTRAST_FILTER 0
+++#define CONFIG_COLORCORRECT_FILTER 0
+++#define CONFIG_COLORIZE_FILTER 0
+++#define CONFIG_COLORKEY_FILTER 0
+++#define CONFIG_COLORKEY_OPENCL_FILTER 0
+++#define CONFIG_COLORHOLD_FILTER 0
+++#define CONFIG_COLORLEVELS_FILTER 0
+++#define CONFIG_COLORMAP_FILTER 0
+++#define CONFIG_COLORMATRIX_FILTER 0
+++#define CONFIG_COLORSPACE_FILTER 0
+++#define CONFIG_COLORSPACE_CUDA_FILTER 0
+++#define CONFIG_COLORTEMPERATURE_FILTER 0
+++#define CONFIG_CONVOLUTION_FILTER 0
+++#define CONFIG_CONVOLUTION_OPENCL_FILTER 0
+++#define CONFIG_CONVOLVE_FILTER 0
+++#define CONFIG_COPY_FILTER 0
+++#define CONFIG_COREIMAGE_FILTER 0
+++#define CONFIG_CORR_FILTER 0
+++#define CONFIG_COVER_RECT_FILTER 0
+++#define CONFIG_CROP_FILTER 0
+++#define CONFIG_CROPDETECT_FILTER 0
+++#define CONFIG_CUE_FILTER 0
+++#define CONFIG_CURVES_FILTER 0
+++#define CONFIG_DATASCOPE_FILTER 0
+++#define CONFIG_DBLUR_FILTER 0
+++#define CONFIG_DCTDNOIZ_FILTER 0
+++#define CONFIG_DEBAND_FILTER 0
+++#define CONFIG_DEBLOCK_FILTER 0
+++#define CONFIG_DECIMATE_FILTER 0
+++#define CONFIG_DECONVOLVE_FILTER 0
+++#define CONFIG_DEDOT_FILTER 0
+++#define CONFIG_DEFLATE_FILTER 0
+++#define CONFIG_DEFLICKER_FILTER 0
+++#define CONFIG_DEINTERLACE_QSV_FILTER 0
+++#define CONFIG_DEINTERLACE_VAAPI_FILTER 0
+++#define CONFIG_DEJUDDER_FILTER 0
+++#define CONFIG_DELOGO_FILTER 0
+++#define CONFIG_DENOISE_VAAPI_FILTER 0
+++#define CONFIG_DERAIN_FILTER 0
+++#define CONFIG_DESHAKE_FILTER 0
+++#define CONFIG_DESHAKE_OPENCL_FILTER 0
+++#define CONFIG_DESPILL_FILTER 0
+++#define CONFIG_DETELECINE_FILTER 0
+++#define CONFIG_DILATION_FILTER 0
+++#define CONFIG_DILATION_OPENCL_FILTER 0
+++#define CONFIG_DISPLACE_FILTER 0
+++#define CONFIG_DNN_CLASSIFY_FILTER 0
+++#define CONFIG_DNN_DETECT_FILTER 0
+++#define CONFIG_DNN_PROCESSING_FILTER 0
+++#define CONFIG_DOUBLEWEAVE_FILTER 0
+++#define CONFIG_DRAWBOX_FILTER 0
+++#define CONFIG_DRAWGRAPH_FILTER 0
+++#define CONFIG_DRAWGRID_FILTER 0
+++#define CONFIG_DRAWTEXT_FILTER 0
+++#define CONFIG_EDGEDETECT_FILTER 0
+++#define CONFIG_ELBG_FILTER 0
+++#define CONFIG_ENTROPY_FILTER 0
+++#define CONFIG_EPX_FILTER 0
+++#define CONFIG_EQ_FILTER 0
+++#define CONFIG_EROSION_FILTER 0
+++#define CONFIG_EROSION_OPENCL_FILTER 0
+++#define CONFIG_ESTDIF_FILTER 0
+++#define CONFIG_EXPOSURE_FILTER 0
+++#define CONFIG_EXTRACTPLANES_FILTER 0
+++#define CONFIG_FADE_FILTER 0
+++#define CONFIG_FEEDBACK_FILTER 0
+++#define CONFIG_FFTDNOIZ_FILTER 0
+++#define CONFIG_FFTFILT_FILTER 0
+++#define CONFIG_FIELD_FILTER 0
+++#define CONFIG_FIELDHINT_FILTER 0
+++#define CONFIG_FIELDMATCH_FILTER 0
+++#define CONFIG_FIELDORDER_FILTER 0
+++#define CONFIG_FILLBORDERS_FILTER 0
+++#define CONFIG_FIND_RECT_FILTER 0
+++#define CONFIG_FLIP_VULKAN_FILTER 0
+++#define CONFIG_FLOODFILL_FILTER 0
+++#define CONFIG_FORMAT_FILTER 0
+++#define CONFIG_FPS_FILTER 0
+++#define CONFIG_FRAMEPACK_FILTER 0
+++#define CONFIG_FRAMERATE_FILTER 0
+++#define CONFIG_FRAMESTEP_FILTER 0
+++#define CONFIG_FREEZEDETECT_FILTER 0
+++#define CONFIG_FREEZEFRAMES_FILTER 0
+++#define CONFIG_FREI0R_FILTER 0
+++#define CONFIG_FSPP_FILTER 0
+++#define CONFIG_FSYNC_FILTER 0
+++#define CONFIG_GBLUR_FILTER 0
+++#define CONFIG_GBLUR_VULKAN_FILTER 0
+++#define CONFIG_GEQ_FILTER 0
+++#define CONFIG_GRADFUN_FILTER 0
+++#define CONFIG_GRAPHMONITOR_FILTER 0
+++#define CONFIG_GRAYWORLD_FILTER 0
+++#define CONFIG_GREYEDGE_FILTER 0
+++#define CONFIG_GUIDED_FILTER 0
+++#define CONFIG_HALDCLUT_FILTER 0
+++#define CONFIG_HFLIP_FILTER 0
+++#define CONFIG_HFLIP_VULKAN_FILTER 0
+++#define CONFIG_HISTEQ_FILTER 0
+++#define CONFIG_HISTOGRAM_FILTER 0
+++#define CONFIG_HQDN3D_FILTER 0
+++#define CONFIG_HQX_FILTER 0
+++#define CONFIG_HSTACK_FILTER 0
+++#define CONFIG_HSVHOLD_FILTER 0
+++#define CONFIG_HSVKEY_FILTER 0
+++#define CONFIG_HUE_FILTER 0
+++#define CONFIG_HUESATURATION_FILTER 0
+++#define CONFIG_HWDOWNLOAD_FILTER 0
+++#define CONFIG_HWMAP_FILTER 0
+++#define CONFIG_HWUPLOAD_FILTER 0
+++#define CONFIG_HWUPLOAD_CUDA_FILTER 0
+++#define CONFIG_HYSTERESIS_FILTER 0
+++#define CONFIG_ICCDETECT_FILTER 0
+++#define CONFIG_ICCGEN_FILTER 0
+++#define CONFIG_IDENTITY_FILTER 0
+++#define CONFIG_IDET_FILTER 0
+++#define CONFIG_IL_FILTER 0
+++#define CONFIG_INFLATE_FILTER 0
+++#define CONFIG_INTERLACE_FILTER 0
+++#define CONFIG_INTERLEAVE_FILTER 0
+++#define CONFIG_KERNDEINT_FILTER 0
+++#define CONFIG_KIRSCH_FILTER 0
+++#define CONFIG_LAGFUN_FILTER 0
+++#define CONFIG_LATENCY_FILTER 0
+++#define CONFIG_LENSCORRECTION_FILTER 0
+++#define CONFIG_LENSFUN_FILTER 0
+++#define CONFIG_LIBPLACEBO_FILTER 0
+++#define CONFIG_LIBVMAF_FILTER 0
+++#define CONFIG_LIBVMAF_CUDA_FILTER 0
+++#define CONFIG_LIMITDIFF_FILTER 0
+++#define CONFIG_LIMITER_FILTER 0
+++#define CONFIG_LOOP_FILTER 0
+++#define CONFIG_LUMAKEY_FILTER 0
+++#define CONFIG_LUT_FILTER 0
+++#define CONFIG_LUT1D_FILTER 0
+++#define CONFIG_LUT2_FILTER 0
+++#define CONFIG_LUT3D_FILTER 0
+++#define CONFIG_LUTRGB_FILTER 0
+++#define CONFIG_LUTYUV_FILTER 0
+++#define CONFIG_MASKEDCLAMP_FILTER 0
+++#define CONFIG_MASKEDMAX_FILTER 0
+++#define CONFIG_MASKEDMERGE_FILTER 0
+++#define CONFIG_MASKEDMIN_FILTER 0
+++#define CONFIG_MASKEDTHRESHOLD_FILTER 0
+++#define CONFIG_MASKFUN_FILTER 0
+++#define CONFIG_MCDEINT_FILTER 0
+++#define CONFIG_MEDIAN_FILTER 0
+++#define CONFIG_MERGEPLANES_FILTER 0
+++#define CONFIG_MESTIMATE_FILTER 0
+++#define CONFIG_METADATA_FILTER 0
+++#define CONFIG_MIDEQUALIZER_FILTER 0
+++#define CONFIG_MINTERPOLATE_FILTER 0
+++#define CONFIG_MIX_FILTER 0
+++#define CONFIG_MONOCHROME_FILTER 0
+++#define CONFIG_MORPHO_FILTER 0
+++#define CONFIG_MPDECIMATE_FILTER 0
+++#define CONFIG_MSAD_FILTER 0
+++#define CONFIG_MULTIPLY_FILTER 0
+++#define CONFIG_NEGATE_FILTER 0
+++#define CONFIG_NLMEANS_FILTER 0
+++#define CONFIG_NLMEANS_OPENCL_FILTER 0
+++#define CONFIG_NLMEANS_VULKAN_FILTER 0
+++#define CONFIG_NNEDI_FILTER 0
+++#define CONFIG_NOFORMAT_FILTER 0
+++#define CONFIG_NOISE_FILTER 0
+++#define CONFIG_NORMALIZE_FILTER 0
+++#define CONFIG_NULL_FILTER 0
+++#define CONFIG_OCR_FILTER 0
+++#define CONFIG_OCV_FILTER 0
+++#define CONFIG_OSCILLOSCOPE_FILTER 0
+++#define CONFIG_OVERLAY_FILTER 0
+++#define CONFIG_OVERLAY_OPENCL_FILTER 0
+++#define CONFIG_OVERLAY_QSV_FILTER 0
+++#define CONFIG_OVERLAY_VAAPI_FILTER 0
+++#define CONFIG_OVERLAY_VULKAN_FILTER 0
+++#define CONFIG_OVERLAY_CUDA_FILTER 0
+++#define CONFIG_OWDENOISE_FILTER 0
+++#define CONFIG_PAD_FILTER 0
+++#define CONFIG_PAD_OPENCL_FILTER 0
+++#define CONFIG_PALETTEGEN_FILTER 0
+++#define CONFIG_PALETTEUSE_FILTER 0
+++#define CONFIG_PERMS_FILTER 0
+++#define CONFIG_PERSPECTIVE_FILTER 0
+++#define CONFIG_PHASE_FILTER 0
+++#define CONFIG_PHOTOSENSITIVITY_FILTER 0
+++#define CONFIG_PIXDESCTEST_FILTER 0
+++#define CONFIG_PIXELIZE_FILTER 0
+++#define CONFIG_PIXSCOPE_FILTER 0
+++#define CONFIG_PP_FILTER 0
+++#define CONFIG_PP7_FILTER 0
+++#define CONFIG_PREMULTIPLY_FILTER 0
+++#define CONFIG_PREWITT_FILTER 0
+++#define CONFIG_PREWITT_OPENCL_FILTER 0
+++#define CONFIG_PROCAMP_VAAPI_FILTER 0
+++#define CONFIG_PROGRAM_OPENCL_FILTER 0
+++#define CONFIG_PSEUDOCOLOR_FILTER 0
+++#define CONFIG_PSNR_FILTER 0
+++#define CONFIG_PULLUP_FILTER 0
+++#define CONFIG_QP_FILTER 0
+++#define CONFIG_QRENCODE_FILTER 0
+++#define CONFIG_QUIRC_FILTER 0
+++#define CONFIG_RANDOM_FILTER 0
+++#define CONFIG_READEIA608_FILTER 0
+++#define CONFIG_READVITC_FILTER 0
+++#define CONFIG_REALTIME_FILTER 0
+++#define CONFIG_REMAP_FILTER 0
+++#define CONFIG_REMAP_OPENCL_FILTER 0
+++#define CONFIG_REMOVEGRAIN_FILTER 0
+++#define CONFIG_REMOVELOGO_FILTER 0
+++#define CONFIG_REPEATFIELDS_FILTER 0
+++#define CONFIG_REVERSE_FILTER 0
+++#define CONFIG_RGBASHIFT_FILTER 0
+++#define CONFIG_ROBERTS_FILTER 0
+++#define CONFIG_ROBERTS_OPENCL_FILTER 0
+++#define CONFIG_ROTATE_FILTER 0
+++#define CONFIG_SAB_FILTER 0
+++#define CONFIG_SCALE_FILTER 0
+++#define CONFIG_SCALE_CUDA_FILTER 0
+++#define CONFIG_SCALE_NPP_FILTER 0
+++#define CONFIG_SCALE_QSV_FILTER 0
+++#define CONFIG_SCALE_VAAPI_FILTER 0
+++#define CONFIG_SCALE_VT_FILTER 0
+++#define CONFIG_SCALE_VULKAN_FILTER 0
+++#define CONFIG_SCALE2REF_FILTER 0
+++#define CONFIG_SCALE2REF_NPP_FILTER 0
+++#define CONFIG_SCDET_FILTER 0
+++#define CONFIG_SCHARR_FILTER 0
+++#define CONFIG_SCROLL_FILTER 0
+++#define CONFIG_SEGMENT_FILTER 0
+++#define CONFIG_SELECT_FILTER 0
+++#define CONFIG_SELECTIVECOLOR_FILTER 0
+++#define CONFIG_SENDCMD_FILTER 0
+++#define CONFIG_SEPARATEFIELDS_FILTER 0
+++#define CONFIG_SETDAR_FILTER 0
+++#define CONFIG_SETFIELD_FILTER 0
+++#define CONFIG_SETPARAMS_FILTER 0
+++#define CONFIG_SETPTS_FILTER 0
+++#define CONFIG_SETRANGE_FILTER 0
+++#define CONFIG_SETSAR_FILTER 0
+++#define CONFIG_SETTB_FILTER 0
+++#define CONFIG_SHARPEN_NPP_FILTER 0
+++#define CONFIG_SHARPNESS_VAAPI_FILTER 0
+++#define CONFIG_SHEAR_FILTER 0
+++#define CONFIG_SHOWINFO_FILTER 0
+++#define CONFIG_SHOWPALETTE_FILTER 0
+++#define CONFIG_SHUFFLEFRAMES_FILTER 0
+++#define CONFIG_SHUFFLEPIXELS_FILTER 0
+++#define CONFIG_SHUFFLEPLANES_FILTER 0
+++#define CONFIG_SIDEDATA_FILTER 0
+++#define CONFIG_SIGNALSTATS_FILTER 0
+++#define CONFIG_SIGNATURE_FILTER 0
+++#define CONFIG_SITI_FILTER 0
+++#define CONFIG_SMARTBLUR_FILTER 0
+++#define CONFIG_SOBEL_FILTER 0
+++#define CONFIG_SOBEL_OPENCL_FILTER 0
+++#define CONFIG_SPLIT_FILTER 0
+++#define CONFIG_SPP_FILTER 0
+++#define CONFIG_SR_FILTER 0
+++#define CONFIG_SSIM_FILTER 0
+++#define CONFIG_SSIM360_FILTER 0
+++#define CONFIG_STEREO3D_FILTER 0
+++#define CONFIG_STREAMSELECT_FILTER 0
+++#define CONFIG_SUBTITLES_FILTER 0
+++#define CONFIG_SUPER2XSAI_FILTER 0
+++#define CONFIG_SWAPRECT_FILTER 0
+++#define CONFIG_SWAPUV_FILTER 0
+++#define CONFIG_TBLEND_FILTER 0
+++#define CONFIG_TELECINE_FILTER 0
+++#define CONFIG_THISTOGRAM_FILTER 0
+++#define CONFIG_THRESHOLD_FILTER 0
+++#define CONFIG_THUMBNAIL_FILTER 0
+++#define CONFIG_THUMBNAIL_CUDA_FILTER 0
+++#define CONFIG_TILE_FILTER 0
+++#define CONFIG_TILTANDSHIFT_FILTER 0
+++#define CONFIG_TINTERLACE_FILTER 0
+++#define CONFIG_TLUT2_FILTER 0
+++#define CONFIG_TMEDIAN_FILTER 0
+++#define CONFIG_TMIDEQUALIZER_FILTER 0
+++#define CONFIG_TMIX_FILTER 0
+++#define CONFIG_TONEMAP_FILTER 0
+++#define CONFIG_TONEMAP_OPENCL_FILTER 0
+++#define CONFIG_TONEMAP_VAAPI_FILTER 0
+++#define CONFIG_TPAD_FILTER 0
+++#define CONFIG_TRANSPOSE_FILTER 0
+++#define CONFIG_TRANSPOSE_NPP_FILTER 0
+++#define CONFIG_TRANSPOSE_OPENCL_FILTER 0
+++#define CONFIG_TRANSPOSE_VAAPI_FILTER 0
+++#define CONFIG_TRANSPOSE_VT_FILTER 0
+++#define CONFIG_TRANSPOSE_VULKAN_FILTER 0
+++#define CONFIG_TRIM_FILTER 0
+++#define CONFIG_UNPREMULTIPLY_FILTER 0
+++#define CONFIG_UNSHARP_FILTER 0
+++#define CONFIG_UNSHARP_OPENCL_FILTER 0
+++#define CONFIG_UNTILE_FILTER 0
+++#define CONFIG_USPP_FILTER 0
+++#define CONFIG_V360_FILTER 0
+++#define CONFIG_VAGUEDENOISER_FILTER 0
+++#define CONFIG_VARBLUR_FILTER 0
+++#define CONFIG_VECTORSCOPE_FILTER 0
+++#define CONFIG_VFLIP_FILTER 0
+++#define CONFIG_VFLIP_VULKAN_FILTER 0
+++#define CONFIG_VFRDET_FILTER 0
+++#define CONFIG_VIBRANCE_FILTER 0
+++#define CONFIG_VIDSTABDETECT_FILTER 0
+++#define CONFIG_VIDSTABTRANSFORM_FILTER 0
+++#define CONFIG_VIF_FILTER 0
+++#define CONFIG_VIGNETTE_FILTER 0
+++#define CONFIG_VMAFMOTION_FILTER 0
+++#define CONFIG_VPP_QSV_FILTER 0
+++#define CONFIG_VSTACK_FILTER 0
+++#define CONFIG_W3FDIF_FILTER 0
+++#define CONFIG_WAVEFORM_FILTER 0
+++#define CONFIG_WEAVE_FILTER 0
+++#define CONFIG_XBR_FILTER 0
+++#define CONFIG_XCORRELATE_FILTER 0
+++#define CONFIG_XFADE_FILTER 0
+++#define CONFIG_XFADE_OPENCL_FILTER 0
+++#define CONFIG_XFADE_VULKAN_FILTER 0
+++#define CONFIG_XMEDIAN_FILTER 0
+++#define CONFIG_XSTACK_FILTER 0
+++#define CONFIG_YADIF_FILTER 0
+++#define CONFIG_YADIF_CUDA_FILTER 0
+++#define CONFIG_YADIF_VIDEOTOOLBOX_FILTER 0
+++#define CONFIG_YAEPBLUR_FILTER 0
+++#define CONFIG_ZMQ_FILTER 0
+++#define CONFIG_ZOOMPAN_FILTER 0
+++#define CONFIG_ZSCALE_FILTER 0
+++#define CONFIG_HSTACK_VAAPI_FILTER 0
+++#define CONFIG_VSTACK_VAAPI_FILTER 0
+++#define CONFIG_XSTACK_VAAPI_FILTER 0
+++#define CONFIG_HSTACK_QSV_FILTER 0
+++#define CONFIG_VSTACK_QSV_FILTER 0
+++#define CONFIG_XSTACK_QSV_FILTER 0
+++#define CONFIG_ALLRGB_FILTER 0
+++#define CONFIG_ALLYUV_FILTER 0
+++#define CONFIG_CELLAUTO_FILTER 0
+++#define CONFIG_COLOR_FILTER 0
+++#define CONFIG_COLOR_VULKAN_FILTER 0
+++#define CONFIG_COLORCHART_FILTER 0
+++#define CONFIG_COLORSPECTRUM_FILTER 0
+++#define CONFIG_COREIMAGESRC_FILTER 0
+++#define CONFIG_DDAGRAB_FILTER 0
+++#define CONFIG_FREI0R_SRC_FILTER 0
+++#define CONFIG_GRADIENTS_FILTER 0
+++#define CONFIG_HALDCLUTSRC_FILTER 0
+++#define CONFIG_LIFE_FILTER 0
+++#define CONFIG_MANDELBROT_FILTER 0
+++#define CONFIG_MPTESTSRC_FILTER 0
+++#define CONFIG_NULLSRC_FILTER 0
+++#define CONFIG_OPENCLSRC_FILTER 0
+++#define CONFIG_QRENCODESRC_FILTER 0
+++#define CONFIG_PAL75BARS_FILTER 0
+++#define CONFIG_PAL100BARS_FILTER 0
+++#define CONFIG_RGBTESTSRC_FILTER 0
+++#define CONFIG_SIERPINSKI_FILTER 0
+++#define CONFIG_SMPTEBARS_FILTER 0
+++#define CONFIG_SMPTEHDBARS_FILTER 0
+++#define CONFIG_TESTSRC_FILTER 0
+++#define CONFIG_TESTSRC2_FILTER 0
+++#define CONFIG_YUVTESTSRC_FILTER 0
+++#define CONFIG_ZONEPLATE_FILTER 0
+++#define CONFIG_NULLSINK_FILTER 0
+++#define CONFIG_A3DSCOPE_FILTER 0
+++#define CONFIG_ABITSCOPE_FILTER 0
+++#define CONFIG_ADRAWGRAPH_FILTER 0
+++#define CONFIG_AGRAPHMONITOR_FILTER 0
+++#define CONFIG_AHISTOGRAM_FILTER 0
+++#define CONFIG_APHASEMETER_FILTER 0
+++#define CONFIG_AVECTORSCOPE_FILTER 0
+++#define CONFIG_CONCAT_FILTER 0
+++#define CONFIG_SHOWCQT_FILTER 0
+++#define CONFIG_SHOWCWT_FILTER 0
+++#define CONFIG_SHOWFREQS_FILTER 0
+++#define CONFIG_SHOWSPATIAL_FILTER 0
+++#define CONFIG_SHOWSPECTRUM_FILTER 0
+++#define CONFIG_SHOWSPECTRUMPIC_FILTER 0
+++#define CONFIG_SHOWVOLUME_FILTER 0
+++#define CONFIG_SHOWWAVES_FILTER 0
+++#define CONFIG_SHOWWAVESPIC_FILTER 0
+++#define CONFIG_SPECTRUMSYNTH_FILTER 0
+++#define CONFIG_AVSYNCTEST_FILTER 0
+++#define CONFIG_AMOVIE_FILTER 0
+++#define CONFIG_MOVIE_FILTER 0
+++#define CONFIG_AA_DEMUXER 0
+++#define CONFIG_AAC_DEMUXER 1
+++#define CONFIG_AAX_DEMUXER 0
+++#define CONFIG_AC3_DEMUXER 0
+++#define CONFIG_AC4_DEMUXER 0
+++#define CONFIG_ACE_DEMUXER 0
+++#define CONFIG_ACM_DEMUXER 0
+++#define CONFIG_ACT_DEMUXER 0
+++#define CONFIG_ADF_DEMUXER 0
+++#define CONFIG_ADP_DEMUXER 0
+++#define CONFIG_ADS_DEMUXER 0
+++#define CONFIG_ADX_DEMUXER 0
+++#define CONFIG_AEA_DEMUXER 0
+++#define CONFIG_AFC_DEMUXER 0
+++#define CONFIG_AIFF_DEMUXER 0
+++#define CONFIG_AIX_DEMUXER 0
+++#define CONFIG_ALP_DEMUXER 0
+++#define CONFIG_AMR_DEMUXER 0
+++#define CONFIG_AMRNB_DEMUXER 0
+++#define CONFIG_AMRWB_DEMUXER 0
+++#define CONFIG_ANM_DEMUXER 0
+++#define CONFIG_APAC_DEMUXER 0
+++#define CONFIG_APC_DEMUXER 0
+++#define CONFIG_APE_DEMUXER 0
+++#define CONFIG_APM_DEMUXER 0
+++#define CONFIG_APNG_DEMUXER 0
+++#define CONFIG_APTX_DEMUXER 0
+++#define CONFIG_APTX_HD_DEMUXER 0
+++#define CONFIG_AQTITLE_DEMUXER 0
+++#define CONFIG_ARGO_ASF_DEMUXER 0
+++#define CONFIG_ARGO_BRP_DEMUXER 0
+++#define CONFIG_ARGO_CVG_DEMUXER 0
+++#define CONFIG_ASF_DEMUXER 0
+++#define CONFIG_ASF_O_DEMUXER 0
+++#define CONFIG_ASS_DEMUXER 0
+++#define CONFIG_AST_DEMUXER 0
+++#define CONFIG_AU_DEMUXER 0
+++#define CONFIG_AV1_DEMUXER 0
+++#define CONFIG_AVI_DEMUXER 0
+++#define CONFIG_AVISYNTH_DEMUXER 0
+++#define CONFIG_AVR_DEMUXER 0
+++#define CONFIG_AVS_DEMUXER 0
+++#define CONFIG_AVS2_DEMUXER 0
+++#define CONFIG_AVS3_DEMUXER 0
+++#define CONFIG_BETHSOFTVID_DEMUXER 0
+++#define CONFIG_BFI_DEMUXER 0
+++#define CONFIG_BINTEXT_DEMUXER 0
+++#define CONFIG_BINK_DEMUXER 0
+++#define CONFIG_BINKA_DEMUXER 0
+++#define CONFIG_BIT_DEMUXER 0
+++#define CONFIG_BITPACKED_DEMUXER 0
+++#define CONFIG_BMV_DEMUXER 0
+++#define CONFIG_BFSTM_DEMUXER 0
+++#define CONFIG_BRSTM_DEMUXER 0
+++#define CONFIG_BOA_DEMUXER 0
+++#define CONFIG_BONK_DEMUXER 0
+++#define CONFIG_C93_DEMUXER 0
+++#define CONFIG_CAF_DEMUXER 0
+++#define CONFIG_CAVSVIDEO_DEMUXER 0
+++#define CONFIG_CDG_DEMUXER 0
+++#define CONFIG_CDXL_DEMUXER 0
+++#define CONFIG_CINE_DEMUXER 0
+++#define CONFIG_CODEC2_DEMUXER 0
+++#define CONFIG_CODEC2RAW_DEMUXER 0
+++#define CONFIG_CONCAT_DEMUXER 0
+++#define CONFIG_DASH_DEMUXER 0
+++#define CONFIG_DATA_DEMUXER 0
+++#define CONFIG_DAUD_DEMUXER 0
+++#define CONFIG_DCSTR_DEMUXER 0
+++#define CONFIG_DERF_DEMUXER 0
+++#define CONFIG_DFA_DEMUXER 0
+++#define CONFIG_DFPWM_DEMUXER 0
+++#define CONFIG_DHAV_DEMUXER 0
+++#define CONFIG_DIRAC_DEMUXER 0
+++#define CONFIG_DNXHD_DEMUXER 0
+++#define CONFIG_DSF_DEMUXER 0
+++#define CONFIG_DSICIN_DEMUXER 0
+++#define CONFIG_DSS_DEMUXER 0
+++#define CONFIG_DTS_DEMUXER 0
+++#define CONFIG_DTSHD_DEMUXER 0
+++#define CONFIG_DV_DEMUXER 0
+++#define CONFIG_DVBSUB_DEMUXER 0
+++#define CONFIG_DVBTXT_DEMUXER 0
+++#define CONFIG_DXA_DEMUXER 0
+++#define CONFIG_EA_DEMUXER 0
+++#define CONFIG_EA_CDATA_DEMUXER 0
+++#define CONFIG_EAC3_DEMUXER 0
+++#define CONFIG_EPAF_DEMUXER 0
+++#define CONFIG_EVC_DEMUXER 0
+++#define CONFIG_FFMETADATA_DEMUXER 0
+++#define CONFIG_FILMSTRIP_DEMUXER 0
+++#define CONFIG_FITS_DEMUXER 0
+++#define CONFIG_FLAC_DEMUXER 1
+++#define CONFIG_FLIC_DEMUXER 0
+++#define CONFIG_FLV_DEMUXER 0
+++#define CONFIG_LIVE_FLV_DEMUXER 0
+++#define CONFIG_FOURXM_DEMUXER 0
+++#define CONFIG_FRM_DEMUXER 0
+++#define CONFIG_FSB_DEMUXER 0
+++#define CONFIG_FWSE_DEMUXER 0
+++#define CONFIG_G722_DEMUXER 0
+++#define CONFIG_G723_1_DEMUXER 0
+++#define CONFIG_G726_DEMUXER 0
+++#define CONFIG_G726LE_DEMUXER 0
+++#define CONFIG_G729_DEMUXER 0
+++#define CONFIG_GDV_DEMUXER 0
+++#define CONFIG_GENH_DEMUXER 0
+++#define CONFIG_GIF_DEMUXER 0
+++#define CONFIG_GSM_DEMUXER 0
+++#define CONFIG_GXF_DEMUXER 0
+++#define CONFIG_H261_DEMUXER 0
+++#define CONFIG_H263_DEMUXER 0
+++#define CONFIG_H264_DEMUXER 0
+++#define CONFIG_HCA_DEMUXER 0
+++#define CONFIG_HCOM_DEMUXER 0
+++#define CONFIG_HEVC_DEMUXER 0
+++#define CONFIG_HLS_DEMUXER 0
+++#define CONFIG_HNM_DEMUXER 0
+++#define CONFIG_IAMF_DEMUXER 0
+++#define CONFIG_ICO_DEMUXER 0
+++#define CONFIG_IDCIN_DEMUXER 0
+++#define CONFIG_IDF_DEMUXER 0
+++#define CONFIG_IFF_DEMUXER 0
+++#define CONFIG_IFV_DEMUXER 0
+++#define CONFIG_ILBC_DEMUXER 0
+++#define CONFIG_IMAGE2_DEMUXER 0
+++#define CONFIG_IMAGE2PIPE_DEMUXER 0
+++#define CONFIG_IMAGE2_ALIAS_PIX_DEMUXER 0
+++#define CONFIG_IMAGE2_BRENDER_PIX_DEMUXER 0
+++#define CONFIG_IMF_DEMUXER 0
+++#define CONFIG_INGENIENT_DEMUXER 0
+++#define CONFIG_IPMOVIE_DEMUXER 0
+++#define CONFIG_IPU_DEMUXER 0
+++#define CONFIG_IRCAM_DEMUXER 0
+++#define CONFIG_ISS_DEMUXER 0
+++#define CONFIG_IV8_DEMUXER 0
+++#define CONFIG_IVF_DEMUXER 0
+++#define CONFIG_IVR_DEMUXER 0
+++#define CONFIG_JACOSUB_DEMUXER 0
+++#define CONFIG_JV_DEMUXER 0
+++#define CONFIG_JPEGXL_ANIM_DEMUXER 0
+++#define CONFIG_KUX_DEMUXER 0
+++#define CONFIG_KVAG_DEMUXER 0
+++#define CONFIG_LAF_DEMUXER 0
+++#define CONFIG_LMLM4_DEMUXER 0
+++#define CONFIG_LOAS_DEMUXER 0
+++#define CONFIG_LUODAT_DEMUXER 0
+++#define CONFIG_LRC_DEMUXER 0
+++#define CONFIG_LVF_DEMUXER 0
+++#define CONFIG_LXF_DEMUXER 0
+++#define CONFIG_M4V_DEMUXER 0
+++#define CONFIG_MCA_DEMUXER 0
+++#define CONFIG_MCC_DEMUXER 0
+++#define CONFIG_MATROSKA_DEMUXER 1
+++#define CONFIG_MGSTS_DEMUXER 0
+++#define CONFIG_MICRODVD_DEMUXER 0
+++#define CONFIG_MJPEG_DEMUXER 0
+++#define CONFIG_MJPEG_2000_DEMUXER 0
+++#define CONFIG_MLP_DEMUXER 0
+++#define CONFIG_MLV_DEMUXER 0
+++#define CONFIG_MM_DEMUXER 0
+++#define CONFIG_MMF_DEMUXER 0
+++#define CONFIG_MODS_DEMUXER 0
+++#define CONFIG_MOFLEX_DEMUXER 0
+++#define CONFIG_MOV_DEMUXER 1
+++#define CONFIG_MP3_DEMUXER 1
+++#define CONFIG_MPC_DEMUXER 0
+++#define CONFIG_MPC8_DEMUXER 0
+++#define CONFIG_MPEGPS_DEMUXER 0
+++#define CONFIG_MPEGTS_DEMUXER 0
+++#define CONFIG_MPEGTSRAW_DEMUXER 0
+++#define CONFIG_MPEGVIDEO_DEMUXER 0
+++#define CONFIG_MPJPEG_DEMUXER 0
+++#define CONFIG_MPL2_DEMUXER 0
+++#define CONFIG_MPSUB_DEMUXER 0
+++#define CONFIG_MSF_DEMUXER 0
+++#define CONFIG_MSNWC_TCP_DEMUXER 0
+++#define CONFIG_MSP_DEMUXER 0
+++#define CONFIG_MTAF_DEMUXER 0
+++#define CONFIG_MTV_DEMUXER 0
+++#define CONFIG_MUSX_DEMUXER 0
+++#define CONFIG_MV_DEMUXER 0
+++#define CONFIG_MVI_DEMUXER 0
+++#define CONFIG_MXF_DEMUXER 0
+++#define CONFIG_MXG_DEMUXER 0
+++#define CONFIG_NC_DEMUXER 0
+++#define CONFIG_NISTSPHERE_DEMUXER 0
+++#define CONFIG_NSP_DEMUXER 0
+++#define CONFIG_NSV_DEMUXER 0
+++#define CONFIG_NUT_DEMUXER 0
+++#define CONFIG_NUV_DEMUXER 0
+++#define CONFIG_OBU_DEMUXER 0
+++#define CONFIG_OGG_DEMUXER 1
+++#define CONFIG_OMA_DEMUXER 0
+++#define CONFIG_OSQ_DEMUXER 0
+++#define CONFIG_PAF_DEMUXER 0
+++#define CONFIG_PCM_ALAW_DEMUXER 0
+++#define CONFIG_PCM_MULAW_DEMUXER 0
+++#define CONFIG_PCM_VIDC_DEMUXER 0
+++#define CONFIG_PCM_F64BE_DEMUXER 0
+++#define CONFIG_PCM_F64LE_DEMUXER 0
+++#define CONFIG_PCM_F32BE_DEMUXER 0
+++#define CONFIG_PCM_F32LE_DEMUXER 0
+++#define CONFIG_PCM_S32BE_DEMUXER 0
+++#define CONFIG_PCM_S32LE_DEMUXER 0
+++#define CONFIG_PCM_S24BE_DEMUXER 0
+++#define CONFIG_PCM_S24LE_DEMUXER 0
+++#define CONFIG_PCM_S16BE_DEMUXER 0
+++#define CONFIG_PCM_S16LE_DEMUXER 0
+++#define CONFIG_PCM_S8_DEMUXER 0
+++#define CONFIG_PCM_U32BE_DEMUXER 0
+++#define CONFIG_PCM_U32LE_DEMUXER 0
+++#define CONFIG_PCM_U24BE_DEMUXER 0
+++#define CONFIG_PCM_U24LE_DEMUXER 0
+++#define CONFIG_PCM_U16BE_DEMUXER 0
+++#define CONFIG_PCM_U16LE_DEMUXER 0
+++#define CONFIG_PCM_U8_DEMUXER 0
+++#define CONFIG_PDV_DEMUXER 0
+++#define CONFIG_PJS_DEMUXER 0
+++#define CONFIG_PMP_DEMUXER 0
+++#define CONFIG_PP_BNK_DEMUXER 0
+++#define CONFIG_PVA_DEMUXER 0
+++#define CONFIG_PVF_DEMUXER 0
+++#define CONFIG_QCP_DEMUXER 0
+++#define CONFIG_QOA_DEMUXER 0
+++#define CONFIG_R3D_DEMUXER 0
+++#define CONFIG_RAWVIDEO_DEMUXER 0
+++#define CONFIG_REALTEXT_DEMUXER 0
+++#define CONFIG_REDSPARK_DEMUXER 0
+++#define CONFIG_RKA_DEMUXER 0
+++#define CONFIG_RL2_DEMUXER 0
+++#define CONFIG_RM_DEMUXER 0
+++#define CONFIG_ROQ_DEMUXER 0
+++#define CONFIG_RPL_DEMUXER 0
+++#define CONFIG_RSD_DEMUXER 0
+++#define CONFIG_RSO_DEMUXER 0
+++#define CONFIG_RTP_DEMUXER 0
+++#define CONFIG_RTSP_DEMUXER 0
+++#define CONFIG_S337M_DEMUXER 0
+++#define CONFIG_SAMI_DEMUXER 0
+++#define CONFIG_SAP_DEMUXER 0
+++#define CONFIG_SBC_DEMUXER 0
+++#define CONFIG_SBG_DEMUXER 0
+++#define CONFIG_SCC_DEMUXER 0
+++#define CONFIG_SCD_DEMUXER 0
+++#define CONFIG_SDNS_DEMUXER 0
+++#define CONFIG_SDP_DEMUXER 0
+++#define CONFIG_SDR2_DEMUXER 0
+++#define CONFIG_SDS_DEMUXER 0
+++#define CONFIG_SDX_DEMUXER 0
+++#define CONFIG_SEGAFILM_DEMUXER 0
+++#define CONFIG_SER_DEMUXER 0
+++#define CONFIG_SGA_DEMUXER 0
+++#define CONFIG_SHORTEN_DEMUXER 0
+++#define CONFIG_SIFF_DEMUXER 0
+++#define CONFIG_SIMBIOSIS_IMX_DEMUXER 0
+++#define CONFIG_SLN_DEMUXER 0
+++#define CONFIG_SMACKER_DEMUXER 0
+++#define CONFIG_SMJPEG_DEMUXER 0
+++#define CONFIG_SMUSH_DEMUXER 0
+++#define CONFIG_SOL_DEMUXER 0
+++#define CONFIG_SOX_DEMUXER 0
+++#define CONFIG_SPDIF_DEMUXER 0
+++#define CONFIG_SRT_DEMUXER 0
+++#define CONFIG_STR_DEMUXER 0
+++#define CONFIG_STL_DEMUXER 0
+++#define CONFIG_SUBVIEWER1_DEMUXER 0
+++#define CONFIG_SUBVIEWER_DEMUXER 0
+++#define CONFIG_SUP_DEMUXER 0
+++#define CONFIG_SVAG_DEMUXER 0
+++#define CONFIG_SVS_DEMUXER 0
+++#define CONFIG_SWF_DEMUXER 0
+++#define CONFIG_TAK_DEMUXER 0
+++#define CONFIG_TEDCAPTIONS_DEMUXER 0
+++#define CONFIG_THP_DEMUXER 0
+++#define CONFIG_THREEDOSTR_DEMUXER 0
+++#define CONFIG_TIERTEXSEQ_DEMUXER 0
+++#define CONFIG_TMV_DEMUXER 0
+++#define CONFIG_TRUEHD_DEMUXER 0
+++#define CONFIG_TTA_DEMUXER 0
+++#define CONFIG_TXD_DEMUXER 0
+++#define CONFIG_TTY_DEMUXER 0
+++#define CONFIG_TY_DEMUXER 0
+++#define CONFIG_USM_DEMUXER 0
+++#define CONFIG_V210_DEMUXER 0
+++#define CONFIG_V210X_DEMUXER 0
+++#define CONFIG_VAG_DEMUXER 0
+++#define CONFIG_VC1_DEMUXER 0
+++#define CONFIG_VC1T_DEMUXER 0
+++#define CONFIG_VIVIDAS_DEMUXER 0
+++#define CONFIG_VIVO_DEMUXER 0
+++#define CONFIG_VMD_DEMUXER 0
+++#define CONFIG_VOBSUB_DEMUXER 0
+++#define CONFIG_VOC_DEMUXER 0
+++#define CONFIG_VPK_DEMUXER 0
+++#define CONFIG_VPLAYER_DEMUXER 0
+++#define CONFIG_VQF_DEMUXER 0
+++#define CONFIG_VVC_DEMUXER 0
+++#define CONFIG_W64_DEMUXER 0
+++#define CONFIG_WADY_DEMUXER 0
+++#define CONFIG_WAVARC_DEMUXER 0
+++#define CONFIG_WAV_DEMUXER 1
+++#define CONFIG_WC3_DEMUXER 0
+++#define CONFIG_WEBM_DASH_MANIFEST_DEMUXER 0
+++#define CONFIG_WEBVTT_DEMUXER 0
+++#define CONFIG_WSAUD_DEMUXER 0
+++#define CONFIG_WSD_DEMUXER 0
+++#define CONFIG_WSVQA_DEMUXER 0
+++#define CONFIG_WTV_DEMUXER 0
+++#define CONFIG_WVE_DEMUXER 0
+++#define CONFIG_WV_DEMUXER 0
+++#define CONFIG_XA_DEMUXER 0
+++#define CONFIG_XBIN_DEMUXER 0
+++#define CONFIG_XMD_DEMUXER 0
+++#define CONFIG_XMV_DEMUXER 0
+++#define CONFIG_XVAG_DEMUXER 0
+++#define CONFIG_XWMA_DEMUXER 0
+++#define CONFIG_YOP_DEMUXER 0
+++#define CONFIG_YUV4MPEGPIPE_DEMUXER 0
+++#define CONFIG_IMAGE_BMP_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_CRI_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_DDS_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_DPX_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_EXR_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_GEM_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_GIF_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_HDR_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_J2K_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_JPEG_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_JPEGLS_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_JPEGXL_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PAM_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PBM_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PCX_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PFM_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PGMYUV_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PGM_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PGX_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PHM_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PHOTOCD_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PICTOR_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PNG_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PPM_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PSD_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_QDRAW_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_QOI_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_SGI_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_SVG_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_SUNRAST_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_TIFF_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_VBN_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_WEBP_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_XBM_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_XPM_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_XWD_PIPE_DEMUXER 0
+++#define CONFIG_LIBGME_DEMUXER 0
+++#define CONFIG_LIBMODPLUG_DEMUXER 0
+++#define CONFIG_LIBOPENMPT_DEMUXER 0
+++#define CONFIG_VAPOURSYNTH_DEMUXER 0
+++#define CONFIG_A64_MUXER 0
+++#define CONFIG_AC3_MUXER 0
+++#define CONFIG_AC4_MUXER 0
+++#define CONFIG_ADTS_MUXER 0
+++#define CONFIG_ADX_MUXER 0
+++#define CONFIG_AIFF_MUXER 0
+++#define CONFIG_ALP_MUXER 0
+++#define CONFIG_AMR_MUXER 0
+++#define CONFIG_AMV_MUXER 0
+++#define CONFIG_APM_MUXER 0
+++#define CONFIG_APNG_MUXER 0
+++#define CONFIG_APTX_MUXER 0
+++#define CONFIG_APTX_HD_MUXER 0
+++#define CONFIG_ARGO_ASF_MUXER 0
+++#define CONFIG_ARGO_CVG_MUXER 0
+++#define CONFIG_ASF_MUXER 0
+++#define CONFIG_ASS_MUXER 0
+++#define CONFIG_AST_MUXER 0
+++#define CONFIG_ASF_STREAM_MUXER 0
+++#define CONFIG_AU_MUXER 0
+++#define CONFIG_AVI_MUXER 0
+++#define CONFIG_AVIF_MUXER 0
+++#define CONFIG_AVM2_MUXER 0
+++#define CONFIG_AVS2_MUXER 0
+++#define CONFIG_AVS3_MUXER 0
+++#define CONFIG_BIT_MUXER 0
+++#define CONFIG_CAF_MUXER 0
+++#define CONFIG_CAVSVIDEO_MUXER 0
+++#define CONFIG_CODEC2_MUXER 0
+++#define CONFIG_CODEC2RAW_MUXER 0
+++#define CONFIG_CRC_MUXER 0
+++#define CONFIG_DASH_MUXER 0
+++#define CONFIG_DATA_MUXER 0
+++#define CONFIG_DAUD_MUXER 0
+++#define CONFIG_DFPWM_MUXER 0
+++#define CONFIG_DIRAC_MUXER 0
+++#define CONFIG_DNXHD_MUXER 0
+++#define CONFIG_DTS_MUXER 0
+++#define CONFIG_DV_MUXER 0
+++#define CONFIG_EAC3_MUXER 0
+++#define CONFIG_EVC_MUXER 0
+++#define CONFIG_F4V_MUXER 0
+++#define CONFIG_FFMETADATA_MUXER 0
+++#define CONFIG_FIFO_MUXER 0
+++#define CONFIG_FIFO_TEST_MUXER 0
+++#define CONFIG_FILMSTRIP_MUXER 0
+++#define CONFIG_FITS_MUXER 0
+++#define CONFIG_FLAC_MUXER 0
+++#define CONFIG_FLV_MUXER 0
+++#define CONFIG_FRAMECRC_MUXER 0
+++#define CONFIG_FRAMEHASH_MUXER 0
+++#define CONFIG_FRAMEMD5_MUXER 0
+++#define CONFIG_G722_MUXER 0
+++#define CONFIG_G723_1_MUXER 0
+++#define CONFIG_G726_MUXER 0
+++#define CONFIG_G726LE_MUXER 0
+++#define CONFIG_GIF_MUXER 0
+++#define CONFIG_GSM_MUXER 0
+++#define CONFIG_GXF_MUXER 0
+++#define CONFIG_H261_MUXER 0
+++#define CONFIG_H263_MUXER 0
+++#define CONFIG_H264_MUXER 0
+++#define CONFIG_HASH_MUXER 0
+++#define CONFIG_HDS_MUXER 0
+++#define CONFIG_HEVC_MUXER 0
+++#define CONFIG_HLS_MUXER 0
+++#define CONFIG_IAMF_MUXER 0
+++#define CONFIG_ICO_MUXER 0
+++#define CONFIG_ILBC_MUXER 0
+++#define CONFIG_IMAGE2_MUXER 0
+++#define CONFIG_IMAGE2PIPE_MUXER 0
+++#define CONFIG_IPOD_MUXER 0
+++#define CONFIG_IRCAM_MUXER 0
+++#define CONFIG_ISMV_MUXER 0
+++#define CONFIG_IVF_MUXER 0
+++#define CONFIG_JACOSUB_MUXER 0
+++#define CONFIG_KVAG_MUXER 0
+++#define CONFIG_LATM_MUXER 0
+++#define CONFIG_LRC_MUXER 0
+++#define CONFIG_M4V_MUXER 0
+++#define CONFIG_MD5_MUXER 0
+++#define CONFIG_MATROSKA_MUXER 0
+++#define CONFIG_MATROSKA_AUDIO_MUXER 0
+++#define CONFIG_MICRODVD_MUXER 0
+++#define CONFIG_MJPEG_MUXER 0
+++#define CONFIG_MLP_MUXER 0
+++#define CONFIG_MMF_MUXER 0
+++#define CONFIG_MOV_MUXER 0
+++#define CONFIG_MP2_MUXER 0
+++#define CONFIG_MP3_MUXER 0
+++#define CONFIG_MP4_MUXER 0
+++#define CONFIG_MPEG1SYSTEM_MUXER 0
+++#define CONFIG_MPEG1VCD_MUXER 0
+++#define CONFIG_MPEG1VIDEO_MUXER 0
+++#define CONFIG_MPEG2DVD_MUXER 0
+++#define CONFIG_MPEG2SVCD_MUXER 0
+++#define CONFIG_MPEG2VIDEO_MUXER 0
+++#define CONFIG_MPEG2VOB_MUXER 0
+++#define CONFIG_MPEGTS_MUXER 0
+++#define CONFIG_MPJPEG_MUXER 0
+++#define CONFIG_MXF_MUXER 0
+++#define CONFIG_MXF_D10_MUXER 0
+++#define CONFIG_MXF_OPATOM_MUXER 0
+++#define CONFIG_NULL_MUXER 0
+++#define CONFIG_NUT_MUXER 0
+++#define CONFIG_OBU_MUXER 0
+++#define CONFIG_OGA_MUXER 0
+++#define CONFIG_OGG_MUXER 0
+++#define CONFIG_OGV_MUXER 0
+++#define CONFIG_OMA_MUXER 0
+++#define CONFIG_OPUS_MUXER 0
+++#define CONFIG_PCM_ALAW_MUXER 0
+++#define CONFIG_PCM_MULAW_MUXER 0
+++#define CONFIG_PCM_VIDC_MUXER 0
+++#define CONFIG_PCM_F64BE_MUXER 0
+++#define CONFIG_PCM_F64LE_MUXER 0
+++#define CONFIG_PCM_F32BE_MUXER 0
+++#define CONFIG_PCM_F32LE_MUXER 0
+++#define CONFIG_PCM_S32BE_MUXER 0
+++#define CONFIG_PCM_S32LE_MUXER 0
+++#define CONFIG_PCM_S24BE_MUXER 0
+++#define CONFIG_PCM_S24LE_MUXER 0
+++#define CONFIG_PCM_S16BE_MUXER 0
+++#define CONFIG_PCM_S16LE_MUXER 0
+++#define CONFIG_PCM_S8_MUXER 0
+++#define CONFIG_PCM_U32BE_MUXER 0
+++#define CONFIG_PCM_U32LE_MUXER 0
+++#define CONFIG_PCM_U24BE_MUXER 0
+++#define CONFIG_PCM_U24LE_MUXER 0
+++#define CONFIG_PCM_U16BE_MUXER 0
+++#define CONFIG_PCM_U16LE_MUXER 0
+++#define CONFIG_PCM_U8_MUXER 0
+++#define CONFIG_PSP_MUXER 0
+++#define CONFIG_RAWVIDEO_MUXER 0
+++#define CONFIG_RCWT_MUXER 0
+++#define CONFIG_RM_MUXER 0
+++#define CONFIG_ROQ_MUXER 0
+++#define CONFIG_RSO_MUXER 0
+++#define CONFIG_RTP_MUXER 0
+++#define CONFIG_RTP_MPEGTS_MUXER 0
+++#define CONFIG_RTSP_MUXER 0
+++#define CONFIG_SAP_MUXER 0
+++#define CONFIG_SBC_MUXER 0
+++#define CONFIG_SCC_MUXER 0
+++#define CONFIG_SEGAFILM_MUXER 0
+++#define CONFIG_SEGMENT_MUXER 0
+++#define CONFIG_STREAM_SEGMENT_MUXER 0
+++#define CONFIG_SMJPEG_MUXER 0
+++#define CONFIG_SMOOTHSTREAMING_MUXER 0
+++#define CONFIG_SOX_MUXER 0
+++#define CONFIG_SPX_MUXER 0
+++#define CONFIG_SPDIF_MUXER 0
+++#define CONFIG_SRT_MUXER 0
+++#define CONFIG_STREAMHASH_MUXER 0
+++#define CONFIG_SUP_MUXER 0
+++#define CONFIG_SWF_MUXER 0
+++#define CONFIG_TEE_MUXER 0
+++#define CONFIG_TG2_MUXER 0
+++#define CONFIG_TGP_MUXER 0
+++#define CONFIG_MKVTIMESTAMP_V2_MUXER 0
+++#define CONFIG_TRUEHD_MUXER 0
+++#define CONFIG_TTA_MUXER 0
+++#define CONFIG_TTML_MUXER 0
+++#define CONFIG_UNCODEDFRAMECRC_MUXER 0
+++#define CONFIG_VC1_MUXER 0
+++#define CONFIG_VC1T_MUXER 0
+++#define CONFIG_VOC_MUXER 0
+++#define CONFIG_VVC_MUXER 0
+++#define CONFIG_W64_MUXER 0
+++#define CONFIG_WAV_MUXER 0
+++#define CONFIG_WEBM_MUXER 0
+++#define CONFIG_WEBM_DASH_MANIFEST_MUXER 0
+++#define CONFIG_WEBM_CHUNK_MUXER 0
+++#define CONFIG_WEBP_MUXER 0
+++#define CONFIG_WEBVTT_MUXER 0
+++#define CONFIG_WSAUD_MUXER 0
+++#define CONFIG_WTV_MUXER 0
+++#define CONFIG_WV_MUXER 0
+++#define CONFIG_YUV4MPEGPIPE_MUXER 0
+++#define CONFIG_CHROMAPRINT_MUXER 0
+++#define CONFIG_ASYNC_PROTOCOL 0
+++#define CONFIG_BLURAY_PROTOCOL 0
+++#define CONFIG_CACHE_PROTOCOL 0
+++#define CONFIG_CONCAT_PROTOCOL 0
+++#define CONFIG_CONCATF_PROTOCOL 0
+++#define CONFIG_CRYPTO_PROTOCOL 0
+++#define CONFIG_DATA_PROTOCOL 0
+++#define CONFIG_FD_PROTOCOL 0
+++#define CONFIG_FFRTMPCRYPT_PROTOCOL 0
+++#define CONFIG_FFRTMPHTTP_PROTOCOL 0
+++#define CONFIG_FILE_PROTOCOL 0
+++#define CONFIG_FTP_PROTOCOL 0
+++#define CONFIG_GOPHER_PROTOCOL 0
+++#define CONFIG_GOPHERS_PROTOCOL 0
+++#define CONFIG_HLS_PROTOCOL 0
+++#define CONFIG_HTTP_PROTOCOL 0
+++#define CONFIG_HTTPPROXY_PROTOCOL 0
+++#define CONFIG_HTTPS_PROTOCOL 0
+++#define CONFIG_ICECAST_PROTOCOL 0
+++#define CONFIG_MMSH_PROTOCOL 0
+++#define CONFIG_MMST_PROTOCOL 0
+++#define CONFIG_MD5_PROTOCOL 0
+++#define CONFIG_PIPE_PROTOCOL 0
+++#define CONFIG_PROMPEG_PROTOCOL 0
+++#define CONFIG_RTMP_PROTOCOL 0
+++#define CONFIG_RTMPE_PROTOCOL 0
+++#define CONFIG_RTMPS_PROTOCOL 0
+++#define CONFIG_RTMPT_PROTOCOL 0
+++#define CONFIG_RTMPTE_PROTOCOL 0
+++#define CONFIG_RTMPTS_PROTOCOL 0
+++#define CONFIG_RTP_PROTOCOL 0
+++#define CONFIG_SCTP_PROTOCOL 0
+++#define CONFIG_SRTP_PROTOCOL 0
+++#define CONFIG_SUBFILE_PROTOCOL 0
+++#define CONFIG_TEE_PROTOCOL 0
+++#define CONFIG_TCP_PROTOCOL 0
+++#define CONFIG_TLS_PROTOCOL 0
+++#define CONFIG_UDP_PROTOCOL 0
+++#define CONFIG_UDPLITE_PROTOCOL 0
+++#define CONFIG_UNIX_PROTOCOL 0
+++#define CONFIG_LIBAMQP_PROTOCOL 0
+++#define CONFIG_LIBRIST_PROTOCOL 0
+++#define CONFIG_LIBRTMP_PROTOCOL 0
+++#define CONFIG_LIBRTMPE_PROTOCOL 0
+++#define CONFIG_LIBRTMPS_PROTOCOL 0
+++#define CONFIG_LIBRTMPT_PROTOCOL 0
+++#define CONFIG_LIBRTMPTE_PROTOCOL 0
+++#define CONFIG_LIBSRT_PROTOCOL 0
+++#define CONFIG_LIBSSH_PROTOCOL 0
+++#define CONFIG_LIBSMBCLIENT_PROTOCOL 0
+++#define CONFIG_LIBZMQ_PROTOCOL 0
+++#define CONFIG_IPFS_GATEWAY_PROTOCOL 0
+++#define CONFIG_IPNS_GATEWAY_PROTOCOL 0
+++#endif /* FFMPEG_CONFIG_COMPONENTS_H */
++diff --git a/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c b/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c
++new file mode 100644
++index 0000000000000000000000000000000000000000..7ff70c6e2d601734d335e33114f18ef17a6cf74b
++--- /dev/null
+++++ b/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c
++@@ -0,0 +1,2 @@
+++static const FFBitStreamFilter * const bitstream_filters[] = {
+++    NULL };
++diff --git a/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c b/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c
++new file mode 100644
++index 0000000000000000000000000000000000000000..fe5adb0d923023e0c408627e324f4c799489a1da
++--- /dev/null
+++++ b/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c
++@@ -0,0 +1,17 @@
+++static const FFCodec * const codec_list[] = {
+++    &ff_h264_decoder,
+++    &ff_aac_decoder,
+++    &ff_flac_decoder,
+++    &ff_mp3_decoder,
+++    &ff_vorbis_decoder,
+++    &ff_pcm_alaw_decoder,
+++    &ff_pcm_f32le_decoder,
+++    &ff_pcm_mulaw_decoder,
+++    &ff_pcm_s16be_decoder,
+++    &ff_pcm_s16le_decoder,
+++    &ff_pcm_s24be_decoder,
+++    &ff_pcm_s24le_decoder,
+++    &ff_pcm_s32le_decoder,
+++    &ff_pcm_u8_decoder,
+++    &ff_libopus_decoder,
+++    NULL };
++diff --git a/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c b/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c
++new file mode 100644
++index 0000000000000000000000000000000000000000..3e4fa9c320e8e1d5f550ec05e08a4cf67b855cdc
++--- /dev/null
+++++ b/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c
++@@ -0,0 +1,9 @@
+++static const AVCodecParser * const parser_list[] = {
+++    &ff_aac_parser,
+++    &ff_flac_parser,
+++    &ff_h264_parser,
+++    &ff_mpegaudio_parser,
+++    &ff_opus_parser,
+++    &ff_vorbis_parser,
+++    &ff_vp9_parser,
+++    NULL };
++diff --git a/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c b/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c
++new file mode 100644
++index 0000000000000000000000000000000000000000..920b22bfa7d9d14f9b996cf57d6be346730753e4
++--- /dev/null
+++++ b/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c
++@@ -0,0 +1,9 @@
+++static const AVInputFormat * const demuxer_list[] = {
+++    &ff_aac_demuxer,
+++    &ff_flac_demuxer,
+++    &ff_matroska_demuxer,
+++    &ff_mov_demuxer,
+++    &ff_mp3_demuxer,
+++    &ff_ogg_demuxer,
+++    &ff_wav_demuxer,
+++    NULL };
++diff --git a/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c b/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c
++new file mode 100644
++index 0000000000000000000000000000000000000000..ae54c39f23d86d82a59e5c06ac66f9d5cc99056a
++--- /dev/null
+++++ b/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c
++@@ -0,0 +1,2 @@
+++static const FFOutputFormat * const muxer_list[] = {
+++    NULL };
++diff --git a/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c b/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c
++new file mode 100644
++index 0000000000000000000000000000000000000000..247e1e4c3a2895996fbe9d6bc51ac6fcca38f751
++--- /dev/null
+++++ b/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c
++@@ -0,0 +1,2 @@
+++static const URLProtocol * const url_protocols[] = {
+++    NULL };
++diff --git a/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h b/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h
++new file mode 100644
++index 0000000000000000000000000000000000000000..c289fbb551c1f89b72e8090b81139d8fb745af08
++--- /dev/null
+++++ b/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h
++@@ -0,0 +1,6 @@
+++/* Generated by ffmpeg configure */
+++#ifndef AVUTIL_AVCONFIG_H
+++#define AVUTIL_AVCONFIG_H
+++#define AV_HAVE_BIGENDIAN 0
+++#define AV_HAVE_FAST_UNALIGNED 1
+++#endif /* AVUTIL_AVCONFIG_H */
++diff --git a/chromium/config/Chrome/linux/loong64/libavutil/ffversion.h b/chromium/config/Chrome/linux/loong64/libavutil/ffversion.h
++new file mode 100644
++index 0000000000000000000000000000000000000000..52b8160ee44f281b642188e868efa395c8666d39
++--- /dev/null
+++++ b/chromium/config/Chrome/linux/loong64/libavutil/ffversion.h
++@@ -0,0 +1,5 @@
+++/* Automatically generated by version.sh, do not manually edit! */
+++#ifndef AVUTIL_FFVERSION_H
+++#define AVUTIL_FFVERSION_H
+++#define FFMPEG_VERSION "n5.0.1"
+++#endif /* AVUTIL_FFVERSION_H */
++diff --git a/chromium/config/Chromium/linux/loong64/config.h b/chromium/config/Chromium/linux/loong64/config.h
++new file mode 100644
++index 0000000000000000000000000000000000000000..efeb70b8efdcc2d7bf245de6d197d69530197f24
++--- /dev/null
+++++ b/chromium/config/Chromium/linux/loong64/config.h
++@@ -0,0 +1,772 @@
+++/* Automatically generated by configure - do not modify! */
+++#ifndef FFMPEG_CONFIG_H
+++#define FFMPEG_CONFIG_H
+++/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-lsx --disable-lasx --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --disable-linux-perf --x86asmexe=nasm --optflags='\\\\\\\\\"-O2\\\\\\\\\"' --cc=clang --cxx=clang++ --ld=clang" */
+++#define FFMPEG_LICENSE "LGPL version 2.1 or later"
+++#define CONFIG_THIS_YEAR 2024
+++#define FFMPEG_DATADIR "/usr/local/share/ffmpeg"
+++#define AVCONV_DATADIR "/usr/local/share/ffmpeg"
+++#define CC_IDENT "clang version 17.0.6"
+++#define OS_NAME linux
+++#define av_restrict restrict
+++#define EXTERN_PREFIX ""
+++#define EXTERN_ASM 
+++#define BUILDSUF ""
+++#define SLIBSUF ".so"
+++#define SWS_MAX_FILTER_SIZE 256
+++#define ARCH_AARCH64 0
+++#define ARCH_ALPHA 0
+++#define ARCH_ARM 0
+++#define ARCH_AVR32 0
+++#define ARCH_AVR32_AP 0
+++#define ARCH_AVR32_UC 0
+++#define ARCH_BFIN 0
+++#define ARCH_IA64 0
+++#define ARCH_LOONGARCH 1
+++#define ARCH_LOONGARCH32 0
+++#define ARCH_LOONGARCH64 1
+++#define ARCH_M68K 0
+++#define ARCH_MIPS 0
+++#define ARCH_MIPS64 0
+++#define ARCH_PARISC 0
+++#define ARCH_PPC 0
+++#define ARCH_PPC64 0
+++#define ARCH_RISCV 0
+++#define ARCH_S390 0
+++#define ARCH_SH4 0
+++#define ARCH_SPARC 0
+++#define ARCH_SPARC64 0
+++#define ARCH_TILEGX 0
+++#define ARCH_TILEPRO 0
+++#define ARCH_X86 0
+++#define ARCH_X86_32 0
+++#define ARCH_X86_64 0
+++#define HAVE_ARMV5TE 0
+++#define HAVE_ARMV6 0
+++#define HAVE_ARMV6T2 0
+++#define HAVE_ARMV8 0
+++#define HAVE_DOTPROD 0
+++#define HAVE_I8MM 0
+++#define HAVE_NEON 0
+++#define HAVE_VFP 0
+++#define HAVE_VFPV3 0
+++#define HAVE_SETEND 0
+++#define HAVE_ALTIVEC 0
+++#define HAVE_DCBZL 0
+++#define HAVE_LDBRX 0
+++#define HAVE_POWER8 0
+++#define HAVE_PPC4XX 0
+++#define HAVE_VSX 0
+++#define HAVE_RV 0
+++#define HAVE_RVV 0
+++#define HAVE_AESNI 0
+++#define HAVE_AMD3DNOW 0
+++#define HAVE_AMD3DNOWEXT 0
+++#define HAVE_AVX 0
+++#define HAVE_AVX2 0
+++#define HAVE_AVX512 0
+++#define HAVE_AVX512ICL 0
+++#define HAVE_FMA3 0
+++#define HAVE_FMA4 0
+++#define HAVE_MMX 0
+++#define HAVE_MMXEXT 0
+++#define HAVE_SSE 0
+++#define HAVE_SSE2 0
+++#define HAVE_SSE3 0
+++#define HAVE_SSE4 0
+++#define HAVE_SSE42 0
+++#define HAVE_SSSE3 0
+++#define HAVE_XOP 0
+++#define HAVE_CPUNOP 0
+++#define HAVE_I686 0
+++#define HAVE_MIPSFPU 0
+++#define HAVE_MIPS32R2 0
+++#define HAVE_MIPS32R5 0
+++#define HAVE_MIPS64R2 0
+++#define HAVE_MIPS32R6 0
+++#define HAVE_MIPS64R6 0
+++#define HAVE_MIPSDSP 0
+++#define HAVE_MIPSDSPR2 0
+++#define HAVE_MSA 0
+++#define HAVE_LOONGSON2 0
+++#define HAVE_LOONGSON3 0
+++#define HAVE_MMI 0
+++#define HAVE_LSX 0
+++#define HAVE_LASX 0
+++#define HAVE_ARMV5TE_EXTERNAL 0
+++#define HAVE_ARMV6_EXTERNAL 0
+++#define HAVE_ARMV6T2_EXTERNAL 0
+++#define HAVE_ARMV8_EXTERNAL 0
+++#define HAVE_DOTPROD_EXTERNAL 0
+++#define HAVE_I8MM_EXTERNAL 0
+++#define HAVE_NEON_EXTERNAL 0
+++#define HAVE_VFP_EXTERNAL 0
+++#define HAVE_VFPV3_EXTERNAL 0
+++#define HAVE_SETEND_EXTERNAL 0
+++#define HAVE_ALTIVEC_EXTERNAL 0
+++#define HAVE_DCBZL_EXTERNAL 0
+++#define HAVE_LDBRX_EXTERNAL 0
+++#define HAVE_POWER8_EXTERNAL 0
+++#define HAVE_PPC4XX_EXTERNAL 0
+++#define HAVE_VSX_EXTERNAL 0
+++#define HAVE_RV_EXTERNAL 0
+++#define HAVE_RVV_EXTERNAL 0
+++#define HAVE_AESNI_EXTERNAL 0
+++#define HAVE_AMD3DNOW_EXTERNAL 0
+++#define HAVE_AMD3DNOWEXT_EXTERNAL 0
+++#define HAVE_AVX_EXTERNAL 0
+++#define HAVE_AVX2_EXTERNAL 0
+++#define HAVE_AVX512_EXTERNAL 0
+++#define HAVE_AVX512ICL_EXTERNAL 0
+++#define HAVE_FMA3_EXTERNAL 0
+++#define HAVE_FMA4_EXTERNAL 0
+++#define HAVE_MMX_EXTERNAL 0
+++#define HAVE_MMXEXT_EXTERNAL 0
+++#define HAVE_SSE_EXTERNAL 0
+++#define HAVE_SSE2_EXTERNAL 0
+++#define HAVE_SSE3_EXTERNAL 0
+++#define HAVE_SSE4_EXTERNAL 0
+++#define HAVE_SSE42_EXTERNAL 0
+++#define HAVE_SSSE3_EXTERNAL 0
+++#define HAVE_XOP_EXTERNAL 0
+++#define HAVE_CPUNOP_EXTERNAL 0
+++#define HAVE_I686_EXTERNAL 0
+++#define HAVE_MIPSFPU_EXTERNAL 0
+++#define HAVE_MIPS32R2_EXTERNAL 0
+++#define HAVE_MIPS32R5_EXTERNAL 0
+++#define HAVE_MIPS64R2_EXTERNAL 0
+++#define HAVE_MIPS32R6_EXTERNAL 0
+++#define HAVE_MIPS64R6_EXTERNAL 0
+++#define HAVE_MIPSDSP_EXTERNAL 0
+++#define HAVE_MIPSDSPR2_EXTERNAL 0
+++#define HAVE_MSA_EXTERNAL 0
+++#define HAVE_LOONGSON2_EXTERNAL 0
+++#define HAVE_LOONGSON3_EXTERNAL 0
+++#define HAVE_MMI_EXTERNAL 0
+++#define HAVE_LSX_EXTERNAL 0
+++#define HAVE_LASX_EXTERNAL 0
+++#define HAVE_ARMV5TE_INLINE 0
+++#define HAVE_ARMV6_INLINE 0
+++#define HAVE_ARMV6T2_INLINE 0
+++#define HAVE_ARMV8_INLINE 0
+++#define HAVE_DOTPROD_INLINE 0
+++#define HAVE_I8MM_INLINE 0
+++#define HAVE_NEON_INLINE 0
+++#define HAVE_VFP_INLINE 0
+++#define HAVE_VFPV3_INLINE 0
+++#define HAVE_SETEND_INLINE 0
+++#define HAVE_ALTIVEC_INLINE 0
+++#define HAVE_DCBZL_INLINE 0
+++#define HAVE_LDBRX_INLINE 0
+++#define HAVE_POWER8_INLINE 0
+++#define HAVE_PPC4XX_INLINE 0
+++#define HAVE_VSX_INLINE 0
+++#define HAVE_RV_INLINE 0
+++#define HAVE_RVV_INLINE 0
+++#define HAVE_AESNI_INLINE 0
+++#define HAVE_AMD3DNOW_INLINE 0
+++#define HAVE_AMD3DNOWEXT_INLINE 0
+++#define HAVE_AVX_INLINE 0
+++#define HAVE_AVX2_INLINE 0
+++#define HAVE_AVX512_INLINE 0
+++#define HAVE_AVX512ICL_INLINE 0
+++#define HAVE_FMA3_INLINE 0
+++#define HAVE_FMA4_INLINE 0
+++#define HAVE_MMX_INLINE 0
+++#define HAVE_MMXEXT_INLINE 0
+++#define HAVE_SSE_INLINE 0
+++#define HAVE_SSE2_INLINE 0
+++#define HAVE_SSE3_INLINE 0
+++#define HAVE_SSE4_INLINE 0
+++#define HAVE_SSE42_INLINE 0
+++#define HAVE_SSSE3_INLINE 0
+++#define HAVE_XOP_INLINE 0
+++#define HAVE_CPUNOP_INLINE 0
+++#define HAVE_I686_INLINE 0
+++#define HAVE_MIPSFPU_INLINE 0
+++#define HAVE_MIPS32R2_INLINE 0
+++#define HAVE_MIPS32R5_INLINE 0
+++#define HAVE_MIPS64R2_INLINE 0
+++#define HAVE_MIPS32R6_INLINE 0
+++#define HAVE_MIPS64R6_INLINE 0
+++#define HAVE_MIPSDSP_INLINE 0
+++#define HAVE_MIPSDSPR2_INLINE 0
+++#define HAVE_MSA_INLINE 0
+++#define HAVE_LOONGSON2_INLINE 0
+++#define HAVE_LOONGSON3_INLINE 0
+++#define HAVE_MMI_INLINE 0
+++#define HAVE_LSX_INLINE 0
+++#define HAVE_LASX_INLINE 0
+++#define HAVE_ALIGNED_STACK 0
+++#define HAVE_FAST_64BIT 1
+++#define HAVE_FAST_CLZ 1
+++#define HAVE_FAST_CMOV 0
+++#define HAVE_FAST_FLOAT16 0
+++#define HAVE_LOCAL_ALIGNED 1
+++#define HAVE_SIMD_ALIGN_16 0
+++#define HAVE_SIMD_ALIGN_32 1
+++#define HAVE_SIMD_ALIGN_64 0
+++#define HAVE_ATOMIC_CAS_PTR 0
+++#define HAVE_MACHINE_RW_BARRIER 0
+++#define HAVE_MEMORYBARRIER 0
+++#define HAVE_MM_EMPTY 0
+++#define HAVE_RDTSC 0
+++#define HAVE_SEM_TIMEDWAIT 1
+++#define HAVE_SYNC_VAL_COMPARE_AND_SWAP 1
+++#define HAVE_INLINE_ASM 1
+++#define HAVE_SYMVER 0
+++#define HAVE_X86ASM 0
+++#define HAVE_BIGENDIAN 0
+++#define HAVE_FAST_UNALIGNED 1
+++#define HAVE_ARPA_INET_H 0
+++#define HAVE_ASM_TYPES_H 1
+++#define HAVE_CDIO_PARANOIA_H 0
+++#define HAVE_CDIO_PARANOIA_PARANOIA_H 0
+++#define HAVE_CUDA_H 0
+++#define HAVE_DISPATCH_DISPATCH_H 0
+++#define HAVE_DEV_BKTR_IOCTL_BT848_H 0
+++#define HAVE_DEV_BKTR_IOCTL_METEOR_H 0
+++#define HAVE_DEV_IC_BT8XX_H 0
+++#define HAVE_DEV_VIDEO_BKTR_IOCTL_BT848_H 0
+++#define HAVE_DEV_VIDEO_METEOR_IOCTL_METEOR_H 0
+++#define HAVE_DIRECT_H 0
+++#define HAVE_DIRENT_H 1
+++#define HAVE_DXGIDEBUG_H 0
+++#define HAVE_DXVA_H 0
+++#define HAVE_ES2_GL_H 0
+++#define HAVE_GSM_H 0
+++#define HAVE_IO_H 0
+++#define HAVE_LINUX_DMA_BUF_H 0
+++#define HAVE_LINUX_PERF_EVENT_H 1
+++#define HAVE_MACHINE_IOCTL_BT848_H 0
+++#define HAVE_MACHINE_IOCTL_METEOR_H 0
+++#define HAVE_MALLOC_H 1
+++#define HAVE_OPENCV2_CORE_CORE_C_H 0
+++#define HAVE_OPENGL_GL3_H 0
+++#define HAVE_POLL_H 1
+++#define HAVE_PTHREAD_NP_H 0
+++#define HAVE_SYS_PARAM_H 1
+++#define HAVE_SYS_RESOURCE_H 1
+++#define HAVE_SYS_SELECT_H 1
+++#define HAVE_SYS_SOUNDCARD_H 1
+++#define HAVE_SYS_TIME_H 1
+++#define HAVE_SYS_UN_H 1
+++#define HAVE_SYS_VIDEOIO_H 0
+++#define HAVE_TERMIOS_H 1
+++#define HAVE_UDPLITE_H 0
+++#define HAVE_UNISTD_H 1
+++#define HAVE_VALGRIND_VALGRIND_H 0
+++#define HAVE_WINDOWS_H 0
+++#define HAVE_WINSOCK2_H 0
+++#define HAVE_INTRINSICS_NEON 0
+++#define HAVE_ATANF 1
+++#define HAVE_ATAN2F 1
+++#define HAVE_CBRT 1
+++#define HAVE_CBRTF 1
+++#define HAVE_COPYSIGN 1
+++#define HAVE_COSF 1
+++#define HAVE_ERF 1
+++#define HAVE_EXP2 1
+++#define HAVE_EXP2F 1
+++#define HAVE_EXPF 1
+++#define HAVE_HYPOT 1
+++#define HAVE_ISFINITE 1
+++#define HAVE_ISINF 1
+++#define HAVE_ISNAN 1
+++#define HAVE_LDEXPF 1
+++#define HAVE_LLRINT 1
+++#define HAVE_LLRINTF 1
+++#define HAVE_LOG2 1
+++#define HAVE_LOG2F 1
+++#define HAVE_LOG10F 1
+++#define HAVE_LRINT 1
+++#define HAVE_LRINTF 1
+++#define HAVE_POWF 1
+++#define HAVE_RINT 1
+++#define HAVE_ROUND 1
+++#define HAVE_ROUNDF 1
+++#define HAVE_SINF 1
+++#define HAVE_TRUNC 1
+++#define HAVE_TRUNCF 1
+++#define HAVE_DOS_PATHS 0
+++#define HAVE_LIBC_MSVCRT 0
+++#define HAVE_MMAL_PARAMETER_VIDEO_MAX_NUM_CALLBACKS 0
+++#define HAVE_SECTION_DATA_REL_RO 1
+++#define HAVE_THREADS 1
+++#define HAVE_UWP 0
+++#define HAVE_WINRT 0
+++#define HAVE_ACCESS 1
+++#define HAVE_ALIGNED_MALLOC 0
+++#define HAVE_ARC4RANDOM_BUF 0
+++#define HAVE_CLOCK_GETTIME 1
+++#define HAVE_CLOSESOCKET 0
+++#define HAVE_COMMANDLINETOARGVW 0
+++#define HAVE_FCNTL 1
+++#define HAVE_GETADDRINFO 0
+++#define HAVE_GETAUXVAL 1
+++#define HAVE_GETENV 1
+++#define HAVE_GETHRTIME 0
+++#define HAVE_GETOPT 1
+++#define HAVE_GETMODULEHANDLE 0
+++#define HAVE_GETPROCESSAFFINITYMASK 0
+++#define HAVE_GETPROCESSMEMORYINFO 0
+++#define HAVE_GETPROCESSTIMES 0
+++#define HAVE_GETRUSAGE 1
+++#define HAVE_GETSTDHANDLE 0
+++#define HAVE_GETSYSTEMTIMEASFILETIME 0
+++#define HAVE_GETTIMEOFDAY 1
+++#define HAVE_GLOB 1
+++#define HAVE_GLXGETPROCADDRESS 0
+++#define HAVE_GMTIME_R 1
+++#define HAVE_INET_ATON 0
+++#define HAVE_ISATTY 1
+++#define HAVE_KBHIT 0
+++#define HAVE_LOCALTIME_R 1
+++#define HAVE_LSTAT 1
+++#define HAVE_LZO1X_999_COMPRESS 0
+++#define HAVE_MACH_ABSOLUTE_TIME 0
+++#define HAVE_MAPVIEWOFFILE 0
+++#define HAVE_MEMALIGN 1
+++#define HAVE_MKSTEMP 1
+++#define HAVE_MMAP 1
+++#define HAVE_MPROTECT 1
+++#define HAVE_NANOSLEEP 1
+++#define HAVE_PEEKNAMEDPIPE 0
+++#define HAVE_POSIX_MEMALIGN 1
+++#define HAVE_PRCTL 1
+++#define HAVE_PTHREAD_CANCEL 1
+++#define HAVE_PTHREAD_SET_NAME_NP 0
+++#define HAVE_PTHREAD_SETNAME_NP 0
+++#define HAVE_SCHED_GETAFFINITY 1
+++#define HAVE_SECITEMIMPORT 0
+++#define HAVE_SETCONSOLETEXTATTRIBUTE 0
+++#define HAVE_SETCONSOLECTRLHANDLER 0
+++#define HAVE_SETDLLDIRECTORY 0
+++#define HAVE_SETMODE 0
+++#define HAVE_SETRLIMIT 1
+++#define HAVE_SLEEP 0
+++#define HAVE_STRERROR_R 1
+++#define HAVE_SYSCONF 1
+++#define HAVE_SYSCTL 0
+++#define HAVE_SYSCTLBYNAME 0
+++#define HAVE_USLEEP 1
+++#define HAVE_UTGETOSTYPEFROMSTRING 0
+++#define HAVE_VIRTUALALLOC 0
+++#define HAVE_WGLGETPROCADDRESS 0
+++#define HAVE_BCRYPT 0
+++#define HAVE_VAAPI_DRM 0
+++#define HAVE_VAAPI_X11 0
+++#define HAVE_VAAPI_WIN32 0
+++#define HAVE_VDPAU_X11 0
+++#define HAVE_PTHREADS 1
+++#define HAVE_OS2THREADS 0
+++#define HAVE_W32THREADS 0
+++#define HAVE_AS_ARCH_DIRECTIVE 0
+++#define HAVE_AS_ARCHEXT_DOTPROD_DIRECTIVE 0
+++#define HAVE_AS_ARCHEXT_I8MM_DIRECTIVE 0
+++#define HAVE_AS_DN_DIRECTIVE 0
+++#define HAVE_AS_FPU_DIRECTIVE 0
+++#define HAVE_AS_FUNC 0
+++#define HAVE_AS_OBJECT_ARCH 0
+++#define HAVE_ASM_MOD_Q 0
+++#define HAVE_BLOCKS_EXTENSION 0
+++#define HAVE_EBP_AVAILABLE 0
+++#define HAVE_EBX_AVAILABLE 0
+++#define HAVE_GNU_AS 0
+++#define HAVE_GNU_WINDRES 0
+++#define HAVE_IBM_ASM 0
+++#define HAVE_INLINE_ASM_DIRECT_SYMBOL_REFS 0
+++#define HAVE_INLINE_ASM_LABELS 1
+++#define HAVE_INLINE_ASM_NONLOCAL_LABELS 1
+++#define HAVE_PRAGMA_DEPRECATED 1
+++#define HAVE_RSYNC_CONTIMEOUT 1
+++#define HAVE_SYMVER_ASM_LABEL 1
+++#define HAVE_SYMVER_GNU_ASM 1
+++#define HAVE_VFP_ARGS 0
+++#define HAVE_XFORM_ASM 0
+++#define HAVE_XMM_CLOBBERS 0
+++#define HAVE_DPI_AWARENESS_CONTEXT 0
+++#define HAVE_IDXGIOUTPUT5 0
+++#define HAVE_KCMVIDEOCODECTYPE_HEVC 0
+++#define HAVE_KCMVIDEOCODECTYPE_HEVCWITHALPHA 0
+++#define HAVE_KCMVIDEOCODECTYPE_VP9 0
+++#define HAVE_KCVPIXELFORMATTYPE_420YPCBCR10BIPLANARVIDEORANGE 0
+++#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR8BIPLANARVIDEORANGE 0
+++#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR10BIPLANARVIDEORANGE 0
+++#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR16BIPLANARVIDEORANGE 0
+++#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR8BIPLANARVIDEORANGE 0
+++#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR10BIPLANARVIDEORANGE 0
+++#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR16BIPLANARVIDEORANGE 0
+++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_2084_PQ 0
+++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2100_HLG 0
+++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_LINEAR 0
+++#define HAVE_KCVIMAGEBUFFERYCBCRMATRIX_ITU_R_2020 0
+++#define HAVE_KCVIMAGEBUFFERCOLORPRIMARIES_ITU_R_2020 0
+++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2020 0
+++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_428_1 0
+++#define HAVE_SOCKLEN_T 0
+++#define HAVE_STRUCT_ADDRINFO 0
+++#define HAVE_STRUCT_GROUP_SOURCE_REQ 0
+++#define HAVE_STRUCT_IP_MREQ_SOURCE 0
+++#define HAVE_STRUCT_IPV6_MREQ 0
+++#define HAVE_STRUCT_MSGHDR_MSG_FLAGS 0
+++#define HAVE_STRUCT_POLLFD 0
+++#define HAVE_STRUCT_RUSAGE_RU_MAXRSS 1
+++#define HAVE_STRUCT_SCTP_EVENT_SUBSCRIBE 0
+++#define HAVE_STRUCT_SOCKADDR_IN6 0
+++#define HAVE_STRUCT_SOCKADDR_SA_LEN 0
+++#define HAVE_STRUCT_SOCKADDR_STORAGE 0
+++#define HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC 1
+++#define HAVE_STRUCT_V4L2_FRMIVALENUM_DISCRETE 0
+++#define HAVE_GZIP 1
+++#define HAVE_LIBDRM_GETFB2 0
+++#define HAVE_MAKEINFO 1
+++#define HAVE_MAKEINFO_HTML 1
+++#define HAVE_OPENCL_D3D11 0
+++#define HAVE_OPENCL_DRM_ARM 0
+++#define HAVE_OPENCL_DRM_BEIGNET 0
+++#define HAVE_OPENCL_DXVA2 0
+++#define HAVE_OPENCL_VAAPI_BEIGNET 0
+++#define HAVE_OPENCL_VAAPI_INTEL_MEDIA 0
+++#define HAVE_PERL 1
+++#define HAVE_POD2MAN 1
+++#define HAVE_TEXI2HTML 0
+++#define HAVE_XMLLINT 1
+++#define HAVE_ZLIB_GZIP 0
+++#define HAVE_OPENVINO2 0
+++#define CONFIG_DOC 0
+++#define CONFIG_HTMLPAGES 0
+++#define CONFIG_MANPAGES 0
+++#define CONFIG_PODPAGES 0
+++#define CONFIG_TXTPAGES 0
+++#define CONFIG_AVIO_HTTP_SERVE_FILES_EXAMPLE 1
+++#define CONFIG_AVIO_LIST_DIR_EXAMPLE 1
+++#define CONFIG_AVIO_READ_CALLBACK_EXAMPLE 1
+++#define CONFIG_DECODE_AUDIO_EXAMPLE 1
+++#define CONFIG_DECODE_FILTER_AUDIO_EXAMPLE 0
+++#define CONFIG_DECODE_FILTER_VIDEO_EXAMPLE 0
+++#define CONFIG_DECODE_VIDEO_EXAMPLE 1
+++#define CONFIG_DEMUX_DECODE_EXAMPLE 1
+++#define CONFIG_ENCODE_AUDIO_EXAMPLE 1
+++#define CONFIG_ENCODE_VIDEO_EXAMPLE 1
+++#define CONFIG_EXTRACT_MVS_EXAMPLE 1
+++#define CONFIG_FILTER_AUDIO_EXAMPLE 0
+++#define CONFIG_HW_DECODE_EXAMPLE 1
+++#define CONFIG_MUX_EXAMPLE 0
+++#define CONFIG_QSV_DECODE_EXAMPLE 0
+++#define CONFIG_REMUX_EXAMPLE 1
+++#define CONFIG_RESAMPLE_AUDIO_EXAMPLE 0
+++#define CONFIG_SCALE_VIDEO_EXAMPLE 0
+++#define CONFIG_SHOW_METADATA_EXAMPLE 1
+++#define CONFIG_TRANSCODE_AAC_EXAMPLE 0
+++#define CONFIG_TRANSCODE_EXAMPLE 0
+++#define CONFIG_VAAPI_ENCODE_EXAMPLE 0
+++#define CONFIG_VAAPI_TRANSCODE_EXAMPLE 0
+++#define CONFIG_QSV_TRANSCODE_EXAMPLE 0
+++#define CONFIG_AVISYNTH 0
+++#define CONFIG_FREI0R 0
+++#define CONFIG_LIBCDIO 0
+++#define CONFIG_LIBDAVS2 0
+++#define CONFIG_LIBRUBBERBAND 0
+++#define CONFIG_LIBVIDSTAB 0
+++#define CONFIG_LIBX264 0
+++#define CONFIG_LIBX265 0
+++#define CONFIG_LIBXAVS 0
+++#define CONFIG_LIBXAVS2 0
+++#define CONFIG_LIBXVID 0
+++#define CONFIG_DECKLINK 0
+++#define CONFIG_LIBFDK_AAC 0
+++#define CONFIG_LIBTLS 0
+++#define CONFIG_GMP 0
+++#define CONFIG_LIBARIBB24 0
+++#define CONFIG_LIBLENSFUN 0
+++#define CONFIG_LIBOPENCORE_AMRNB 0
+++#define CONFIG_LIBOPENCORE_AMRWB 0
+++#define CONFIG_LIBVO_AMRWBENC 0
+++#define CONFIG_MBEDTLS 0
+++#define CONFIG_RKMPP 0
+++#define CONFIG_LIBSMBCLIENT 0
+++#define CONFIG_CHROMAPRINT 0
+++#define CONFIG_GCRYPT 0
+++#define CONFIG_GNUTLS 0
+++#define CONFIG_JNI 0
+++#define CONFIG_LADSPA 0
+++#define CONFIG_LCMS2 0
+++#define CONFIG_LIBAOM 0
+++#define CONFIG_LIBARIBCAPTION 0
+++#define CONFIG_LIBASS 0
+++#define CONFIG_LIBBLURAY 0
+++#define CONFIG_LIBBS2B 0
+++#define CONFIG_LIBCACA 0
+++#define CONFIG_LIBCELT 0
+++#define CONFIG_LIBCODEC2 0
+++#define CONFIG_LIBDAV1D 0
+++#define CONFIG_LIBDC1394 0
+++#define CONFIG_LIBFLITE 0
+++#define CONFIG_LIBFONTCONFIG 0
+++#define CONFIG_LIBFREETYPE 0
+++#define CONFIG_LIBFRIBIDI 0
+++#define CONFIG_LIBHARFBUZZ 0
+++#define CONFIG_LIBGLSLANG 0
+++#define CONFIG_LIBGME 0
+++#define CONFIG_LIBGSM 0
+++#define CONFIG_LIBIEC61883 0
+++#define CONFIG_LIBILBC 0
+++#define CONFIG_LIBJACK 0
+++#define CONFIG_LIBJXL 0
+++#define CONFIG_LIBKLVANC 0
+++#define CONFIG_LIBKVAZAAR 0
+++#define CONFIG_LIBMODPLUG 0
+++#define CONFIG_LIBMP3LAME 0
+++#define CONFIG_LIBMYSOFA 0
+++#define CONFIG_LIBOPENCV 0
+++#define CONFIG_LIBOPENH264 0
+++#define CONFIG_LIBOPENJPEG 0
+++#define CONFIG_LIBOPENMPT 0
+++#define CONFIG_LIBOPENVINO 0
+++#define CONFIG_LIBOPUS 1
+++#define CONFIG_LIBPLACEBO 0
+++#define CONFIG_LIBPULSE 0
+++#define CONFIG_LIBQRENCODE 0
+++#define CONFIG_LIBQUIRC 0
+++#define CONFIG_LIBRABBITMQ 0
+++#define CONFIG_LIBRAV1E 0
+++#define CONFIG_LIBRIST 0
+++#define CONFIG_LIBRSVG 0
+++#define CONFIG_LIBRTMP 0
+++#define CONFIG_LIBSHADERC 0
+++#define CONFIG_LIBSHINE 0
+++#define CONFIG_LIBSMBCLIENT 0
+++#define CONFIG_LIBSNAPPY 0
+++#define CONFIG_LIBSOXR 0
+++#define CONFIG_LIBSPEEX 0
+++#define CONFIG_LIBSRT 0
+++#define CONFIG_LIBSSH 0
+++#define CONFIG_LIBSVTAV1 0
+++#define CONFIG_LIBTENSORFLOW 0
+++#define CONFIG_LIBTESSERACT 0
+++#define CONFIG_LIBTHEORA 0
+++#define CONFIG_LIBTWOLAME 0
+++#define CONFIG_LIBUAVS3D 0
+++#define CONFIG_LIBV4L2 0
+++#define CONFIG_LIBVMAF 0
+++#define CONFIG_LIBVORBIS 0
+++#define CONFIG_LIBVPX 0
+++#define CONFIG_LIBWEBP 0
+++#define CONFIG_LIBXEVD 0
+++#define CONFIG_LIBXEVE 0
+++#define CONFIG_LIBXML2 0
+++#define CONFIG_LIBZIMG 0
+++#define CONFIG_LIBZMQ 0
+++#define CONFIG_LIBZVBI 0
+++#define CONFIG_LV2 0
+++#define CONFIG_MEDIACODEC 0
+++#define CONFIG_OPENAL 0
+++#define CONFIG_OPENGL 0
+++#define CONFIG_OPENSSL 0
+++#define CONFIG_POCKETSPHINX 0
+++#define CONFIG_VAPOURSYNTH 0
+++#define CONFIG_ALSA 0
+++#define CONFIG_APPKIT 0
+++#define CONFIG_AVFOUNDATION 0
+++#define CONFIG_BZLIB 0
+++#define CONFIG_COREIMAGE 0
+++#define CONFIG_ICONV 0
+++#define CONFIG_LIBXCB 0
+++#define CONFIG_LIBXCB_SHM 0
+++#define CONFIG_LIBXCB_SHAPE 0
+++#define CONFIG_LIBXCB_XFIXES 0
+++#define CONFIG_LZMA 0
+++#define CONFIG_MEDIAFOUNDATION 0
+++#define CONFIG_METAL 0
+++#define CONFIG_SCHANNEL 0
+++#define CONFIG_SDL2 0
+++#define CONFIG_SECURETRANSPORT 0
+++#define CONFIG_SNDIO 0
+++#define CONFIG_XLIB 0
+++#define CONFIG_ZLIB 0
+++#define CONFIG_CUDA_NVCC 0
+++#define CONFIG_CUDA_SDK 0
+++#define CONFIG_LIBNPP 0
+++#define CONFIG_LIBMFX 0
+++#define CONFIG_LIBVPL 0
+++#define CONFIG_MMAL 0
+++#define CONFIG_OMX 0
+++#define CONFIG_OPENCL 0
+++#define CONFIG_AMF 0
+++#define CONFIG_AUDIOTOOLBOX 0
+++#define CONFIG_CRYSTALHD 0
+++#define CONFIG_CUDA 0
+++#define CONFIG_CUDA_LLVM 0
+++#define CONFIG_CUVID 0
+++#define CONFIG_D3D11VA 0
+++#define CONFIG_D3D12VA 0
+++#define CONFIG_DXVA2 0
+++#define CONFIG_FFNVCODEC 0
+++#define CONFIG_LIBDRM 0
+++#define CONFIG_NVDEC 0
+++#define CONFIG_NVENC 0
+++#define CONFIG_VAAPI 0
+++#define CONFIG_VDPAU 0
+++#define CONFIG_VIDEOTOOLBOX 0
+++#define CONFIG_VULKAN 0
+++#define CONFIG_V4L2_M2M 0
+++#define CONFIG_FTRAPV 0
+++#define CONFIG_GRAY 0
+++#define CONFIG_HARDCODED_TABLES 0
+++#define CONFIG_OMX_RPI 0
+++#define CONFIG_RUNTIME_CPUDETECT 1
+++#define CONFIG_SAFE_BITSTREAM_READER 1
+++#define CONFIG_SHARED 0
+++#define CONFIG_SMALL 0
+++#define CONFIG_STATIC 1
+++#define CONFIG_SWSCALE_ALPHA 1
+++#define CONFIG_GPL 0
+++#define CONFIG_NONFREE 0
+++#define CONFIG_VERSION3 0
+++#define CONFIG_AVDEVICE 0
+++#define CONFIG_AVFILTER 0
+++#define CONFIG_SWSCALE 0
+++#define CONFIG_POSTPROC 0
+++#define CONFIG_AVFORMAT 1
+++#define CONFIG_AVCODEC 1
+++#define CONFIG_SWRESAMPLE 0
+++#define CONFIG_AVUTIL 1
+++#define CONFIG_FFPLAY 0
+++#define CONFIG_FFPROBE 0
+++#define CONFIG_FFMPEG 0
+++#define CONFIG_DWT 0
+++#define CONFIG_ERROR_RESILIENCE 0
+++#define CONFIG_FAAN 0
+++#define CONFIG_FAST_UNALIGNED 1
+++#define CONFIG_LSP 0
+++#define CONFIG_PIXELUTILS 0
+++#define CONFIG_NETWORK 0
+++#define CONFIG_AUTODETECT 0
+++#define CONFIG_FONTCONFIG 0
+++#define CONFIG_LARGE_TESTS 1
+++#define CONFIG_LINUX_PERF 0
+++#define CONFIG_MACOS_KPERF 0
+++#define CONFIG_MEMORY_POISONING 0
+++#define CONFIG_NEON_CLOBBER_TEST 0
+++#define CONFIG_OSSFUZZ 0
+++#define CONFIG_PIC 1
+++#define CONFIG_PTX_COMPRESSION 0
+++#define CONFIG_THUMB 0
+++#define CONFIG_VALGRIND_BACKTRACE 0
+++#define CONFIG_XMM_CLOBBER_TEST 0
+++#define CONFIG_BSFS 0
+++#define CONFIG_DECODERS 1
+++#define CONFIG_ENCODERS 0
+++#define CONFIG_HWACCELS 0
+++#define CONFIG_PARSERS 1
+++#define CONFIG_INDEVS 0
+++#define CONFIG_OUTDEVS 0
+++#define CONFIG_FILTERS 0
+++#define CONFIG_DEMUXERS 1
+++#define CONFIG_MUXERS 0
+++#define CONFIG_PROTOCOLS 0
+++#define CONFIG_AANDCTTABLES 0
+++#define CONFIG_AC3DSP 0
+++#define CONFIG_ADTS_HEADER 0
+++#define CONFIG_ATSC_A53 0
+++#define CONFIG_AUDIO_FRAME_QUEUE 0
+++#define CONFIG_AUDIODSP 0
+++#define CONFIG_BLOCKDSP 0
+++#define CONFIG_BSWAPDSP 0
+++#define CONFIG_CABAC 0
+++#define CONFIG_CBS 0
+++#define CONFIG_CBS_AV1 0
+++#define CONFIG_CBS_H264 0
+++#define CONFIG_CBS_H265 0
+++#define CONFIG_CBS_H266 0
+++#define CONFIG_CBS_JPEG 0
+++#define CONFIG_CBS_MPEG2 0
+++#define CONFIG_CBS_VP8 0
+++#define CONFIG_CBS_VP9 0
+++#define CONFIG_DEFLATE_WRAPPER 0
+++#define CONFIG_DIRAC_PARSE 1
+++#define CONFIG_DNN 0
+++#define CONFIG_DOVI_RPU 0
+++#define CONFIG_DVPROFILE 0
+++#define CONFIG_EVCPARSE 0
+++#define CONFIG_EXIF 0
+++#define CONFIG_FAANDCT 0
+++#define CONFIG_FAANIDCT 0
+++#define CONFIG_FDCTDSP 0
+++#define CONFIG_FMTCONVERT 0
+++#define CONFIG_FRAME_THREAD_ENCODER 0
+++#define CONFIG_G722DSP 0
+++#define CONFIG_GOLOMB 1
+++#define CONFIG_GPLV3 0
+++#define CONFIG_H263DSP 0
+++#define CONFIG_H264CHROMA 0
+++#define CONFIG_H264DSP 0
+++#define CONFIG_H264PARSE 0
+++#define CONFIG_H264PRED 0
+++#define CONFIG_H264QPEL 0
+++#define CONFIG_H264_SEI 0
+++#define CONFIG_HEVCPARSE 0
+++#define CONFIG_HEVC_SEI 0
+++#define CONFIG_HPELDSP 0
+++#define CONFIG_HUFFMAN 0
+++#define CONFIG_HUFFYUVDSP 0
+++#define CONFIG_HUFFYUVENCDSP 0
+++#define CONFIG_IAMFDEC 0
+++#define CONFIG_IAMFENC 0
+++#define CONFIG_IDCTDSP 0
+++#define CONFIG_IIRFILTER 0
+++#define CONFIG_INFLATE_WRAPPER 0
+++#define CONFIG_INTRAX8 0
+++#define CONFIG_ISO_MEDIA 1
+++#define CONFIG_IVIDSP 0
+++#define CONFIG_JPEGTABLES 0
+++#define CONFIG_LGPLV3 0
+++#define CONFIG_LIBX262 0
+++#define CONFIG_LLAUDDSP 0
+++#define CONFIG_LLVIDDSP 0
+++#define CONFIG_LLVIDENCDSP 0
+++#define CONFIG_LPC 0
+++#define CONFIG_LZF 0
+++#define CONFIG_ME_CMP 0
+++#define CONFIG_MPEG_ER 0
+++#define CONFIG_MPEGAUDIO 1
+++#define CONFIG_MPEGAUDIODSP 1
+++#define CONFIG_MPEGAUDIOHEADER 1
+++#define CONFIG_MPEG4AUDIO 1
+++#define CONFIG_MPEGVIDEO 0
+++#define CONFIG_MPEGVIDEODEC 0
+++#define CONFIG_MPEGVIDEOENC 0
+++#define CONFIG_MSMPEG4DEC 0
+++#define CONFIG_MSMPEG4ENC 0
+++#define CONFIG_MSS34DSP 0
+++#define CONFIG_PIXBLOCKDSP 0
+++#define CONFIG_QPELDSP 0
+++#define CONFIG_QSV 0
+++#define CONFIG_QSVDEC 0
+++#define CONFIG_QSVENC 0
+++#define CONFIG_QSVVPP 0
+++#define CONFIG_RANGECODER 0
+++#define CONFIG_RIFFDEC 1
+++#define CONFIG_RIFFENC 0
+++#define CONFIG_RTPDEC 0
+++#define CONFIG_RTPENC_CHAIN 0
+++#define CONFIG_RV34DSP 0
+++#define CONFIG_SCENE_SAD 0
+++#define CONFIG_SINEWIN 0
+++#define CONFIG_SNAPPY 0
+++#define CONFIG_SRTP 0
+++#define CONFIG_STARTCODE 0
+++#define CONFIG_TEXTUREDSP 0
+++#define CONFIG_TEXTUREDSPENC 0
+++#define CONFIG_TPELDSP 0
+++#define CONFIG_VAAPI_1 0
+++#define CONFIG_VAAPI_ENCODE 0
+++#define CONFIG_VC1DSP 0
+++#define CONFIG_VIDEODSP 0
+++#define CONFIG_VP3DSP 0
+++#define CONFIG_VP56DSP 0
+++#define CONFIG_VP8DSP 0
+++#define CONFIG_WMA_FREQS 0
+++#define CONFIG_WMV2DSP 0
+++#endif /* FFMPEG_CONFIG_H */
++diff --git a/chromium/config/Chromium/linux/loong64/config_components.h b/chromium/config/Chromium/linux/loong64/config_components.h
++new file mode 100644
++index 0000000000000000000000000000000000000000..7d2f7ea320a1bcafac1b5a618e792cc385a18a70
++--- /dev/null
+++++ b/chromium/config/Chromium/linux/loong64/config_components.h
++@@ -0,0 +1,2218 @@
+++/* Automatically generated by configure - do not modify! */
+++#ifndef FFMPEG_CONFIG_COMPONENTS_H
+++#define FFMPEG_CONFIG_COMPONENTS_H
+++#define CONFIG_AAC_ADTSTOASC_BSF 0
+++#define CONFIG_AV1_FRAME_MERGE_BSF 0
+++#define CONFIG_AV1_FRAME_SPLIT_BSF 0
+++#define CONFIG_AV1_METADATA_BSF 0
+++#define CONFIG_CHOMP_BSF 0
+++#define CONFIG_DUMP_EXTRADATA_BSF 0
+++#define CONFIG_DCA_CORE_BSF 0
+++#define CONFIG_DTS2PTS_BSF 0
+++#define CONFIG_DV_ERROR_MARKER_BSF 0
+++#define CONFIG_EAC3_CORE_BSF 0
+++#define CONFIG_EXTRACT_EXTRADATA_BSF 0
+++#define CONFIG_FILTER_UNITS_BSF 0
+++#define CONFIG_H264_METADATA_BSF 0
+++#define CONFIG_H264_MP4TOANNEXB_BSF 0
+++#define CONFIG_H264_REDUNDANT_PPS_BSF 0
+++#define CONFIG_HAPQA_EXTRACT_BSF 0
+++#define CONFIG_HEVC_METADATA_BSF 0
+++#define CONFIG_HEVC_MP4TOANNEXB_BSF 0
+++#define CONFIG_IMX_DUMP_HEADER_BSF 0
+++#define CONFIG_MEDIA100_TO_MJPEGB_BSF 0
+++#define CONFIG_MJPEG2JPEG_BSF 0
+++#define CONFIG_MJPEGA_DUMP_HEADER_BSF 0
+++#define CONFIG_MP3_HEADER_DECOMPRESS_BSF 0
+++#define CONFIG_MPEG2_METADATA_BSF 0
+++#define CONFIG_MPEG4_UNPACK_BFRAMES_BSF 0
+++#define CONFIG_MOV2TEXTSUB_BSF 0
+++#define CONFIG_NOISE_BSF 0
+++#define CONFIG_NULL_BSF 0
+++#define CONFIG_OPUS_METADATA_BSF 0
+++#define CONFIG_PCM_RECHUNK_BSF 0
+++#define CONFIG_PGS_FRAME_MERGE_BSF 0
+++#define CONFIG_PRORES_METADATA_BSF 0
+++#define CONFIG_REMOVE_EXTRADATA_BSF 0
+++#define CONFIG_SETTS_BSF 0
+++#define CONFIG_SHOWINFO_BSF 0
+++#define CONFIG_TEXT2MOVSUB_BSF 0
+++#define CONFIG_TRACE_HEADERS_BSF 0
+++#define CONFIG_TRUEHD_CORE_BSF 0
+++#define CONFIG_VP9_METADATA_BSF 0
+++#define CONFIG_VP9_RAW_REORDER_BSF 0
+++#define CONFIG_VP9_SUPERFRAME_BSF 0
+++#define CONFIG_VP9_SUPERFRAME_SPLIT_BSF 0
+++#define CONFIG_VVC_METADATA_BSF 0
+++#define CONFIG_VVC_MP4TOANNEXB_BSF 0
+++#define CONFIG_EVC_FRAME_MERGE_BSF 0
+++#define CONFIG_AASC_DECODER 0
+++#define CONFIG_AIC_DECODER 0
+++#define CONFIG_ALIAS_PIX_DECODER 0
+++#define CONFIG_AGM_DECODER 0
+++#define CONFIG_AMV_DECODER 0
+++#define CONFIG_ANM_DECODER 0
+++#define CONFIG_ANSI_DECODER 0
+++#define CONFIG_APNG_DECODER 0
+++#define CONFIG_ARBC_DECODER 0
+++#define CONFIG_ARGO_DECODER 0
+++#define CONFIG_ASV1_DECODER 0
+++#define CONFIG_ASV2_DECODER 0
+++#define CONFIG_AURA_DECODER 0
+++#define CONFIG_AURA2_DECODER 0
+++#define CONFIG_AVRP_DECODER 0
+++#define CONFIG_AVRN_DECODER 0
+++#define CONFIG_AVS_DECODER 0
+++#define CONFIG_AVUI_DECODER 0
+++#define CONFIG_AYUV_DECODER 0
+++#define CONFIG_BETHSOFTVID_DECODER 0
+++#define CONFIG_BFI_DECODER 0
+++#define CONFIG_BINK_DECODER 0
+++#define CONFIG_BITPACKED_DECODER 0
+++#define CONFIG_BMP_DECODER 0
+++#define CONFIG_BMV_VIDEO_DECODER 0
+++#define CONFIG_BRENDER_PIX_DECODER 0
+++#define CONFIG_C93_DECODER 0
+++#define CONFIG_CAVS_DECODER 0
+++#define CONFIG_CDGRAPHICS_DECODER 0
+++#define CONFIG_CDTOONS_DECODER 0
+++#define CONFIG_CDXL_DECODER 0
+++#define CONFIG_CFHD_DECODER 0
+++#define CONFIG_CINEPAK_DECODER 0
+++#define CONFIG_CLEARVIDEO_DECODER 0
+++#define CONFIG_CLJR_DECODER 0
+++#define CONFIG_CLLC_DECODER 0
+++#define CONFIG_COMFORTNOISE_DECODER 0
+++#define CONFIG_CPIA_DECODER 0
+++#define CONFIG_CRI_DECODER 0
+++#define CONFIG_CSCD_DECODER 0
+++#define CONFIG_CYUV_DECODER 0
+++#define CONFIG_DDS_DECODER 0
+++#define CONFIG_DFA_DECODER 0
+++#define CONFIG_DIRAC_DECODER 0
+++#define CONFIG_DNXHD_DECODER 0
+++#define CONFIG_DPX_DECODER 0
+++#define CONFIG_DSICINVIDEO_DECODER 0
+++#define CONFIG_DVAUDIO_DECODER 0
+++#define CONFIG_DVVIDEO_DECODER 0
+++#define CONFIG_DXA_DECODER 0
+++#define CONFIG_DXTORY_DECODER 0
+++#define CONFIG_DXV_DECODER 0
+++#define CONFIG_EACMV_DECODER 0
+++#define CONFIG_EAMAD_DECODER 0
+++#define CONFIG_EATGQ_DECODER 0
+++#define CONFIG_EATGV_DECODER 0
+++#define CONFIG_EATQI_DECODER 0
+++#define CONFIG_EIGHTBPS_DECODER 0
+++#define CONFIG_EIGHTSVX_EXP_DECODER 0
+++#define CONFIG_EIGHTSVX_FIB_DECODER 0
+++#define CONFIG_ESCAPE124_DECODER 0
+++#define CONFIG_ESCAPE130_DECODER 0
+++#define CONFIG_EXR_DECODER 0
+++#define CONFIG_FFV1_DECODER 0
+++#define CONFIG_FFVHUFF_DECODER 0
+++#define CONFIG_FIC_DECODER 0
+++#define CONFIG_FITS_DECODER 0
+++#define CONFIG_FLASHSV_DECODER 0
+++#define CONFIG_FLASHSV2_DECODER 0
+++#define CONFIG_FLIC_DECODER 0
+++#define CONFIG_FLV_DECODER 0
+++#define CONFIG_FMVC_DECODER 0
+++#define CONFIG_FOURXM_DECODER 0
+++#define CONFIG_FRAPS_DECODER 0
+++#define CONFIG_FRWU_DECODER 0
+++#define CONFIG_G2M_DECODER 0
+++#define CONFIG_GDV_DECODER 0
+++#define CONFIG_GEM_DECODER 0
+++#define CONFIG_GIF_DECODER 0
+++#define CONFIG_H261_DECODER 0
+++#define CONFIG_H263_DECODER 0
+++#define CONFIG_H263I_DECODER 0
+++#define CONFIG_H263P_DECODER 0
+++#define CONFIG_H263_V4L2M2M_DECODER 0
+++#define CONFIG_H264_DECODER 0
+++#define CONFIG_H264_CRYSTALHD_DECODER 0
+++#define CONFIG_H264_V4L2M2M_DECODER 0
+++#define CONFIG_H264_MEDIACODEC_DECODER 0
+++#define CONFIG_H264_MMAL_DECODER 0
+++#define CONFIG_H264_QSV_DECODER 0
+++#define CONFIG_H264_RKMPP_DECODER 0
+++#define CONFIG_HAP_DECODER 0
+++#define CONFIG_HEVC_DECODER 0
+++#define CONFIG_HEVC_QSV_DECODER 0
+++#define CONFIG_HEVC_RKMPP_DECODER 0
+++#define CONFIG_HEVC_V4L2M2M_DECODER 0
+++#define CONFIG_HNM4_VIDEO_DECODER 0
+++#define CONFIG_HQ_HQA_DECODER 0
+++#define CONFIG_HQX_DECODER 0
+++#define CONFIG_HUFFYUV_DECODER 0
+++#define CONFIG_HYMT_DECODER 0
+++#define CONFIG_IDCIN_DECODER 0
+++#define CONFIG_IFF_ILBM_DECODER 0
+++#define CONFIG_IMM4_DECODER 0
+++#define CONFIG_IMM5_DECODER 0
+++#define CONFIG_INDEO2_DECODER 0
+++#define CONFIG_INDEO3_DECODER 0
+++#define CONFIG_INDEO4_DECODER 0
+++#define CONFIG_INDEO5_DECODER 0
+++#define CONFIG_INTERPLAY_VIDEO_DECODER 0
+++#define CONFIG_IPU_DECODER 0
+++#define CONFIG_JPEG2000_DECODER 0
+++#define CONFIG_JPEGLS_DECODER 0
+++#define CONFIG_JV_DECODER 0
+++#define CONFIG_KGV1_DECODER 0
+++#define CONFIG_KMVC_DECODER 0
+++#define CONFIG_LAGARITH_DECODER 0
+++#define CONFIG_LEAD_DECODER 0
+++#define CONFIG_LOCO_DECODER 0
+++#define CONFIG_LSCR_DECODER 0
+++#define CONFIG_M101_DECODER 0
+++#define CONFIG_MAGICYUV_DECODER 0
+++#define CONFIG_MDEC_DECODER 0
+++#define CONFIG_MEDIA100_DECODER 0
+++#define CONFIG_MIMIC_DECODER 0
+++#define CONFIG_MJPEG_DECODER 0
+++#define CONFIG_MJPEGB_DECODER 0
+++#define CONFIG_MMVIDEO_DECODER 0
+++#define CONFIG_MOBICLIP_DECODER 0
+++#define CONFIG_MOTIONPIXELS_DECODER 0
+++#define CONFIG_MPEG1VIDEO_DECODER 0
+++#define CONFIG_MPEG2VIDEO_DECODER 0
+++#define CONFIG_MPEG4_DECODER 0
+++#define CONFIG_MPEG4_CRYSTALHD_DECODER 0
+++#define CONFIG_MPEG4_V4L2M2M_DECODER 0
+++#define CONFIG_MPEG4_MMAL_DECODER 0
+++#define CONFIG_MPEGVIDEO_DECODER 0
+++#define CONFIG_MPEG1_V4L2M2M_DECODER 0
+++#define CONFIG_MPEG2_MMAL_DECODER 0
+++#define CONFIG_MPEG2_CRYSTALHD_DECODER 0
+++#define CONFIG_MPEG2_V4L2M2M_DECODER 0
+++#define CONFIG_MPEG2_QSV_DECODER 0
+++#define CONFIG_MPEG2_MEDIACODEC_DECODER 0
+++#define CONFIG_MSA1_DECODER 0
+++#define CONFIG_MSCC_DECODER 0
+++#define CONFIG_MSMPEG4V1_DECODER 0
+++#define CONFIG_MSMPEG4V2_DECODER 0
+++#define CONFIG_MSMPEG4V3_DECODER 0
+++#define CONFIG_MSMPEG4_CRYSTALHD_DECODER 0
+++#define CONFIG_MSP2_DECODER 0
+++#define CONFIG_MSRLE_DECODER 0
+++#define CONFIG_MSS1_DECODER 0
+++#define CONFIG_MSS2_DECODER 0
+++#define CONFIG_MSVIDEO1_DECODER 0
+++#define CONFIG_MSZH_DECODER 0
+++#define CONFIG_MTS2_DECODER 0
+++#define CONFIG_MV30_DECODER 0
+++#define CONFIG_MVC1_DECODER 0
+++#define CONFIG_MVC2_DECODER 0
+++#define CONFIG_MVDV_DECODER 0
+++#define CONFIG_MVHA_DECODER 0
+++#define CONFIG_MWSC_DECODER 0
+++#define CONFIG_MXPEG_DECODER 0
+++#define CONFIG_NOTCHLC_DECODER 0
+++#define CONFIG_NUV_DECODER 0
+++#define CONFIG_PAF_VIDEO_DECODER 0
+++#define CONFIG_PAM_DECODER 0
+++#define CONFIG_PBM_DECODER 0
+++#define CONFIG_PCX_DECODER 0
+++#define CONFIG_PDV_DECODER 0
+++#define CONFIG_PFM_DECODER 0
+++#define CONFIG_PGM_DECODER 0
+++#define CONFIG_PGMYUV_DECODER 0
+++#define CONFIG_PGX_DECODER 0
+++#define CONFIG_PHM_DECODER 0
+++#define CONFIG_PHOTOCD_DECODER 0
+++#define CONFIG_PICTOR_DECODER 0
+++#define CONFIG_PIXLET_DECODER 0
+++#define CONFIG_PNG_DECODER 0
+++#define CONFIG_PPM_DECODER 0
+++#define CONFIG_PRORES_DECODER 0
+++#define CONFIG_PROSUMER_DECODER 0
+++#define CONFIG_PSD_DECODER 0
+++#define CONFIG_PTX_DECODER 0
+++#define CONFIG_QDRAW_DECODER 0
+++#define CONFIG_QOI_DECODER 0
+++#define CONFIG_QPEG_DECODER 0
+++#define CONFIG_QTRLE_DECODER 0
+++#define CONFIG_R10K_DECODER 0
+++#define CONFIG_R210_DECODER 0
+++#define CONFIG_RASC_DECODER 0
+++#define CONFIG_RAWVIDEO_DECODER 0
+++#define CONFIG_RKA_DECODER 0
+++#define CONFIG_RL2_DECODER 0
+++#define CONFIG_ROQ_DECODER 0
+++#define CONFIG_RPZA_DECODER 0
+++#define CONFIG_RSCC_DECODER 0
+++#define CONFIG_RTV1_DECODER 0
+++#define CONFIG_RV10_DECODER 0
+++#define CONFIG_RV20_DECODER 0
+++#define CONFIG_RV30_DECODER 0
+++#define CONFIG_RV40_DECODER 0
+++#define CONFIG_S302M_DECODER 0
+++#define CONFIG_SANM_DECODER 0
+++#define CONFIG_SCPR_DECODER 0
+++#define CONFIG_SCREENPRESSO_DECODER 0
+++#define CONFIG_SGA_DECODER 0
+++#define CONFIG_SGI_DECODER 0
+++#define CONFIG_SGIRLE_DECODER 0
+++#define CONFIG_SHEERVIDEO_DECODER 0
+++#define CONFIG_SIMBIOSIS_IMX_DECODER 0
+++#define CONFIG_SMACKER_DECODER 0
+++#define CONFIG_SMC_DECODER 0
+++#define CONFIG_SMVJPEG_DECODER 0
+++#define CONFIG_SNOW_DECODER 0
+++#define CONFIG_SP5X_DECODER 0
+++#define CONFIG_SPEEDHQ_DECODER 0
+++#define CONFIG_SPEEX_DECODER 0
+++#define CONFIG_SRGC_DECODER 0
+++#define CONFIG_SUNRAST_DECODER 0
+++#define CONFIG_SVQ1_DECODER 0
+++#define CONFIG_SVQ3_DECODER 0
+++#define CONFIG_TARGA_DECODER 0
+++#define CONFIG_TARGA_Y216_DECODER 0
+++#define CONFIG_TDSC_DECODER 0
+++#define CONFIG_THEORA_DECODER 0
+++#define CONFIG_THP_DECODER 0
+++#define CONFIG_TIERTEXSEQVIDEO_DECODER 0
+++#define CONFIG_TIFF_DECODER 0
+++#define CONFIG_TMV_DECODER 0
+++#define CONFIG_TRUEMOTION1_DECODER 0
+++#define CONFIG_TRUEMOTION2_DECODER 0
+++#define CONFIG_TRUEMOTION2RT_DECODER 0
+++#define CONFIG_TSCC_DECODER 0
+++#define CONFIG_TSCC2_DECODER 0
+++#define CONFIG_TXD_DECODER 0
+++#define CONFIG_ULTI_DECODER 0
+++#define CONFIG_UTVIDEO_DECODER 0
+++#define CONFIG_V210_DECODER 0
+++#define CONFIG_V210X_DECODER 0
+++#define CONFIG_V308_DECODER 0
+++#define CONFIG_V408_DECODER 0
+++#define CONFIG_V410_DECODER 0
+++#define CONFIG_VB_DECODER 0
+++#define CONFIG_VBN_DECODER 0
+++#define CONFIG_VBLE_DECODER 0
+++#define CONFIG_VC1_DECODER 0
+++#define CONFIG_VC1_CRYSTALHD_DECODER 0
+++#define CONFIG_VC1IMAGE_DECODER 0
+++#define CONFIG_VC1_MMAL_DECODER 0
+++#define CONFIG_VC1_QSV_DECODER 0
+++#define CONFIG_VC1_V4L2M2M_DECODER 0
+++#define CONFIG_VCR1_DECODER 0
+++#define CONFIG_VMDVIDEO_DECODER 0
+++#define CONFIG_VMIX_DECODER 0
+++#define CONFIG_VMNC_DECODER 0
+++#define CONFIG_VP3_DECODER 0
+++#define CONFIG_VP4_DECODER 0
+++#define CONFIG_VP5_DECODER 0
+++#define CONFIG_VP6_DECODER 0
+++#define CONFIG_VP6A_DECODER 0
+++#define CONFIG_VP6F_DECODER 0
+++#define CONFIG_VP7_DECODER 0
+++#define CONFIG_VP8_DECODER 0
+++#define CONFIG_VP8_RKMPP_DECODER 0
+++#define CONFIG_VP8_V4L2M2M_DECODER 0
+++#define CONFIG_VP9_DECODER 0
+++#define CONFIG_VP9_RKMPP_DECODER 0
+++#define CONFIG_VP9_V4L2M2M_DECODER 0
+++#define CONFIG_VQA_DECODER 0
+++#define CONFIG_VQC_DECODER 0
+++#define CONFIG_VVC_DECODER 0
+++#define CONFIG_WBMP_DECODER 0
+++#define CONFIG_WEBP_DECODER 0
+++#define CONFIG_WCMV_DECODER 0
+++#define CONFIG_WRAPPED_AVFRAME_DECODER 0
+++#define CONFIG_WMV1_DECODER 0
+++#define CONFIG_WMV2_DECODER 0
+++#define CONFIG_WMV3_DECODER 0
+++#define CONFIG_WMV3_CRYSTALHD_DECODER 0
+++#define CONFIG_WMV3IMAGE_DECODER 0
+++#define CONFIG_WNV1_DECODER 0
+++#define CONFIG_XAN_WC3_DECODER 0
+++#define CONFIG_XAN_WC4_DECODER 0
+++#define CONFIG_XBM_DECODER 0
+++#define CONFIG_XFACE_DECODER 0
+++#define CONFIG_XL_DECODER 0
+++#define CONFIG_XPM_DECODER 0
+++#define CONFIG_XWD_DECODER 0
+++#define CONFIG_Y41P_DECODER 0
+++#define CONFIG_YLC_DECODER 0
+++#define CONFIG_YOP_DECODER 0
+++#define CONFIG_YUV4_DECODER 0
+++#define CONFIG_ZERO12V_DECODER 0
+++#define CONFIG_ZEROCODEC_DECODER 0
+++#define CONFIG_ZLIB_DECODER 0
+++#define CONFIG_ZMBV_DECODER 0
+++#define CONFIG_AAC_DECODER 0
+++#define CONFIG_AAC_FIXED_DECODER 0
+++#define CONFIG_AAC_LATM_DECODER 0
+++#define CONFIG_AC3_DECODER 0
+++#define CONFIG_AC3_FIXED_DECODER 0
+++#define CONFIG_ACELP_KELVIN_DECODER 0
+++#define CONFIG_ALAC_DECODER 0
+++#define CONFIG_ALS_DECODER 0
+++#define CONFIG_AMRNB_DECODER 0
+++#define CONFIG_AMRWB_DECODER 0
+++#define CONFIG_APAC_DECODER 0
+++#define CONFIG_APE_DECODER 0
+++#define CONFIG_APTX_DECODER 0
+++#define CONFIG_APTX_HD_DECODER 0
+++#define CONFIG_ATRAC1_DECODER 0
+++#define CONFIG_ATRAC3_DECODER 0
+++#define CONFIG_ATRAC3AL_DECODER 0
+++#define CONFIG_ATRAC3P_DECODER 0
+++#define CONFIG_ATRAC3PAL_DECODER 0
+++#define CONFIG_ATRAC9_DECODER 0
+++#define CONFIG_BINKAUDIO_DCT_DECODER 0
+++#define CONFIG_BINKAUDIO_RDFT_DECODER 0
+++#define CONFIG_BMV_AUDIO_DECODER 0
+++#define CONFIG_BONK_DECODER 0
+++#define CONFIG_COOK_DECODER 0
+++#define CONFIG_DCA_DECODER 0
+++#define CONFIG_DFPWM_DECODER 0
+++#define CONFIG_DOLBY_E_DECODER 0
+++#define CONFIG_DSD_LSBF_DECODER 0
+++#define CONFIG_DSD_MSBF_DECODER 0
+++#define CONFIG_DSD_LSBF_PLANAR_DECODER 0
+++#define CONFIG_DSD_MSBF_PLANAR_DECODER 0
+++#define CONFIG_DSICINAUDIO_DECODER 0
+++#define CONFIG_DSS_SP_DECODER 0
+++#define CONFIG_DST_DECODER 0
+++#define CONFIG_EAC3_DECODER 0
+++#define CONFIG_EVRC_DECODER 0
+++#define CONFIG_FASTAUDIO_DECODER 0
+++#define CONFIG_FFWAVESYNTH_DECODER 0
+++#define CONFIG_FLAC_DECODER 1
+++#define CONFIG_FTR_DECODER 0
+++#define CONFIG_G723_1_DECODER 0
+++#define CONFIG_G729_DECODER 0
+++#define CONFIG_GSM_DECODER 0
+++#define CONFIG_GSM_MS_DECODER 0
+++#define CONFIG_HCA_DECODER 0
+++#define CONFIG_HCOM_DECODER 0
+++#define CONFIG_HDR_DECODER 0
+++#define CONFIG_IAC_DECODER 0
+++#define CONFIG_ILBC_DECODER 0
+++#define CONFIG_IMC_DECODER 0
+++#define CONFIG_INTERPLAY_ACM_DECODER 0
+++#define CONFIG_MACE3_DECODER 0
+++#define CONFIG_MACE6_DECODER 0
+++#define CONFIG_METASOUND_DECODER 0
+++#define CONFIG_MISC4_DECODER 0
+++#define CONFIG_MLP_DECODER 0
+++#define CONFIG_MP1_DECODER 0
+++#define CONFIG_MP1FLOAT_DECODER 0
+++#define CONFIG_MP2_DECODER 0
+++#define CONFIG_MP2FLOAT_DECODER 0
+++#define CONFIG_MP3FLOAT_DECODER 0
+++#define CONFIG_MP3_DECODER 1
+++#define CONFIG_MP3ADUFLOAT_DECODER 0
+++#define CONFIG_MP3ADU_DECODER 0
+++#define CONFIG_MP3ON4FLOAT_DECODER 0
+++#define CONFIG_MP3ON4_DECODER 0
+++#define CONFIG_MPC7_DECODER 0
+++#define CONFIG_MPC8_DECODER 0
+++#define CONFIG_MSNSIREN_DECODER 0
+++#define CONFIG_NELLYMOSER_DECODER 0
+++#define CONFIG_ON2AVC_DECODER 0
+++#define CONFIG_OPUS_DECODER 0
+++#define CONFIG_OSQ_DECODER 0
+++#define CONFIG_PAF_AUDIO_DECODER 0
+++#define CONFIG_QCELP_DECODER 0
+++#define CONFIG_QDM2_DECODER 0
+++#define CONFIG_QDMC_DECODER 0
+++#define CONFIG_QOA_DECODER 0
+++#define CONFIG_RA_144_DECODER 0
+++#define CONFIG_RA_288_DECODER 0
+++#define CONFIG_RALF_DECODER 0
+++#define CONFIG_SBC_DECODER 0
+++#define CONFIG_SHORTEN_DECODER 0
+++#define CONFIG_SIPR_DECODER 0
+++#define CONFIG_SIREN_DECODER 0
+++#define CONFIG_SMACKAUD_DECODER 0
+++#define CONFIG_SONIC_DECODER 0
+++#define CONFIG_TAK_DECODER 0
+++#define CONFIG_TRUEHD_DECODER 0
+++#define CONFIG_TRUESPEECH_DECODER 0
+++#define CONFIG_TTA_DECODER 0
+++#define CONFIG_TWINVQ_DECODER 0
+++#define CONFIG_VMDAUDIO_DECODER 0
+++#define CONFIG_VORBIS_DECODER 1
+++#define CONFIG_WAVARC_DECODER 0
+++#define CONFIG_WAVPACK_DECODER 0
+++#define CONFIG_WMALOSSLESS_DECODER 0
+++#define CONFIG_WMAPRO_DECODER 0
+++#define CONFIG_WMAV1_DECODER 0
+++#define CONFIG_WMAV2_DECODER 0
+++#define CONFIG_WMAVOICE_DECODER 0
+++#define CONFIG_WS_SND1_DECODER 0
+++#define CONFIG_XMA1_DECODER 0
+++#define CONFIG_XMA2_DECODER 0
+++#define CONFIG_PCM_ALAW_DECODER 1
+++#define CONFIG_PCM_BLURAY_DECODER 0
+++#define CONFIG_PCM_DVD_DECODER 0
+++#define CONFIG_PCM_F16LE_DECODER 0
+++#define CONFIG_PCM_F24LE_DECODER 0
+++#define CONFIG_PCM_F32BE_DECODER 0
+++#define CONFIG_PCM_F32LE_DECODER 1
+++#define CONFIG_PCM_F64BE_DECODER 0
+++#define CONFIG_PCM_F64LE_DECODER 0
+++#define CONFIG_PCM_LXF_DECODER 0
+++#define CONFIG_PCM_MULAW_DECODER 1
+++#define CONFIG_PCM_S8_DECODER 0
+++#define CONFIG_PCM_S8_PLANAR_DECODER 0
+++#define CONFIG_PCM_S16BE_DECODER 1
+++#define CONFIG_PCM_S16BE_PLANAR_DECODER 0
+++#define CONFIG_PCM_S16LE_DECODER 1
+++#define CONFIG_PCM_S16LE_PLANAR_DECODER 0
+++#define CONFIG_PCM_S24BE_DECODER 1
+++#define CONFIG_PCM_S24DAUD_DECODER 0
+++#define CONFIG_PCM_S24LE_DECODER 1
+++#define CONFIG_PCM_S24LE_PLANAR_DECODER 0
+++#define CONFIG_PCM_S32BE_DECODER 0
+++#define CONFIG_PCM_S32LE_DECODER 1
+++#define CONFIG_PCM_S32LE_PLANAR_DECODER 0
+++#define CONFIG_PCM_S64BE_DECODER 0
+++#define CONFIG_PCM_S64LE_DECODER 0
+++#define CONFIG_PCM_SGA_DECODER 0
+++#define CONFIG_PCM_U8_DECODER 1
+++#define CONFIG_PCM_U16BE_DECODER 0
+++#define CONFIG_PCM_U16LE_DECODER 0
+++#define CONFIG_PCM_U24BE_DECODER 0
+++#define CONFIG_PCM_U24LE_DECODER 0
+++#define CONFIG_PCM_U32BE_DECODER 0
+++#define CONFIG_PCM_U32LE_DECODER 0
+++#define CONFIG_PCM_VIDC_DECODER 0
+++#define CONFIG_CBD2_DPCM_DECODER 0
+++#define CONFIG_DERF_DPCM_DECODER 0
+++#define CONFIG_GREMLIN_DPCM_DECODER 0
+++#define CONFIG_INTERPLAY_DPCM_DECODER 0
+++#define CONFIG_ROQ_DPCM_DECODER 0
+++#define CONFIG_SDX2_DPCM_DECODER 0
+++#define CONFIG_SOL_DPCM_DECODER 0
+++#define CONFIG_XAN_DPCM_DECODER 0
+++#define CONFIG_WADY_DPCM_DECODER 0
+++#define CONFIG_ADPCM_4XM_DECODER 0
+++#define CONFIG_ADPCM_ADX_DECODER 0
+++#define CONFIG_ADPCM_AFC_DECODER 0
+++#define CONFIG_ADPCM_AGM_DECODER 0
+++#define CONFIG_ADPCM_AICA_DECODER 0
+++#define CONFIG_ADPCM_ARGO_DECODER 0
+++#define CONFIG_ADPCM_CT_DECODER 0
+++#define CONFIG_ADPCM_DTK_DECODER 0
+++#define CONFIG_ADPCM_EA_DECODER 0
+++#define CONFIG_ADPCM_EA_MAXIS_XA_DECODER 0
+++#define CONFIG_ADPCM_EA_R1_DECODER 0
+++#define CONFIG_ADPCM_EA_R2_DECODER 0
+++#define CONFIG_ADPCM_EA_R3_DECODER 0
+++#define CONFIG_ADPCM_EA_XAS_DECODER 0
+++#define CONFIG_ADPCM_G722_DECODER 0
+++#define CONFIG_ADPCM_G726_DECODER 0
+++#define CONFIG_ADPCM_G726LE_DECODER 0
+++#define CONFIG_ADPCM_IMA_ACORN_DECODER 0
+++#define CONFIG_ADPCM_IMA_AMV_DECODER 0
+++#define CONFIG_ADPCM_IMA_ALP_DECODER 0
+++#define CONFIG_ADPCM_IMA_APC_DECODER 0
+++#define CONFIG_ADPCM_IMA_APM_DECODER 0
+++#define CONFIG_ADPCM_IMA_CUNNING_DECODER 0
+++#define CONFIG_ADPCM_IMA_DAT4_DECODER 0
+++#define CONFIG_ADPCM_IMA_DK3_DECODER 0
+++#define CONFIG_ADPCM_IMA_DK4_DECODER 0
+++#define CONFIG_ADPCM_IMA_EA_EACS_DECODER 0
+++#define CONFIG_ADPCM_IMA_EA_SEAD_DECODER 0
+++#define CONFIG_ADPCM_IMA_ISS_DECODER 0
+++#define CONFIG_ADPCM_IMA_MOFLEX_DECODER 0
+++#define CONFIG_ADPCM_IMA_MTF_DECODER 0
+++#define CONFIG_ADPCM_IMA_OKI_DECODER 0
+++#define CONFIG_ADPCM_IMA_QT_DECODER 0
+++#define CONFIG_ADPCM_IMA_RAD_DECODER 0
+++#define CONFIG_ADPCM_IMA_SSI_DECODER 0
+++#define CONFIG_ADPCM_IMA_SMJPEG_DECODER 0
+++#define CONFIG_ADPCM_IMA_WAV_DECODER 0
+++#define CONFIG_ADPCM_IMA_WS_DECODER 0
+++#define CONFIG_ADPCM_MS_DECODER 0
+++#define CONFIG_ADPCM_MTAF_DECODER 0
+++#define CONFIG_ADPCM_PSX_DECODER 0
+++#define CONFIG_ADPCM_SBPRO_2_DECODER 0
+++#define CONFIG_ADPCM_SBPRO_3_DECODER 0
+++#define CONFIG_ADPCM_SBPRO_4_DECODER 0
+++#define CONFIG_ADPCM_SWF_DECODER 0
+++#define CONFIG_ADPCM_THP_DECODER 0
+++#define CONFIG_ADPCM_THP_LE_DECODER 0
+++#define CONFIG_ADPCM_VIMA_DECODER 0
+++#define CONFIG_ADPCM_XA_DECODER 0
+++#define CONFIG_ADPCM_XMD_DECODER 0
+++#define CONFIG_ADPCM_YAMAHA_DECODER 0
+++#define CONFIG_ADPCM_ZORK_DECODER 0
+++#define CONFIG_SSA_DECODER 0
+++#define CONFIG_ASS_DECODER 0
+++#define CONFIG_CCAPTION_DECODER 0
+++#define CONFIG_DVBSUB_DECODER 0
+++#define CONFIG_DVDSUB_DECODER 0
+++#define CONFIG_JACOSUB_DECODER 0
+++#define CONFIG_MICRODVD_DECODER 0
+++#define CONFIG_MOVTEXT_DECODER 0
+++#define CONFIG_MPL2_DECODER 0
+++#define CONFIG_PGSSUB_DECODER 0
+++#define CONFIG_PJS_DECODER 0
+++#define CONFIG_REALTEXT_DECODER 0
+++#define CONFIG_SAMI_DECODER 0
+++#define CONFIG_SRT_DECODER 0
+++#define CONFIG_STL_DECODER 0
+++#define CONFIG_SUBRIP_DECODER 0
+++#define CONFIG_SUBVIEWER_DECODER 0
+++#define CONFIG_SUBVIEWER1_DECODER 0
+++#define CONFIG_TEXT_DECODER 0
+++#define CONFIG_VPLAYER_DECODER 0
+++#define CONFIG_WEBVTT_DECODER 0
+++#define CONFIG_XSUB_DECODER 0
+++#define CONFIG_AAC_AT_DECODER 0
+++#define CONFIG_AC3_AT_DECODER 0
+++#define CONFIG_ADPCM_IMA_QT_AT_DECODER 0
+++#define CONFIG_ALAC_AT_DECODER 0
+++#define CONFIG_AMR_NB_AT_DECODER 0
+++#define CONFIG_EAC3_AT_DECODER 0
+++#define CONFIG_GSM_MS_AT_DECODER 0
+++#define CONFIG_ILBC_AT_DECODER 0
+++#define CONFIG_MP1_AT_DECODER 0
+++#define CONFIG_MP2_AT_DECODER 0
+++#define CONFIG_MP3_AT_DECODER 0
+++#define CONFIG_PCM_ALAW_AT_DECODER 0
+++#define CONFIG_PCM_MULAW_AT_DECODER 0
+++#define CONFIG_QDMC_AT_DECODER 0
+++#define CONFIG_QDM2_AT_DECODER 0
+++#define CONFIG_LIBARIBCAPTION_DECODER 0
+++#define CONFIG_LIBARIBB24_DECODER 0
+++#define CONFIG_LIBCELT_DECODER 0
+++#define CONFIG_LIBCODEC2_DECODER 0
+++#define CONFIG_LIBDAV1D_DECODER 0
+++#define CONFIG_LIBDAVS2_DECODER 0
+++#define CONFIG_LIBFDK_AAC_DECODER 0
+++#define CONFIG_LIBGSM_DECODER 0
+++#define CONFIG_LIBGSM_MS_DECODER 0
+++#define CONFIG_LIBILBC_DECODER 0
+++#define CONFIG_LIBJXL_DECODER 0
+++#define CONFIG_LIBOPENCORE_AMRNB_DECODER 0
+++#define CONFIG_LIBOPENCORE_AMRWB_DECODER 0
+++#define CONFIG_LIBOPUS_DECODER 1
+++#define CONFIG_LIBRSVG_DECODER 0
+++#define CONFIG_LIBSPEEX_DECODER 0
+++#define CONFIG_LIBUAVS3D_DECODER 0
+++#define CONFIG_LIBVORBIS_DECODER 0
+++#define CONFIG_LIBVPX_VP8_DECODER 0
+++#define CONFIG_LIBVPX_VP9_DECODER 0
+++#define CONFIG_LIBXEVD_DECODER 0
+++#define CONFIG_LIBZVBI_TELETEXT_DECODER 0
+++#define CONFIG_BINTEXT_DECODER 0
+++#define CONFIG_XBIN_DECODER 0
+++#define CONFIG_IDF_DECODER 0
+++#define CONFIG_LIBAOM_AV1_DECODER 0
+++#define CONFIG_AV1_DECODER 0
+++#define CONFIG_AV1_CUVID_DECODER 0
+++#define CONFIG_AV1_MEDIACODEC_DECODER 0
+++#define CONFIG_AV1_QSV_DECODER 0
+++#define CONFIG_LIBOPENH264_DECODER 0
+++#define CONFIG_H264_CUVID_DECODER 0
+++#define CONFIG_HEVC_CUVID_DECODER 0
+++#define CONFIG_HEVC_MEDIACODEC_DECODER 0
+++#define CONFIG_MJPEG_CUVID_DECODER 0
+++#define CONFIG_MJPEG_QSV_DECODER 0
+++#define CONFIG_MPEG1_CUVID_DECODER 0
+++#define CONFIG_MPEG2_CUVID_DECODER 0
+++#define CONFIG_MPEG4_CUVID_DECODER 0
+++#define CONFIG_MPEG4_MEDIACODEC_DECODER 0
+++#define CONFIG_VC1_CUVID_DECODER 0
+++#define CONFIG_VP8_CUVID_DECODER 0
+++#define CONFIG_VP8_MEDIACODEC_DECODER 0
+++#define CONFIG_VP8_QSV_DECODER 0
+++#define CONFIG_VP9_CUVID_DECODER 0
+++#define CONFIG_VP9_MEDIACODEC_DECODER 0
+++#define CONFIG_VP9_QSV_DECODER 0
+++#define CONFIG_VNULL_DECODER 0
+++#define CONFIG_ANULL_DECODER 0
+++#define CONFIG_A64MULTI_ENCODER 0
+++#define CONFIG_A64MULTI5_ENCODER 0
+++#define CONFIG_ALIAS_PIX_ENCODER 0
+++#define CONFIG_AMV_ENCODER 0
+++#define CONFIG_APNG_ENCODER 0
+++#define CONFIG_ASV1_ENCODER 0
+++#define CONFIG_ASV2_ENCODER 0
+++#define CONFIG_AVRP_ENCODER 0
+++#define CONFIG_AVUI_ENCODER 0
+++#define CONFIG_AYUV_ENCODER 0
+++#define CONFIG_BITPACKED_ENCODER 0
+++#define CONFIG_BMP_ENCODER 0
+++#define CONFIG_CFHD_ENCODER 0
+++#define CONFIG_CINEPAK_ENCODER 0
+++#define CONFIG_CLJR_ENCODER 0
+++#define CONFIG_COMFORTNOISE_ENCODER 0
+++#define CONFIG_DNXHD_ENCODER 0
+++#define CONFIG_DPX_ENCODER 0
+++#define CONFIG_DVVIDEO_ENCODER 0
+++#define CONFIG_DXV_ENCODER 0
+++#define CONFIG_EXR_ENCODER 0
+++#define CONFIG_FFV1_ENCODER 0
+++#define CONFIG_FFVHUFF_ENCODER 0
+++#define CONFIG_FITS_ENCODER 0
+++#define CONFIG_FLASHSV_ENCODER 0
+++#define CONFIG_FLASHSV2_ENCODER 0
+++#define CONFIG_FLV_ENCODER 0
+++#define CONFIG_GIF_ENCODER 0
+++#define CONFIG_H261_ENCODER 0
+++#define CONFIG_H263_ENCODER 0
+++#define CONFIG_H263P_ENCODER 0
+++#define CONFIG_H264_MEDIACODEC_ENCODER 0
+++#define CONFIG_HAP_ENCODER 0
+++#define CONFIG_HUFFYUV_ENCODER 0
+++#define CONFIG_JPEG2000_ENCODER 0
+++#define CONFIG_JPEGLS_ENCODER 0
+++#define CONFIG_LJPEG_ENCODER 0
+++#define CONFIG_MAGICYUV_ENCODER 0
+++#define CONFIG_MJPEG_ENCODER 0
+++#define CONFIG_MPEG1VIDEO_ENCODER 0
+++#define CONFIG_MPEG2VIDEO_ENCODER 0
+++#define CONFIG_MPEG4_ENCODER 0
+++#define CONFIG_MSMPEG4V2_ENCODER 0
+++#define CONFIG_MSMPEG4V3_ENCODER 0
+++#define CONFIG_MSRLE_ENCODER 0
+++#define CONFIG_MSVIDEO1_ENCODER 0
+++#define CONFIG_PAM_ENCODER 0
+++#define CONFIG_PBM_ENCODER 0
+++#define CONFIG_PCX_ENCODER 0
+++#define CONFIG_PFM_ENCODER 0
+++#define CONFIG_PGM_ENCODER 0
+++#define CONFIG_PGMYUV_ENCODER 0
+++#define CONFIG_PHM_ENCODER 0
+++#define CONFIG_PNG_ENCODER 0
+++#define CONFIG_PPM_ENCODER 0
+++#define CONFIG_PRORES_ENCODER 0
+++#define CONFIG_PRORES_AW_ENCODER 0
+++#define CONFIG_PRORES_KS_ENCODER 0
+++#define CONFIG_QOI_ENCODER 0
+++#define CONFIG_QTRLE_ENCODER 0
+++#define CONFIG_R10K_ENCODER 0
+++#define CONFIG_R210_ENCODER 0
+++#define CONFIG_RAWVIDEO_ENCODER 0
+++#define CONFIG_ROQ_ENCODER 0
+++#define CONFIG_RPZA_ENCODER 0
+++#define CONFIG_RV10_ENCODER 0
+++#define CONFIG_RV20_ENCODER 0
+++#define CONFIG_S302M_ENCODER 0
+++#define CONFIG_SGI_ENCODER 0
+++#define CONFIG_SMC_ENCODER 0
+++#define CONFIG_SNOW_ENCODER 0
+++#define CONFIG_SPEEDHQ_ENCODER 0
+++#define CONFIG_SUNRAST_ENCODER 0
+++#define CONFIG_SVQ1_ENCODER 0
+++#define CONFIG_TARGA_ENCODER 0
+++#define CONFIG_TIFF_ENCODER 0
+++#define CONFIG_UTVIDEO_ENCODER 0
+++#define CONFIG_V210_ENCODER 0
+++#define CONFIG_V308_ENCODER 0
+++#define CONFIG_V408_ENCODER 0
+++#define CONFIG_V410_ENCODER 0
+++#define CONFIG_VBN_ENCODER 0
+++#define CONFIG_VC2_ENCODER 0
+++#define CONFIG_WBMP_ENCODER 0
+++#define CONFIG_WRAPPED_AVFRAME_ENCODER 0
+++#define CONFIG_WMV1_ENCODER 0
+++#define CONFIG_WMV2_ENCODER 0
+++#define CONFIG_XBM_ENCODER 0
+++#define CONFIG_XFACE_ENCODER 0
+++#define CONFIG_XWD_ENCODER 0
+++#define CONFIG_Y41P_ENCODER 0
+++#define CONFIG_YUV4_ENCODER 0
+++#define CONFIG_ZLIB_ENCODER 0
+++#define CONFIG_ZMBV_ENCODER 0
+++#define CONFIG_AAC_ENCODER 0
+++#define CONFIG_AC3_ENCODER 0
+++#define CONFIG_AC3_FIXED_ENCODER 0
+++#define CONFIG_ALAC_ENCODER 0
+++#define CONFIG_APTX_ENCODER 0
+++#define CONFIG_APTX_HD_ENCODER 0
+++#define CONFIG_DCA_ENCODER 0
+++#define CONFIG_DFPWM_ENCODER 0
+++#define CONFIG_EAC3_ENCODER 0
+++#define CONFIG_FLAC_ENCODER 0
+++#define CONFIG_G723_1_ENCODER 0
+++#define CONFIG_HDR_ENCODER 0
+++#define CONFIG_MLP_ENCODER 0
+++#define CONFIG_MP2_ENCODER 0
+++#define CONFIG_MP2FIXED_ENCODER 0
+++#define CONFIG_NELLYMOSER_ENCODER 0
+++#define CONFIG_OPUS_ENCODER 0
+++#define CONFIG_RA_144_ENCODER 0
+++#define CONFIG_SBC_ENCODER 0
+++#define CONFIG_SONIC_ENCODER 0
+++#define CONFIG_SONIC_LS_ENCODER 0
+++#define CONFIG_TRUEHD_ENCODER 0
+++#define CONFIG_TTA_ENCODER 0
+++#define CONFIG_VORBIS_ENCODER 0
+++#define CONFIG_WAVPACK_ENCODER 0
+++#define CONFIG_WMAV1_ENCODER 0
+++#define CONFIG_WMAV2_ENCODER 0
+++#define CONFIG_PCM_ALAW_ENCODER 0
+++#define CONFIG_PCM_BLURAY_ENCODER 0
+++#define CONFIG_PCM_DVD_ENCODER 0
+++#define CONFIG_PCM_F32BE_ENCODER 0
+++#define CONFIG_PCM_F32LE_ENCODER 0
+++#define CONFIG_PCM_F64BE_ENCODER 0
+++#define CONFIG_PCM_F64LE_ENCODER 0
+++#define CONFIG_PCM_MULAW_ENCODER 0
+++#define CONFIG_PCM_S8_ENCODER 0
+++#define CONFIG_PCM_S8_PLANAR_ENCODER 0
+++#define CONFIG_PCM_S16BE_ENCODER 0
+++#define CONFIG_PCM_S16BE_PLANAR_ENCODER 0
+++#define CONFIG_PCM_S16LE_ENCODER 0
+++#define CONFIG_PCM_S16LE_PLANAR_ENCODER 0
+++#define CONFIG_PCM_S24BE_ENCODER 0
+++#define CONFIG_PCM_S24DAUD_ENCODER 0
+++#define CONFIG_PCM_S24LE_ENCODER 0
+++#define CONFIG_PCM_S24LE_PLANAR_ENCODER 0
+++#define CONFIG_PCM_S32BE_ENCODER 0
+++#define CONFIG_PCM_S32LE_ENCODER 0
+++#define CONFIG_PCM_S32LE_PLANAR_ENCODER 0
+++#define CONFIG_PCM_S64BE_ENCODER 0
+++#define CONFIG_PCM_S64LE_ENCODER 0
+++#define CONFIG_PCM_U8_ENCODER 0
+++#define CONFIG_PCM_U16BE_ENCODER 0
+++#define CONFIG_PCM_U16LE_ENCODER 0
+++#define CONFIG_PCM_U24BE_ENCODER 0
+++#define CONFIG_PCM_U24LE_ENCODER 0
+++#define CONFIG_PCM_U32BE_ENCODER 0
+++#define CONFIG_PCM_U32LE_ENCODER 0
+++#define CONFIG_PCM_VIDC_ENCODER 0
+++#define CONFIG_ROQ_DPCM_ENCODER 0
+++#define CONFIG_ADPCM_ADX_ENCODER 0
+++#define CONFIG_ADPCM_ARGO_ENCODER 0
+++#define CONFIG_ADPCM_G722_ENCODER 0
+++#define CONFIG_ADPCM_G726_ENCODER 0
+++#define CONFIG_ADPCM_G726LE_ENCODER 0
+++#define CONFIG_ADPCM_IMA_AMV_ENCODER 0
+++#define CONFIG_ADPCM_IMA_ALP_ENCODER 0
+++#define CONFIG_ADPCM_IMA_APM_ENCODER 0
+++#define CONFIG_ADPCM_IMA_QT_ENCODER 0
+++#define CONFIG_ADPCM_IMA_SSI_ENCODER 0
+++#define CONFIG_ADPCM_IMA_WAV_ENCODER 0
+++#define CONFIG_ADPCM_IMA_WS_ENCODER 0
+++#define CONFIG_ADPCM_MS_ENCODER 0
+++#define CONFIG_ADPCM_SWF_ENCODER 0
+++#define CONFIG_ADPCM_YAMAHA_ENCODER 0
+++#define CONFIG_SSA_ENCODER 0
+++#define CONFIG_ASS_ENCODER 0
+++#define CONFIG_DVBSUB_ENCODER 0
+++#define CONFIG_DVDSUB_ENCODER 0
+++#define CONFIG_MOVTEXT_ENCODER 0
+++#define CONFIG_SRT_ENCODER 0
+++#define CONFIG_SUBRIP_ENCODER 0
+++#define CONFIG_TEXT_ENCODER 0
+++#define CONFIG_TTML_ENCODER 0
+++#define CONFIG_WEBVTT_ENCODER 0
+++#define CONFIG_XSUB_ENCODER 0
+++#define CONFIG_AAC_AT_ENCODER 0
+++#define CONFIG_ALAC_AT_ENCODER 0
+++#define CONFIG_ILBC_AT_ENCODER 0
+++#define CONFIG_PCM_ALAW_AT_ENCODER 0
+++#define CONFIG_PCM_MULAW_AT_ENCODER 0
+++#define CONFIG_LIBAOM_AV1_ENCODER 0
+++#define CONFIG_LIBCODEC2_ENCODER 0
+++#define CONFIG_LIBFDK_AAC_ENCODER 0
+++#define CONFIG_LIBGSM_ENCODER 0
+++#define CONFIG_LIBGSM_MS_ENCODER 0
+++#define CONFIG_LIBILBC_ENCODER 0
+++#define CONFIG_LIBJXL_ENCODER 0
+++#define CONFIG_LIBMP3LAME_ENCODER 0
+++#define CONFIG_LIBOPENCORE_AMRNB_ENCODER 0
+++#define CONFIG_LIBOPENJPEG_ENCODER 0
+++#define CONFIG_LIBOPUS_ENCODER 0
+++#define CONFIG_LIBRAV1E_ENCODER 0
+++#define CONFIG_LIBSHINE_ENCODER 0
+++#define CONFIG_LIBSPEEX_ENCODER 0
+++#define CONFIG_LIBSVTAV1_ENCODER 0
+++#define CONFIG_LIBTHEORA_ENCODER 0
+++#define CONFIG_LIBTWOLAME_ENCODER 0
+++#define CONFIG_LIBVO_AMRWBENC_ENCODER 0
+++#define CONFIG_LIBVORBIS_ENCODER 0
+++#define CONFIG_LIBVPX_VP8_ENCODER 0
+++#define CONFIG_LIBVPX_VP9_ENCODER 0
+++#define CONFIG_LIBWEBP_ANIM_ENCODER 0
+++#define CONFIG_LIBWEBP_ENCODER 0
+++#define CONFIG_LIBX262_ENCODER 0
+++#define CONFIG_LIBX264_ENCODER 0
+++#define CONFIG_LIBX264RGB_ENCODER 0
+++#define CONFIG_LIBX265_ENCODER 0
+++#define CONFIG_LIBXEVE_ENCODER 0
+++#define CONFIG_LIBXAVS_ENCODER 0
+++#define CONFIG_LIBXAVS2_ENCODER 0
+++#define CONFIG_LIBXVID_ENCODER 0
+++#define CONFIG_AAC_MF_ENCODER 0
+++#define CONFIG_AC3_MF_ENCODER 0
+++#define CONFIG_H263_V4L2M2M_ENCODER 0
+++#define CONFIG_AV1_MEDIACODEC_ENCODER 0
+++#define CONFIG_AV1_NVENC_ENCODER 0
+++#define CONFIG_AV1_QSV_ENCODER 0
+++#define CONFIG_AV1_AMF_ENCODER 0
+++#define CONFIG_AV1_VAAPI_ENCODER 0
+++#define CONFIG_LIBOPENH264_ENCODER 0
+++#define CONFIG_H264_AMF_ENCODER 0
+++#define CONFIG_H264_MF_ENCODER 0
+++#define CONFIG_H264_NVENC_ENCODER 0
+++#define CONFIG_H264_OMX_ENCODER 0
+++#define CONFIG_H264_QSV_ENCODER 0
+++#define CONFIG_H264_V4L2M2M_ENCODER 0
+++#define CONFIG_H264_VAAPI_ENCODER 0
+++#define CONFIG_H264_VIDEOTOOLBOX_ENCODER 0
+++#define CONFIG_HEVC_AMF_ENCODER 0
+++#define CONFIG_HEVC_MEDIACODEC_ENCODER 0
+++#define CONFIG_HEVC_MF_ENCODER 0
+++#define CONFIG_HEVC_NVENC_ENCODER 0
+++#define CONFIG_HEVC_QSV_ENCODER 0
+++#define CONFIG_HEVC_V4L2M2M_ENCODER 0
+++#define CONFIG_HEVC_VAAPI_ENCODER 0
+++#define CONFIG_HEVC_VIDEOTOOLBOX_ENCODER 0
+++#define CONFIG_LIBKVAZAAR_ENCODER 0
+++#define CONFIG_MJPEG_QSV_ENCODER 0
+++#define CONFIG_MJPEG_VAAPI_ENCODER 0
+++#define CONFIG_MP3_MF_ENCODER 0
+++#define CONFIG_MPEG2_QSV_ENCODER 0
+++#define CONFIG_MPEG2_VAAPI_ENCODER 0
+++#define CONFIG_MPEG4_MEDIACODEC_ENCODER 0
+++#define CONFIG_MPEG4_OMX_ENCODER 0
+++#define CONFIG_MPEG4_V4L2M2M_ENCODER 0
+++#define CONFIG_PRORES_VIDEOTOOLBOX_ENCODER 0
+++#define CONFIG_VP8_MEDIACODEC_ENCODER 0
+++#define CONFIG_VP8_V4L2M2M_ENCODER 0
+++#define CONFIG_VP8_VAAPI_ENCODER 0
+++#define CONFIG_VP9_MEDIACODEC_ENCODER 0
+++#define CONFIG_VP9_VAAPI_ENCODER 0
+++#define CONFIG_VP9_QSV_ENCODER 0
+++#define CONFIG_VNULL_ENCODER 0
+++#define CONFIG_ANULL_ENCODER 0
+++#define CONFIG_AV1_D3D11VA_HWACCEL 0
+++#define CONFIG_AV1_D3D11VA2_HWACCEL 0
+++#define CONFIG_AV1_D3D12VA_HWACCEL 0
+++#define CONFIG_AV1_DXVA2_HWACCEL 0
+++#define CONFIG_AV1_NVDEC_HWACCEL 0
+++#define CONFIG_AV1_VAAPI_HWACCEL 0
+++#define CONFIG_AV1_VDPAU_HWACCEL 0
+++#define CONFIG_AV1_VULKAN_HWACCEL 0
+++#define CONFIG_H263_VAAPI_HWACCEL 0
+++#define CONFIG_H263_VIDEOTOOLBOX_HWACCEL 0
+++#define CONFIG_H264_D3D11VA_HWACCEL 0
+++#define CONFIG_H264_D3D11VA2_HWACCEL 0
+++#define CONFIG_H264_D3D12VA_HWACCEL 0
+++#define CONFIG_H264_DXVA2_HWACCEL 0
+++#define CONFIG_H264_NVDEC_HWACCEL 0
+++#define CONFIG_H264_VAAPI_HWACCEL 0
+++#define CONFIG_H264_VDPAU_HWACCEL 0
+++#define CONFIG_H264_VIDEOTOOLBOX_HWACCEL 0
+++#define CONFIG_H264_VULKAN_HWACCEL 0
+++#define CONFIG_HEVC_D3D11VA_HWACCEL 0
+++#define CONFIG_HEVC_D3D11VA2_HWACCEL 0
+++#define CONFIG_HEVC_D3D12VA_HWACCEL 0
+++#define CONFIG_HEVC_DXVA2_HWACCEL 0
+++#define CONFIG_HEVC_NVDEC_HWACCEL 0
+++#define CONFIG_HEVC_VAAPI_HWACCEL 0
+++#define CONFIG_HEVC_VDPAU_HWACCEL 0
+++#define CONFIG_HEVC_VIDEOTOOLBOX_HWACCEL 0
+++#define CONFIG_HEVC_VULKAN_HWACCEL 0
+++#define CONFIG_MJPEG_NVDEC_HWACCEL 0
+++#define CONFIG_MJPEG_VAAPI_HWACCEL 0
+++#define CONFIG_MPEG1_NVDEC_HWACCEL 0
+++#define CONFIG_MPEG1_VDPAU_HWACCEL 0
+++#define CONFIG_MPEG1_VIDEOTOOLBOX_HWACCEL 0
+++#define CONFIG_MPEG2_D3D11VA_HWACCEL 0
+++#define CONFIG_MPEG2_D3D11VA2_HWACCEL 0
+++#define CONFIG_MPEG2_D3D12VA_HWACCEL 0
+++#define CONFIG_MPEG2_DXVA2_HWACCEL 0
+++#define CONFIG_MPEG2_NVDEC_HWACCEL 0
+++#define CONFIG_MPEG2_VAAPI_HWACCEL 0
+++#define CONFIG_MPEG2_VDPAU_HWACCEL 0
+++#define CONFIG_MPEG2_VIDEOTOOLBOX_HWACCEL 0
+++#define CONFIG_MPEG4_NVDEC_HWACCEL 0
+++#define CONFIG_MPEG4_VAAPI_HWACCEL 0
+++#define CONFIG_MPEG4_VDPAU_HWACCEL 0
+++#define CONFIG_MPEG4_VIDEOTOOLBOX_HWACCEL 0
+++#define CONFIG_PRORES_VIDEOTOOLBOX_HWACCEL 0
+++#define CONFIG_VC1_D3D11VA_HWACCEL 0
+++#define CONFIG_VC1_D3D11VA2_HWACCEL 0
+++#define CONFIG_VC1_D3D12VA_HWACCEL 0
+++#define CONFIG_VC1_DXVA2_HWACCEL 0
+++#define CONFIG_VC1_NVDEC_HWACCEL 0
+++#define CONFIG_VC1_VAAPI_HWACCEL 0
+++#define CONFIG_VC1_VDPAU_HWACCEL 0
+++#define CONFIG_VP8_NVDEC_HWACCEL 0
+++#define CONFIG_VP8_VAAPI_HWACCEL 0
+++#define CONFIG_VP9_D3D11VA_HWACCEL 0
+++#define CONFIG_VP9_D3D11VA2_HWACCEL 0
+++#define CONFIG_VP9_D3D12VA_HWACCEL 0
+++#define CONFIG_VP9_DXVA2_HWACCEL 0
+++#define CONFIG_VP9_NVDEC_HWACCEL 0
+++#define CONFIG_VP9_VAAPI_HWACCEL 0
+++#define CONFIG_VP9_VDPAU_HWACCEL 0
+++#define CONFIG_VP9_VIDEOTOOLBOX_HWACCEL 0
+++#define CONFIG_WMV3_D3D11VA_HWACCEL 0
+++#define CONFIG_WMV3_D3D11VA2_HWACCEL 0
+++#define CONFIG_WMV3_D3D12VA_HWACCEL 0
+++#define CONFIG_WMV3_DXVA2_HWACCEL 0
+++#define CONFIG_WMV3_NVDEC_HWACCEL 0
+++#define CONFIG_WMV3_VAAPI_HWACCEL 0
+++#define CONFIG_WMV3_VDPAU_HWACCEL 0
+++#define CONFIG_AAC_PARSER 0
+++#define CONFIG_AAC_LATM_PARSER 0
+++#define CONFIG_AC3_PARSER 0
+++#define CONFIG_ADX_PARSER 0
+++#define CONFIG_AMR_PARSER 0
+++#define CONFIG_AV1_PARSER 0
+++#define CONFIG_AVS2_PARSER 0
+++#define CONFIG_AVS3_PARSER 0
+++#define CONFIG_BMP_PARSER 0
+++#define CONFIG_CAVSVIDEO_PARSER 0
+++#define CONFIG_COOK_PARSER 0
+++#define CONFIG_CRI_PARSER 0
+++#define CONFIG_DCA_PARSER 0
+++#define CONFIG_DIRAC_PARSER 0
+++#define CONFIG_DNXHD_PARSER 0
+++#define CONFIG_DOLBY_E_PARSER 0
+++#define CONFIG_DPX_PARSER 0
+++#define CONFIG_DVAUDIO_PARSER 0
+++#define CONFIG_DVBSUB_PARSER 0
+++#define CONFIG_DVDSUB_PARSER 0
+++#define CONFIG_DVD_NAV_PARSER 0
+++#define CONFIG_EVC_PARSER 0
+++#define CONFIG_FLAC_PARSER 1
+++#define CONFIG_FTR_PARSER 0
+++#define CONFIG_G723_1_PARSER 0
+++#define CONFIG_G729_PARSER 0
+++#define CONFIG_GIF_PARSER 0
+++#define CONFIG_GSM_PARSER 0
+++#define CONFIG_H261_PARSER 0
+++#define CONFIG_H263_PARSER 0
+++#define CONFIG_H264_PARSER 0
+++#define CONFIG_HEVC_PARSER 0
+++#define CONFIG_HDR_PARSER 0
+++#define CONFIG_IPU_PARSER 0
+++#define CONFIG_JPEG2000_PARSER 0
+++#define CONFIG_JPEGXL_PARSER 0
+++#define CONFIG_MISC4_PARSER 0
+++#define CONFIG_MJPEG_PARSER 0
+++#define CONFIG_MLP_PARSER 0
+++#define CONFIG_MPEG4VIDEO_PARSER 0
+++#define CONFIG_MPEGAUDIO_PARSER 1
+++#define CONFIG_MPEGVIDEO_PARSER 0
+++#define CONFIG_OPUS_PARSER 1
+++#define CONFIG_PNG_PARSER 0
+++#define CONFIG_PNM_PARSER 0
+++#define CONFIG_QOI_PARSER 0
+++#define CONFIG_RV34_PARSER 0
+++#define CONFIG_SBC_PARSER 0
+++#define CONFIG_SIPR_PARSER 0
+++#define CONFIG_TAK_PARSER 0
+++#define CONFIG_VC1_PARSER 0
+++#define CONFIG_VORBIS_PARSER 1
+++#define CONFIG_VP3_PARSER 0
+++#define CONFIG_VP8_PARSER 0
+++#define CONFIG_VP9_PARSER 1
+++#define CONFIG_VVC_PARSER 0
+++#define CONFIG_WEBP_PARSER 0
+++#define CONFIG_XBM_PARSER 0
+++#define CONFIG_XMA_PARSER 0
+++#define CONFIG_XWD_PARSER 0
+++#define CONFIG_ALSA_INDEV 0
+++#define CONFIG_ANDROID_CAMERA_INDEV 0
+++#define CONFIG_AVFOUNDATION_INDEV 0
+++#define CONFIG_BKTR_INDEV 0
+++#define CONFIG_DECKLINK_INDEV 0
+++#define CONFIG_DSHOW_INDEV 0
+++#define CONFIG_FBDEV_INDEV 0
+++#define CONFIG_GDIGRAB_INDEV 0
+++#define CONFIG_IEC61883_INDEV 0
+++#define CONFIG_JACK_INDEV 0
+++#define CONFIG_KMSGRAB_INDEV 0
+++#define CONFIG_LAVFI_INDEV 0
+++#define CONFIG_OPENAL_INDEV 0
+++#define CONFIG_OSS_INDEV 0
+++#define CONFIG_PULSE_INDEV 0
+++#define CONFIG_SNDIO_INDEV 0
+++#define CONFIG_V4L2_INDEV 0
+++#define CONFIG_VFWCAP_INDEV 0
+++#define CONFIG_XCBGRAB_INDEV 0
+++#define CONFIG_LIBCDIO_INDEV 0
+++#define CONFIG_LIBDC1394_INDEV 0
+++#define CONFIG_ALSA_OUTDEV 0
+++#define CONFIG_AUDIOTOOLBOX_OUTDEV 0
+++#define CONFIG_CACA_OUTDEV 0
+++#define CONFIG_DECKLINK_OUTDEV 0
+++#define CONFIG_FBDEV_OUTDEV 0
+++#define CONFIG_OPENGL_OUTDEV 0
+++#define CONFIG_OSS_OUTDEV 0
+++#define CONFIG_PULSE_OUTDEV 0
+++#define CONFIG_SDL2_OUTDEV 0
+++#define CONFIG_SNDIO_OUTDEV 0
+++#define CONFIG_V4L2_OUTDEV 0
+++#define CONFIG_XV_OUTDEV 0
+++#define CONFIG_AAP_FILTER 0
+++#define CONFIG_ABENCH_FILTER 0
+++#define CONFIG_ACOMPRESSOR_FILTER 0
+++#define CONFIG_ACONTRAST_FILTER 0
+++#define CONFIG_ACOPY_FILTER 0
+++#define CONFIG_ACUE_FILTER 0
+++#define CONFIG_ACROSSFADE_FILTER 0
+++#define CONFIG_ACROSSOVER_FILTER 0
+++#define CONFIG_ACRUSHER_FILTER 0
+++#define CONFIG_ADECLICK_FILTER 0
+++#define CONFIG_ADECLIP_FILTER 0
+++#define CONFIG_ADECORRELATE_FILTER 0
+++#define CONFIG_ADELAY_FILTER 0
+++#define CONFIG_ADENORM_FILTER 0
+++#define CONFIG_ADERIVATIVE_FILTER 0
+++#define CONFIG_ADRC_FILTER 0
+++#define CONFIG_ADYNAMICEQUALIZER_FILTER 0
+++#define CONFIG_ADYNAMICSMOOTH_FILTER 0
+++#define CONFIG_AECHO_FILTER 0
+++#define CONFIG_AEMPHASIS_FILTER 0
+++#define CONFIG_AEVAL_FILTER 0
+++#define CONFIG_AEXCITER_FILTER 0
+++#define CONFIG_AFADE_FILTER 0
+++#define CONFIG_AFFTDN_FILTER 0
+++#define CONFIG_AFFTFILT_FILTER 0
+++#define CONFIG_AFIR_FILTER 0
+++#define CONFIG_AFORMAT_FILTER 0
+++#define CONFIG_AFREQSHIFT_FILTER 0
+++#define CONFIG_AFWTDN_FILTER 0
+++#define CONFIG_AGATE_FILTER 0
+++#define CONFIG_AIIR_FILTER 0
+++#define CONFIG_AINTEGRAL_FILTER 0
+++#define CONFIG_AINTERLEAVE_FILTER 0
+++#define CONFIG_ALATENCY_FILTER 0
+++#define CONFIG_ALIMITER_FILTER 0
+++#define CONFIG_ALLPASS_FILTER 0
+++#define CONFIG_ALOOP_FILTER 0
+++#define CONFIG_AMERGE_FILTER 0
+++#define CONFIG_AMETADATA_FILTER 0
+++#define CONFIG_AMIX_FILTER 0
+++#define CONFIG_AMULTIPLY_FILTER 0
+++#define CONFIG_ANEQUALIZER_FILTER 0
+++#define CONFIG_ANLMDN_FILTER 0
+++#define CONFIG_ANLMF_FILTER 0
+++#define CONFIG_ANLMS_FILTER 0
+++#define CONFIG_ANULL_FILTER 0
+++#define CONFIG_APAD_FILTER 0
+++#define CONFIG_APERMS_FILTER 0
+++#define CONFIG_APHASER_FILTER 0
+++#define CONFIG_APHASESHIFT_FILTER 0
+++#define CONFIG_APSNR_FILTER 0
+++#define CONFIG_APSYCLIP_FILTER 0
+++#define CONFIG_APULSATOR_FILTER 0
+++#define CONFIG_AREALTIME_FILTER 0
+++#define CONFIG_ARESAMPLE_FILTER 0
+++#define CONFIG_AREVERSE_FILTER 0
+++#define CONFIG_ARLS_FILTER 0
+++#define CONFIG_ARNNDN_FILTER 0
+++#define CONFIG_ASDR_FILTER 0
+++#define CONFIG_ASEGMENT_FILTER 0
+++#define CONFIG_ASELECT_FILTER 0
+++#define CONFIG_ASENDCMD_FILTER 0
+++#define CONFIG_ASETNSAMPLES_FILTER 0
+++#define CONFIG_ASETPTS_FILTER 0
+++#define CONFIG_ASETRATE_FILTER 0
+++#define CONFIG_ASETTB_FILTER 0
+++#define CONFIG_ASHOWINFO_FILTER 0
+++#define CONFIG_ASIDEDATA_FILTER 0
+++#define CONFIG_ASISDR_FILTER 0
+++#define CONFIG_ASOFTCLIP_FILTER 0
+++#define CONFIG_ASPECTRALSTATS_FILTER 0
+++#define CONFIG_ASPLIT_FILTER 0
+++#define CONFIG_ASR_FILTER 0
+++#define CONFIG_ASTATS_FILTER 0
+++#define CONFIG_ASTREAMSELECT_FILTER 0
+++#define CONFIG_ASUBBOOST_FILTER 0
+++#define CONFIG_ASUBCUT_FILTER 0
+++#define CONFIG_ASUPERCUT_FILTER 0
+++#define CONFIG_ASUPERPASS_FILTER 0
+++#define CONFIG_ASUPERSTOP_FILTER 0
+++#define CONFIG_ATEMPO_FILTER 0
+++#define CONFIG_ATILT_FILTER 0
+++#define CONFIG_ATRIM_FILTER 0
+++#define CONFIG_AXCORRELATE_FILTER 0
+++#define CONFIG_AZMQ_FILTER 0
+++#define CONFIG_BANDPASS_FILTER 0
+++#define CONFIG_BANDREJECT_FILTER 0
+++#define CONFIG_BASS_FILTER 0
+++#define CONFIG_BIQUAD_FILTER 0
+++#define CONFIG_BS2B_FILTER 0
+++#define CONFIG_CHANNELMAP_FILTER 0
+++#define CONFIG_CHANNELSPLIT_FILTER 0
+++#define CONFIG_CHORUS_FILTER 0
+++#define CONFIG_COMPAND_FILTER 0
+++#define CONFIG_COMPENSATIONDELAY_FILTER 0
+++#define CONFIG_CROSSFEED_FILTER 0
+++#define CONFIG_CRYSTALIZER_FILTER 0
+++#define CONFIG_DCSHIFT_FILTER 0
+++#define CONFIG_DEESSER_FILTER 0
+++#define CONFIG_DIALOGUENHANCE_FILTER 0
+++#define CONFIG_DRMETER_FILTER 0
+++#define CONFIG_DYNAUDNORM_FILTER 0
+++#define CONFIG_EARWAX_FILTER 0
+++#define CONFIG_EBUR128_FILTER 0
+++#define CONFIG_EQUALIZER_FILTER 0
+++#define CONFIG_EXTRASTEREO_FILTER 0
+++#define CONFIG_FIREQUALIZER_FILTER 0
+++#define CONFIG_FLANGER_FILTER 0
+++#define CONFIG_HAAS_FILTER 0
+++#define CONFIG_HDCD_FILTER 0
+++#define CONFIG_HEADPHONE_FILTER 0
+++#define CONFIG_HIGHPASS_FILTER 0
+++#define CONFIG_HIGHSHELF_FILTER 0
+++#define CONFIG_JOIN_FILTER 0
+++#define CONFIG_LADSPA_FILTER 0
+++#define CONFIG_LOUDNORM_FILTER 0
+++#define CONFIG_LOWPASS_FILTER 0
+++#define CONFIG_LOWSHELF_FILTER 0
+++#define CONFIG_LV2_FILTER 0
+++#define CONFIG_MCOMPAND_FILTER 0
+++#define CONFIG_PAN_FILTER 0
+++#define CONFIG_REPLAYGAIN_FILTER 0
+++#define CONFIG_RUBBERBAND_FILTER 0
+++#define CONFIG_SIDECHAINCOMPRESS_FILTER 0
+++#define CONFIG_SIDECHAINGATE_FILTER 0
+++#define CONFIG_SILENCEDETECT_FILTER 0
+++#define CONFIG_SILENCEREMOVE_FILTER 0
+++#define CONFIG_SOFALIZER_FILTER 0
+++#define CONFIG_SPEECHNORM_FILTER 0
+++#define CONFIG_STEREOTOOLS_FILTER 0
+++#define CONFIG_STEREOWIDEN_FILTER 0
+++#define CONFIG_SUPEREQUALIZER_FILTER 0
+++#define CONFIG_SURROUND_FILTER 0
+++#define CONFIG_TILTSHELF_FILTER 0
+++#define CONFIG_TREBLE_FILTER 0
+++#define CONFIG_TREMOLO_FILTER 0
+++#define CONFIG_VIBRATO_FILTER 0
+++#define CONFIG_VIRTUALBASS_FILTER 0
+++#define CONFIG_VOLUME_FILTER 0
+++#define CONFIG_VOLUMEDETECT_FILTER 0
+++#define CONFIG_AEVALSRC_FILTER 0
+++#define CONFIG_AFDELAYSRC_FILTER 0
+++#define CONFIG_AFIREQSRC_FILTER 0
+++#define CONFIG_AFIRSRC_FILTER 0
+++#define CONFIG_ANOISESRC_FILTER 0
+++#define CONFIG_ANULLSRC_FILTER 0
+++#define CONFIG_FLITE_FILTER 0
+++#define CONFIG_HILBERT_FILTER 0
+++#define CONFIG_SINC_FILTER 0
+++#define CONFIG_SINE_FILTER 0
+++#define CONFIG_ANULLSINK_FILTER 0
+++#define CONFIG_ADDROI_FILTER 0
+++#define CONFIG_ALPHAEXTRACT_FILTER 0
+++#define CONFIG_ALPHAMERGE_FILTER 0
+++#define CONFIG_AMPLIFY_FILTER 0
+++#define CONFIG_ASS_FILTER 0
+++#define CONFIG_ATADENOISE_FILTER 0
+++#define CONFIG_AVGBLUR_FILTER 0
+++#define CONFIG_AVGBLUR_OPENCL_FILTER 0
+++#define CONFIG_AVGBLUR_VULKAN_FILTER 0
+++#define CONFIG_BACKGROUNDKEY_FILTER 0
+++#define CONFIG_BBOX_FILTER 0
+++#define CONFIG_BENCH_FILTER 0
+++#define CONFIG_BILATERAL_FILTER 0
+++#define CONFIG_BILATERAL_CUDA_FILTER 0
+++#define CONFIG_BITPLANENOISE_FILTER 0
+++#define CONFIG_BLACKDETECT_FILTER 0
+++#define CONFIG_BLACKFRAME_FILTER 0
+++#define CONFIG_BLEND_FILTER 0
+++#define CONFIG_BLEND_VULKAN_FILTER 0
+++#define CONFIG_BLOCKDETECT_FILTER 0
+++#define CONFIG_BLURDETECT_FILTER 0
+++#define CONFIG_BM3D_FILTER 0
+++#define CONFIG_BOXBLUR_FILTER 0
+++#define CONFIG_BOXBLUR_OPENCL_FILTER 0
+++#define CONFIG_BWDIF_FILTER 0
+++#define CONFIG_BWDIF_CUDA_FILTER 0
+++#define CONFIG_BWDIF_VULKAN_FILTER 0
+++#define CONFIG_CAS_FILTER 0
+++#define CONFIG_CCREPACK_FILTER 0
+++#define CONFIG_CHROMABER_VULKAN_FILTER 0
+++#define CONFIG_CHROMAHOLD_FILTER 0
+++#define CONFIG_CHROMAKEY_FILTER 0
+++#define CONFIG_CHROMAKEY_CUDA_FILTER 0
+++#define CONFIG_CHROMANR_FILTER 0
+++#define CONFIG_CHROMASHIFT_FILTER 0
+++#define CONFIG_CIESCOPE_FILTER 0
+++#define CONFIG_CODECVIEW_FILTER 0
+++#define CONFIG_COLORBALANCE_FILTER 0
+++#define CONFIG_COLORCHANNELMIXER_FILTER 0
+++#define CONFIG_COLORCONTRAST_FILTER 0
+++#define CONFIG_COLORCORRECT_FILTER 0
+++#define CONFIG_COLORIZE_FILTER 0
+++#define CONFIG_COLORKEY_FILTER 0
+++#define CONFIG_COLORKEY_OPENCL_FILTER 0
+++#define CONFIG_COLORHOLD_FILTER 0
+++#define CONFIG_COLORLEVELS_FILTER 0
+++#define CONFIG_COLORMAP_FILTER 0
+++#define CONFIG_COLORMATRIX_FILTER 0
+++#define CONFIG_COLORSPACE_FILTER 0
+++#define CONFIG_COLORSPACE_CUDA_FILTER 0
+++#define CONFIG_COLORTEMPERATURE_FILTER 0
+++#define CONFIG_CONVOLUTION_FILTER 0
+++#define CONFIG_CONVOLUTION_OPENCL_FILTER 0
+++#define CONFIG_CONVOLVE_FILTER 0
+++#define CONFIG_COPY_FILTER 0
+++#define CONFIG_COREIMAGE_FILTER 0
+++#define CONFIG_CORR_FILTER 0
+++#define CONFIG_COVER_RECT_FILTER 0
+++#define CONFIG_CROP_FILTER 0
+++#define CONFIG_CROPDETECT_FILTER 0
+++#define CONFIG_CUE_FILTER 0
+++#define CONFIG_CURVES_FILTER 0
+++#define CONFIG_DATASCOPE_FILTER 0
+++#define CONFIG_DBLUR_FILTER 0
+++#define CONFIG_DCTDNOIZ_FILTER 0
+++#define CONFIG_DEBAND_FILTER 0
+++#define CONFIG_DEBLOCK_FILTER 0
+++#define CONFIG_DECIMATE_FILTER 0
+++#define CONFIG_DECONVOLVE_FILTER 0
+++#define CONFIG_DEDOT_FILTER 0
+++#define CONFIG_DEFLATE_FILTER 0
+++#define CONFIG_DEFLICKER_FILTER 0
+++#define CONFIG_DEINTERLACE_QSV_FILTER 0
+++#define CONFIG_DEINTERLACE_VAAPI_FILTER 0
+++#define CONFIG_DEJUDDER_FILTER 0
+++#define CONFIG_DELOGO_FILTER 0
+++#define CONFIG_DENOISE_VAAPI_FILTER 0
+++#define CONFIG_DERAIN_FILTER 0
+++#define CONFIG_DESHAKE_FILTER 0
+++#define CONFIG_DESHAKE_OPENCL_FILTER 0
+++#define CONFIG_DESPILL_FILTER 0
+++#define CONFIG_DETELECINE_FILTER 0
+++#define CONFIG_DILATION_FILTER 0
+++#define CONFIG_DILATION_OPENCL_FILTER 0
+++#define CONFIG_DISPLACE_FILTER 0
+++#define CONFIG_DNN_CLASSIFY_FILTER 0
+++#define CONFIG_DNN_DETECT_FILTER 0
+++#define CONFIG_DNN_PROCESSING_FILTER 0
+++#define CONFIG_DOUBLEWEAVE_FILTER 0
+++#define CONFIG_DRAWBOX_FILTER 0
+++#define CONFIG_DRAWGRAPH_FILTER 0
+++#define CONFIG_DRAWGRID_FILTER 0
+++#define CONFIG_DRAWTEXT_FILTER 0
+++#define CONFIG_EDGEDETECT_FILTER 0
+++#define CONFIG_ELBG_FILTER 0
+++#define CONFIG_ENTROPY_FILTER 0
+++#define CONFIG_EPX_FILTER 0
+++#define CONFIG_EQ_FILTER 0
+++#define CONFIG_EROSION_FILTER 0
+++#define CONFIG_EROSION_OPENCL_FILTER 0
+++#define CONFIG_ESTDIF_FILTER 0
+++#define CONFIG_EXPOSURE_FILTER 0
+++#define CONFIG_EXTRACTPLANES_FILTER 0
+++#define CONFIG_FADE_FILTER 0
+++#define CONFIG_FEEDBACK_FILTER 0
+++#define CONFIG_FFTDNOIZ_FILTER 0
+++#define CONFIG_FFTFILT_FILTER 0
+++#define CONFIG_FIELD_FILTER 0
+++#define CONFIG_FIELDHINT_FILTER 0
+++#define CONFIG_FIELDMATCH_FILTER 0
+++#define CONFIG_FIELDORDER_FILTER 0
+++#define CONFIG_FILLBORDERS_FILTER 0
+++#define CONFIG_FIND_RECT_FILTER 0
+++#define CONFIG_FLIP_VULKAN_FILTER 0
+++#define CONFIG_FLOODFILL_FILTER 0
+++#define CONFIG_FORMAT_FILTER 0
+++#define CONFIG_FPS_FILTER 0
+++#define CONFIG_FRAMEPACK_FILTER 0
+++#define CONFIG_FRAMERATE_FILTER 0
+++#define CONFIG_FRAMESTEP_FILTER 0
+++#define CONFIG_FREEZEDETECT_FILTER 0
+++#define CONFIG_FREEZEFRAMES_FILTER 0
+++#define CONFIG_FREI0R_FILTER 0
+++#define CONFIG_FSPP_FILTER 0
+++#define CONFIG_FSYNC_FILTER 0
+++#define CONFIG_GBLUR_FILTER 0
+++#define CONFIG_GBLUR_VULKAN_FILTER 0
+++#define CONFIG_GEQ_FILTER 0
+++#define CONFIG_GRADFUN_FILTER 0
+++#define CONFIG_GRAPHMONITOR_FILTER 0
+++#define CONFIG_GRAYWORLD_FILTER 0
+++#define CONFIG_GREYEDGE_FILTER 0
+++#define CONFIG_GUIDED_FILTER 0
+++#define CONFIG_HALDCLUT_FILTER 0
+++#define CONFIG_HFLIP_FILTER 0
+++#define CONFIG_HFLIP_VULKAN_FILTER 0
+++#define CONFIG_HISTEQ_FILTER 0
+++#define CONFIG_HISTOGRAM_FILTER 0
+++#define CONFIG_HQDN3D_FILTER 0
+++#define CONFIG_HQX_FILTER 0
+++#define CONFIG_HSTACK_FILTER 0
+++#define CONFIG_HSVHOLD_FILTER 0
+++#define CONFIG_HSVKEY_FILTER 0
+++#define CONFIG_HUE_FILTER 0
+++#define CONFIG_HUESATURATION_FILTER 0
+++#define CONFIG_HWDOWNLOAD_FILTER 0
+++#define CONFIG_HWMAP_FILTER 0
+++#define CONFIG_HWUPLOAD_FILTER 0
+++#define CONFIG_HWUPLOAD_CUDA_FILTER 0
+++#define CONFIG_HYSTERESIS_FILTER 0
+++#define CONFIG_ICCDETECT_FILTER 0
+++#define CONFIG_ICCGEN_FILTER 0
+++#define CONFIG_IDENTITY_FILTER 0
+++#define CONFIG_IDET_FILTER 0
+++#define CONFIG_IL_FILTER 0
+++#define CONFIG_INFLATE_FILTER 0
+++#define CONFIG_INTERLACE_FILTER 0
+++#define CONFIG_INTERLEAVE_FILTER 0
+++#define CONFIG_KERNDEINT_FILTER 0
+++#define CONFIG_KIRSCH_FILTER 0
+++#define CONFIG_LAGFUN_FILTER 0
+++#define CONFIG_LATENCY_FILTER 0
+++#define CONFIG_LENSCORRECTION_FILTER 0
+++#define CONFIG_LENSFUN_FILTER 0
+++#define CONFIG_LIBPLACEBO_FILTER 0
+++#define CONFIG_LIBVMAF_FILTER 0
+++#define CONFIG_LIBVMAF_CUDA_FILTER 0
+++#define CONFIG_LIMITDIFF_FILTER 0
+++#define CONFIG_LIMITER_FILTER 0
+++#define CONFIG_LOOP_FILTER 0
+++#define CONFIG_LUMAKEY_FILTER 0
+++#define CONFIG_LUT_FILTER 0
+++#define CONFIG_LUT1D_FILTER 0
+++#define CONFIG_LUT2_FILTER 0
+++#define CONFIG_LUT3D_FILTER 0
+++#define CONFIG_LUTRGB_FILTER 0
+++#define CONFIG_LUTYUV_FILTER 0
+++#define CONFIG_MASKEDCLAMP_FILTER 0
+++#define CONFIG_MASKEDMAX_FILTER 0
+++#define CONFIG_MASKEDMERGE_FILTER 0
+++#define CONFIG_MASKEDMIN_FILTER 0
+++#define CONFIG_MASKEDTHRESHOLD_FILTER 0
+++#define CONFIG_MASKFUN_FILTER 0
+++#define CONFIG_MCDEINT_FILTER 0
+++#define CONFIG_MEDIAN_FILTER 0
+++#define CONFIG_MERGEPLANES_FILTER 0
+++#define CONFIG_MESTIMATE_FILTER 0
+++#define CONFIG_METADATA_FILTER 0
+++#define CONFIG_MIDEQUALIZER_FILTER 0
+++#define CONFIG_MINTERPOLATE_FILTER 0
+++#define CONFIG_MIX_FILTER 0
+++#define CONFIG_MONOCHROME_FILTER 0
+++#define CONFIG_MORPHO_FILTER 0
+++#define CONFIG_MPDECIMATE_FILTER 0
+++#define CONFIG_MSAD_FILTER 0
+++#define CONFIG_MULTIPLY_FILTER 0
+++#define CONFIG_NEGATE_FILTER 0
+++#define CONFIG_NLMEANS_FILTER 0
+++#define CONFIG_NLMEANS_OPENCL_FILTER 0
+++#define CONFIG_NLMEANS_VULKAN_FILTER 0
+++#define CONFIG_NNEDI_FILTER 0
+++#define CONFIG_NOFORMAT_FILTER 0
+++#define CONFIG_NOISE_FILTER 0
+++#define CONFIG_NORMALIZE_FILTER 0
+++#define CONFIG_NULL_FILTER 0
+++#define CONFIG_OCR_FILTER 0
+++#define CONFIG_OCV_FILTER 0
+++#define CONFIG_OSCILLOSCOPE_FILTER 0
+++#define CONFIG_OVERLAY_FILTER 0
+++#define CONFIG_OVERLAY_OPENCL_FILTER 0
+++#define CONFIG_OVERLAY_QSV_FILTER 0
+++#define CONFIG_OVERLAY_VAAPI_FILTER 0
+++#define CONFIG_OVERLAY_VULKAN_FILTER 0
+++#define CONFIG_OVERLAY_CUDA_FILTER 0
+++#define CONFIG_OWDENOISE_FILTER 0
+++#define CONFIG_PAD_FILTER 0
+++#define CONFIG_PAD_OPENCL_FILTER 0
+++#define CONFIG_PALETTEGEN_FILTER 0
+++#define CONFIG_PALETTEUSE_FILTER 0
+++#define CONFIG_PERMS_FILTER 0
+++#define CONFIG_PERSPECTIVE_FILTER 0
+++#define CONFIG_PHASE_FILTER 0
+++#define CONFIG_PHOTOSENSITIVITY_FILTER 0
+++#define CONFIG_PIXDESCTEST_FILTER 0
+++#define CONFIG_PIXELIZE_FILTER 0
+++#define CONFIG_PIXSCOPE_FILTER 0
+++#define CONFIG_PP_FILTER 0
+++#define CONFIG_PP7_FILTER 0
+++#define CONFIG_PREMULTIPLY_FILTER 0
+++#define CONFIG_PREWITT_FILTER 0
+++#define CONFIG_PREWITT_OPENCL_FILTER 0
+++#define CONFIG_PROCAMP_VAAPI_FILTER 0
+++#define CONFIG_PROGRAM_OPENCL_FILTER 0
+++#define CONFIG_PSEUDOCOLOR_FILTER 0
+++#define CONFIG_PSNR_FILTER 0
+++#define CONFIG_PULLUP_FILTER 0
+++#define CONFIG_QP_FILTER 0
+++#define CONFIG_QRENCODE_FILTER 0
+++#define CONFIG_QUIRC_FILTER 0
+++#define CONFIG_RANDOM_FILTER 0
+++#define CONFIG_READEIA608_FILTER 0
+++#define CONFIG_READVITC_FILTER 0
+++#define CONFIG_REALTIME_FILTER 0
+++#define CONFIG_REMAP_FILTER 0
+++#define CONFIG_REMAP_OPENCL_FILTER 0
+++#define CONFIG_REMOVEGRAIN_FILTER 0
+++#define CONFIG_REMOVELOGO_FILTER 0
+++#define CONFIG_REPEATFIELDS_FILTER 0
+++#define CONFIG_REVERSE_FILTER 0
+++#define CONFIG_RGBASHIFT_FILTER 0
+++#define CONFIG_ROBERTS_FILTER 0
+++#define CONFIG_ROBERTS_OPENCL_FILTER 0
+++#define CONFIG_ROTATE_FILTER 0
+++#define CONFIG_SAB_FILTER 0
+++#define CONFIG_SCALE_FILTER 0
+++#define CONFIG_SCALE_CUDA_FILTER 0
+++#define CONFIG_SCALE_NPP_FILTER 0
+++#define CONFIG_SCALE_QSV_FILTER 0
+++#define CONFIG_SCALE_VAAPI_FILTER 0
+++#define CONFIG_SCALE_VT_FILTER 0
+++#define CONFIG_SCALE_VULKAN_FILTER 0
+++#define CONFIG_SCALE2REF_FILTER 0
+++#define CONFIG_SCALE2REF_NPP_FILTER 0
+++#define CONFIG_SCDET_FILTER 0
+++#define CONFIG_SCHARR_FILTER 0
+++#define CONFIG_SCROLL_FILTER 0
+++#define CONFIG_SEGMENT_FILTER 0
+++#define CONFIG_SELECT_FILTER 0
+++#define CONFIG_SELECTIVECOLOR_FILTER 0
+++#define CONFIG_SENDCMD_FILTER 0
+++#define CONFIG_SEPARATEFIELDS_FILTER 0
+++#define CONFIG_SETDAR_FILTER 0
+++#define CONFIG_SETFIELD_FILTER 0
+++#define CONFIG_SETPARAMS_FILTER 0
+++#define CONFIG_SETPTS_FILTER 0
+++#define CONFIG_SETRANGE_FILTER 0
+++#define CONFIG_SETSAR_FILTER 0
+++#define CONFIG_SETTB_FILTER 0
+++#define CONFIG_SHARPEN_NPP_FILTER 0
+++#define CONFIG_SHARPNESS_VAAPI_FILTER 0
+++#define CONFIG_SHEAR_FILTER 0
+++#define CONFIG_SHOWINFO_FILTER 0
+++#define CONFIG_SHOWPALETTE_FILTER 0
+++#define CONFIG_SHUFFLEFRAMES_FILTER 0
+++#define CONFIG_SHUFFLEPIXELS_FILTER 0
+++#define CONFIG_SHUFFLEPLANES_FILTER 0
+++#define CONFIG_SIDEDATA_FILTER 0
+++#define CONFIG_SIGNALSTATS_FILTER 0
+++#define CONFIG_SIGNATURE_FILTER 0
+++#define CONFIG_SITI_FILTER 0
+++#define CONFIG_SMARTBLUR_FILTER 0
+++#define CONFIG_SOBEL_FILTER 0
+++#define CONFIG_SOBEL_OPENCL_FILTER 0
+++#define CONFIG_SPLIT_FILTER 0
+++#define CONFIG_SPP_FILTER 0
+++#define CONFIG_SR_FILTER 0
+++#define CONFIG_SSIM_FILTER 0
+++#define CONFIG_SSIM360_FILTER 0
+++#define CONFIG_STEREO3D_FILTER 0
+++#define CONFIG_STREAMSELECT_FILTER 0
+++#define CONFIG_SUBTITLES_FILTER 0
+++#define CONFIG_SUPER2XSAI_FILTER 0
+++#define CONFIG_SWAPRECT_FILTER 0
+++#define CONFIG_SWAPUV_FILTER 0
+++#define CONFIG_TBLEND_FILTER 0
+++#define CONFIG_TELECINE_FILTER 0
+++#define CONFIG_THISTOGRAM_FILTER 0
+++#define CONFIG_THRESHOLD_FILTER 0
+++#define CONFIG_THUMBNAIL_FILTER 0
+++#define CONFIG_THUMBNAIL_CUDA_FILTER 0
+++#define CONFIG_TILE_FILTER 0
+++#define CONFIG_TILTANDSHIFT_FILTER 0
+++#define CONFIG_TINTERLACE_FILTER 0
+++#define CONFIG_TLUT2_FILTER 0
+++#define CONFIG_TMEDIAN_FILTER 0
+++#define CONFIG_TMIDEQUALIZER_FILTER 0
+++#define CONFIG_TMIX_FILTER 0
+++#define CONFIG_TONEMAP_FILTER 0
+++#define CONFIG_TONEMAP_OPENCL_FILTER 0
+++#define CONFIG_TONEMAP_VAAPI_FILTER 0
+++#define CONFIG_TPAD_FILTER 0
+++#define CONFIG_TRANSPOSE_FILTER 0
+++#define CONFIG_TRANSPOSE_NPP_FILTER 0
+++#define CONFIG_TRANSPOSE_OPENCL_FILTER 0
+++#define CONFIG_TRANSPOSE_VAAPI_FILTER 0
+++#define CONFIG_TRANSPOSE_VT_FILTER 0
+++#define CONFIG_TRANSPOSE_VULKAN_FILTER 0
+++#define CONFIG_TRIM_FILTER 0
+++#define CONFIG_UNPREMULTIPLY_FILTER 0
+++#define CONFIG_UNSHARP_FILTER 0
+++#define CONFIG_UNSHARP_OPENCL_FILTER 0
+++#define CONFIG_UNTILE_FILTER 0
+++#define CONFIG_USPP_FILTER 0
+++#define CONFIG_V360_FILTER 0
+++#define CONFIG_VAGUEDENOISER_FILTER 0
+++#define CONFIG_VARBLUR_FILTER 0
+++#define CONFIG_VECTORSCOPE_FILTER 0
+++#define CONFIG_VFLIP_FILTER 0
+++#define CONFIG_VFLIP_VULKAN_FILTER 0
+++#define CONFIG_VFRDET_FILTER 0
+++#define CONFIG_VIBRANCE_FILTER 0
+++#define CONFIG_VIDSTABDETECT_FILTER 0
+++#define CONFIG_VIDSTABTRANSFORM_FILTER 0
+++#define CONFIG_VIF_FILTER 0
+++#define CONFIG_VIGNETTE_FILTER 0
+++#define CONFIG_VMAFMOTION_FILTER 0
+++#define CONFIG_VPP_QSV_FILTER 0
+++#define CONFIG_VSTACK_FILTER 0
+++#define CONFIG_W3FDIF_FILTER 0
+++#define CONFIG_WAVEFORM_FILTER 0
+++#define CONFIG_WEAVE_FILTER 0
+++#define CONFIG_XBR_FILTER 0
+++#define CONFIG_XCORRELATE_FILTER 0
+++#define CONFIG_XFADE_FILTER 0
+++#define CONFIG_XFADE_OPENCL_FILTER 0
+++#define CONFIG_XFADE_VULKAN_FILTER 0
+++#define CONFIG_XMEDIAN_FILTER 0
+++#define CONFIG_XSTACK_FILTER 0
+++#define CONFIG_YADIF_FILTER 0
+++#define CONFIG_YADIF_CUDA_FILTER 0
+++#define CONFIG_YADIF_VIDEOTOOLBOX_FILTER 0
+++#define CONFIG_YAEPBLUR_FILTER 0
+++#define CONFIG_ZMQ_FILTER 0
+++#define CONFIG_ZOOMPAN_FILTER 0
+++#define CONFIG_ZSCALE_FILTER 0
+++#define CONFIG_HSTACK_VAAPI_FILTER 0
+++#define CONFIG_VSTACK_VAAPI_FILTER 0
+++#define CONFIG_XSTACK_VAAPI_FILTER 0
+++#define CONFIG_HSTACK_QSV_FILTER 0
+++#define CONFIG_VSTACK_QSV_FILTER 0
+++#define CONFIG_XSTACK_QSV_FILTER 0
+++#define CONFIG_ALLRGB_FILTER 0
+++#define CONFIG_ALLYUV_FILTER 0
+++#define CONFIG_CELLAUTO_FILTER 0
+++#define CONFIG_COLOR_FILTER 0
+++#define CONFIG_COLOR_VULKAN_FILTER 0
+++#define CONFIG_COLORCHART_FILTER 0
+++#define CONFIG_COLORSPECTRUM_FILTER 0
+++#define CONFIG_COREIMAGESRC_FILTER 0
+++#define CONFIG_DDAGRAB_FILTER 0
+++#define CONFIG_FREI0R_SRC_FILTER 0
+++#define CONFIG_GRADIENTS_FILTER 0
+++#define CONFIG_HALDCLUTSRC_FILTER 0
+++#define CONFIG_LIFE_FILTER 0
+++#define CONFIG_MANDELBROT_FILTER 0
+++#define CONFIG_MPTESTSRC_FILTER 0
+++#define CONFIG_NULLSRC_FILTER 0
+++#define CONFIG_OPENCLSRC_FILTER 0
+++#define CONFIG_QRENCODESRC_FILTER 0
+++#define CONFIG_PAL75BARS_FILTER 0
+++#define CONFIG_PAL100BARS_FILTER 0
+++#define CONFIG_RGBTESTSRC_FILTER 0
+++#define CONFIG_SIERPINSKI_FILTER 0
+++#define CONFIG_SMPTEBARS_FILTER 0
+++#define CONFIG_SMPTEHDBARS_FILTER 0
+++#define CONFIG_TESTSRC_FILTER 0
+++#define CONFIG_TESTSRC2_FILTER 0
+++#define CONFIG_YUVTESTSRC_FILTER 0
+++#define CONFIG_ZONEPLATE_FILTER 0
+++#define CONFIG_NULLSINK_FILTER 0
+++#define CONFIG_A3DSCOPE_FILTER 0
+++#define CONFIG_ABITSCOPE_FILTER 0
+++#define CONFIG_ADRAWGRAPH_FILTER 0
+++#define CONFIG_AGRAPHMONITOR_FILTER 0
+++#define CONFIG_AHISTOGRAM_FILTER 0
+++#define CONFIG_APHASEMETER_FILTER 0
+++#define CONFIG_AVECTORSCOPE_FILTER 0
+++#define CONFIG_CONCAT_FILTER 0
+++#define CONFIG_SHOWCQT_FILTER 0
+++#define CONFIG_SHOWCWT_FILTER 0
+++#define CONFIG_SHOWFREQS_FILTER 0
+++#define CONFIG_SHOWSPATIAL_FILTER 0
+++#define CONFIG_SHOWSPECTRUM_FILTER 0
+++#define CONFIG_SHOWSPECTRUMPIC_FILTER 0
+++#define CONFIG_SHOWVOLUME_FILTER 0
+++#define CONFIG_SHOWWAVES_FILTER 0
+++#define CONFIG_SHOWWAVESPIC_FILTER 0
+++#define CONFIG_SPECTRUMSYNTH_FILTER 0
+++#define CONFIG_AVSYNCTEST_FILTER 0
+++#define CONFIG_AMOVIE_FILTER 0
+++#define CONFIG_MOVIE_FILTER 0
+++#define CONFIG_AA_DEMUXER 0
+++#define CONFIG_AAC_DEMUXER 0
+++#define CONFIG_AAX_DEMUXER 0
+++#define CONFIG_AC3_DEMUXER 0
+++#define CONFIG_AC4_DEMUXER 0
+++#define CONFIG_ACE_DEMUXER 0
+++#define CONFIG_ACM_DEMUXER 0
+++#define CONFIG_ACT_DEMUXER 0
+++#define CONFIG_ADF_DEMUXER 0
+++#define CONFIG_ADP_DEMUXER 0
+++#define CONFIG_ADS_DEMUXER 0
+++#define CONFIG_ADX_DEMUXER 0
+++#define CONFIG_AEA_DEMUXER 0
+++#define CONFIG_AFC_DEMUXER 0
+++#define CONFIG_AIFF_DEMUXER 0
+++#define CONFIG_AIX_DEMUXER 0
+++#define CONFIG_ALP_DEMUXER 0
+++#define CONFIG_AMR_DEMUXER 0
+++#define CONFIG_AMRNB_DEMUXER 0
+++#define CONFIG_AMRWB_DEMUXER 0
+++#define CONFIG_ANM_DEMUXER 0
+++#define CONFIG_APAC_DEMUXER 0
+++#define CONFIG_APC_DEMUXER 0
+++#define CONFIG_APE_DEMUXER 0
+++#define CONFIG_APM_DEMUXER 0
+++#define CONFIG_APNG_DEMUXER 0
+++#define CONFIG_APTX_DEMUXER 0
+++#define CONFIG_APTX_HD_DEMUXER 0
+++#define CONFIG_AQTITLE_DEMUXER 0
+++#define CONFIG_ARGO_ASF_DEMUXER 0
+++#define CONFIG_ARGO_BRP_DEMUXER 0
+++#define CONFIG_ARGO_CVG_DEMUXER 0
+++#define CONFIG_ASF_DEMUXER 0
+++#define CONFIG_ASF_O_DEMUXER 0
+++#define CONFIG_ASS_DEMUXER 0
+++#define CONFIG_AST_DEMUXER 0
+++#define CONFIG_AU_DEMUXER 0
+++#define CONFIG_AV1_DEMUXER 0
+++#define CONFIG_AVI_DEMUXER 0
+++#define CONFIG_AVISYNTH_DEMUXER 0
+++#define CONFIG_AVR_DEMUXER 0
+++#define CONFIG_AVS_DEMUXER 0
+++#define CONFIG_AVS2_DEMUXER 0
+++#define CONFIG_AVS3_DEMUXER 0
+++#define CONFIG_BETHSOFTVID_DEMUXER 0
+++#define CONFIG_BFI_DEMUXER 0
+++#define CONFIG_BINTEXT_DEMUXER 0
+++#define CONFIG_BINK_DEMUXER 0
+++#define CONFIG_BINKA_DEMUXER 0
+++#define CONFIG_BIT_DEMUXER 0
+++#define CONFIG_BITPACKED_DEMUXER 0
+++#define CONFIG_BMV_DEMUXER 0
+++#define CONFIG_BFSTM_DEMUXER 0
+++#define CONFIG_BRSTM_DEMUXER 0
+++#define CONFIG_BOA_DEMUXER 0
+++#define CONFIG_BONK_DEMUXER 0
+++#define CONFIG_C93_DEMUXER 0
+++#define CONFIG_CAF_DEMUXER 0
+++#define CONFIG_CAVSVIDEO_DEMUXER 0
+++#define CONFIG_CDG_DEMUXER 0
+++#define CONFIG_CDXL_DEMUXER 0
+++#define CONFIG_CINE_DEMUXER 0
+++#define CONFIG_CODEC2_DEMUXER 0
+++#define CONFIG_CODEC2RAW_DEMUXER 0
+++#define CONFIG_CONCAT_DEMUXER 0
+++#define CONFIG_DASH_DEMUXER 0
+++#define CONFIG_DATA_DEMUXER 0
+++#define CONFIG_DAUD_DEMUXER 0
+++#define CONFIG_DCSTR_DEMUXER 0
+++#define CONFIG_DERF_DEMUXER 0
+++#define CONFIG_DFA_DEMUXER 0
+++#define CONFIG_DFPWM_DEMUXER 0
+++#define CONFIG_DHAV_DEMUXER 0
+++#define CONFIG_DIRAC_DEMUXER 0
+++#define CONFIG_DNXHD_DEMUXER 0
+++#define CONFIG_DSF_DEMUXER 0
+++#define CONFIG_DSICIN_DEMUXER 0
+++#define CONFIG_DSS_DEMUXER 0
+++#define CONFIG_DTS_DEMUXER 0
+++#define CONFIG_DTSHD_DEMUXER 0
+++#define CONFIG_DV_DEMUXER 0
+++#define CONFIG_DVBSUB_DEMUXER 0
+++#define CONFIG_DVBTXT_DEMUXER 0
+++#define CONFIG_DXA_DEMUXER 0
+++#define CONFIG_EA_DEMUXER 0
+++#define CONFIG_EA_CDATA_DEMUXER 0
+++#define CONFIG_EAC3_DEMUXER 0
+++#define CONFIG_EPAF_DEMUXER 0
+++#define CONFIG_EVC_DEMUXER 0
+++#define CONFIG_FFMETADATA_DEMUXER 0
+++#define CONFIG_FILMSTRIP_DEMUXER 0
+++#define CONFIG_FITS_DEMUXER 0
+++#define CONFIG_FLAC_DEMUXER 1
+++#define CONFIG_FLIC_DEMUXER 0
+++#define CONFIG_FLV_DEMUXER 0
+++#define CONFIG_LIVE_FLV_DEMUXER 0
+++#define CONFIG_FOURXM_DEMUXER 0
+++#define CONFIG_FRM_DEMUXER 0
+++#define CONFIG_FSB_DEMUXER 0
+++#define CONFIG_FWSE_DEMUXER 0
+++#define CONFIG_G722_DEMUXER 0
+++#define CONFIG_G723_1_DEMUXER 0
+++#define CONFIG_G726_DEMUXER 0
+++#define CONFIG_G726LE_DEMUXER 0
+++#define CONFIG_G729_DEMUXER 0
+++#define CONFIG_GDV_DEMUXER 0
+++#define CONFIG_GENH_DEMUXER 0
+++#define CONFIG_GIF_DEMUXER 0
+++#define CONFIG_GSM_DEMUXER 0
+++#define CONFIG_GXF_DEMUXER 0
+++#define CONFIG_H261_DEMUXER 0
+++#define CONFIG_H263_DEMUXER 0
+++#define CONFIG_H264_DEMUXER 0
+++#define CONFIG_HCA_DEMUXER 0
+++#define CONFIG_HCOM_DEMUXER 0
+++#define CONFIG_HEVC_DEMUXER 0
+++#define CONFIG_HLS_DEMUXER 0
+++#define CONFIG_HNM_DEMUXER 0
+++#define CONFIG_IAMF_DEMUXER 0
+++#define CONFIG_ICO_DEMUXER 0
+++#define CONFIG_IDCIN_DEMUXER 0
+++#define CONFIG_IDF_DEMUXER 0
+++#define CONFIG_IFF_DEMUXER 0
+++#define CONFIG_IFV_DEMUXER 0
+++#define CONFIG_ILBC_DEMUXER 0
+++#define CONFIG_IMAGE2_DEMUXER 0
+++#define CONFIG_IMAGE2PIPE_DEMUXER 0
+++#define CONFIG_IMAGE2_ALIAS_PIX_DEMUXER 0
+++#define CONFIG_IMAGE2_BRENDER_PIX_DEMUXER 0
+++#define CONFIG_IMF_DEMUXER 0
+++#define CONFIG_INGENIENT_DEMUXER 0
+++#define CONFIG_IPMOVIE_DEMUXER 0
+++#define CONFIG_IPU_DEMUXER 0
+++#define CONFIG_IRCAM_DEMUXER 0
+++#define CONFIG_ISS_DEMUXER 0
+++#define CONFIG_IV8_DEMUXER 0
+++#define CONFIG_IVF_DEMUXER 0
+++#define CONFIG_IVR_DEMUXER 0
+++#define CONFIG_JACOSUB_DEMUXER 0
+++#define CONFIG_JV_DEMUXER 0
+++#define CONFIG_JPEGXL_ANIM_DEMUXER 0
+++#define CONFIG_KUX_DEMUXER 0
+++#define CONFIG_KVAG_DEMUXER 0
+++#define CONFIG_LAF_DEMUXER 0
+++#define CONFIG_LMLM4_DEMUXER 0
+++#define CONFIG_LOAS_DEMUXER 0
+++#define CONFIG_LUODAT_DEMUXER 0
+++#define CONFIG_LRC_DEMUXER 0
+++#define CONFIG_LVF_DEMUXER 0
+++#define CONFIG_LXF_DEMUXER 0
+++#define CONFIG_M4V_DEMUXER 0
+++#define CONFIG_MCA_DEMUXER 0
+++#define CONFIG_MCC_DEMUXER 0
+++#define CONFIG_MATROSKA_DEMUXER 1
+++#define CONFIG_MGSTS_DEMUXER 0
+++#define CONFIG_MICRODVD_DEMUXER 0
+++#define CONFIG_MJPEG_DEMUXER 0
+++#define CONFIG_MJPEG_2000_DEMUXER 0
+++#define CONFIG_MLP_DEMUXER 0
+++#define CONFIG_MLV_DEMUXER 0
+++#define CONFIG_MM_DEMUXER 0
+++#define CONFIG_MMF_DEMUXER 0
+++#define CONFIG_MODS_DEMUXER 0
+++#define CONFIG_MOFLEX_DEMUXER 0
+++#define CONFIG_MOV_DEMUXER 1
+++#define CONFIG_MP3_DEMUXER 1
+++#define CONFIG_MPC_DEMUXER 0
+++#define CONFIG_MPC8_DEMUXER 0
+++#define CONFIG_MPEGPS_DEMUXER 0
+++#define CONFIG_MPEGTS_DEMUXER 0
+++#define CONFIG_MPEGTSRAW_DEMUXER 0
+++#define CONFIG_MPEGVIDEO_DEMUXER 0
+++#define CONFIG_MPJPEG_DEMUXER 0
+++#define CONFIG_MPL2_DEMUXER 0
+++#define CONFIG_MPSUB_DEMUXER 0
+++#define CONFIG_MSF_DEMUXER 0
+++#define CONFIG_MSNWC_TCP_DEMUXER 0
+++#define CONFIG_MSP_DEMUXER 0
+++#define CONFIG_MTAF_DEMUXER 0
+++#define CONFIG_MTV_DEMUXER 0
+++#define CONFIG_MUSX_DEMUXER 0
+++#define CONFIG_MV_DEMUXER 0
+++#define CONFIG_MVI_DEMUXER 0
+++#define CONFIG_MXF_DEMUXER 0
+++#define CONFIG_MXG_DEMUXER 0
+++#define CONFIG_NC_DEMUXER 0
+++#define CONFIG_NISTSPHERE_DEMUXER 0
+++#define CONFIG_NSP_DEMUXER 0
+++#define CONFIG_NSV_DEMUXER 0
+++#define CONFIG_NUT_DEMUXER 0
+++#define CONFIG_NUV_DEMUXER 0
+++#define CONFIG_OBU_DEMUXER 0
+++#define CONFIG_OGG_DEMUXER 1
+++#define CONFIG_OMA_DEMUXER 0
+++#define CONFIG_OSQ_DEMUXER 0
+++#define CONFIG_PAF_DEMUXER 0
+++#define CONFIG_PCM_ALAW_DEMUXER 0
+++#define CONFIG_PCM_MULAW_DEMUXER 0
+++#define CONFIG_PCM_VIDC_DEMUXER 0
+++#define CONFIG_PCM_F64BE_DEMUXER 0
+++#define CONFIG_PCM_F64LE_DEMUXER 0
+++#define CONFIG_PCM_F32BE_DEMUXER 0
+++#define CONFIG_PCM_F32LE_DEMUXER 0
+++#define CONFIG_PCM_S32BE_DEMUXER 0
+++#define CONFIG_PCM_S32LE_DEMUXER 0
+++#define CONFIG_PCM_S24BE_DEMUXER 0
+++#define CONFIG_PCM_S24LE_DEMUXER 0
+++#define CONFIG_PCM_S16BE_DEMUXER 0
+++#define CONFIG_PCM_S16LE_DEMUXER 0
+++#define CONFIG_PCM_S8_DEMUXER 0
+++#define CONFIG_PCM_U32BE_DEMUXER 0
+++#define CONFIG_PCM_U32LE_DEMUXER 0
+++#define CONFIG_PCM_U24BE_DEMUXER 0
+++#define CONFIG_PCM_U24LE_DEMUXER 0
+++#define CONFIG_PCM_U16BE_DEMUXER 0
+++#define CONFIG_PCM_U16LE_DEMUXER 0
+++#define CONFIG_PCM_U8_DEMUXER 0
+++#define CONFIG_PDV_DEMUXER 0
+++#define CONFIG_PJS_DEMUXER 0
+++#define CONFIG_PMP_DEMUXER 0
+++#define CONFIG_PP_BNK_DEMUXER 0
+++#define CONFIG_PVA_DEMUXER 0
+++#define CONFIG_PVF_DEMUXER 0
+++#define CONFIG_QCP_DEMUXER 0
+++#define CONFIG_QOA_DEMUXER 0
+++#define CONFIG_R3D_DEMUXER 0
+++#define CONFIG_RAWVIDEO_DEMUXER 0
+++#define CONFIG_REALTEXT_DEMUXER 0
+++#define CONFIG_REDSPARK_DEMUXER 0
+++#define CONFIG_RKA_DEMUXER 0
+++#define CONFIG_RL2_DEMUXER 0
+++#define CONFIG_RM_DEMUXER 0
+++#define CONFIG_ROQ_DEMUXER 0
+++#define CONFIG_RPL_DEMUXER 0
+++#define CONFIG_RSD_DEMUXER 0
+++#define CONFIG_RSO_DEMUXER 0
+++#define CONFIG_RTP_DEMUXER 0
+++#define CONFIG_RTSP_DEMUXER 0
+++#define CONFIG_S337M_DEMUXER 0
+++#define CONFIG_SAMI_DEMUXER 0
+++#define CONFIG_SAP_DEMUXER 0
+++#define CONFIG_SBC_DEMUXER 0
+++#define CONFIG_SBG_DEMUXER 0
+++#define CONFIG_SCC_DEMUXER 0
+++#define CONFIG_SCD_DEMUXER 0
+++#define CONFIG_SDNS_DEMUXER 0
+++#define CONFIG_SDP_DEMUXER 0
+++#define CONFIG_SDR2_DEMUXER 0
+++#define CONFIG_SDS_DEMUXER 0
+++#define CONFIG_SDX_DEMUXER 0
+++#define CONFIG_SEGAFILM_DEMUXER 0
+++#define CONFIG_SER_DEMUXER 0
+++#define CONFIG_SGA_DEMUXER 0
+++#define CONFIG_SHORTEN_DEMUXER 0
+++#define CONFIG_SIFF_DEMUXER 0
+++#define CONFIG_SIMBIOSIS_IMX_DEMUXER 0
+++#define CONFIG_SLN_DEMUXER 0
+++#define CONFIG_SMACKER_DEMUXER 0
+++#define CONFIG_SMJPEG_DEMUXER 0
+++#define CONFIG_SMUSH_DEMUXER 0
+++#define CONFIG_SOL_DEMUXER 0
+++#define CONFIG_SOX_DEMUXER 0
+++#define CONFIG_SPDIF_DEMUXER 0
+++#define CONFIG_SRT_DEMUXER 0
+++#define CONFIG_STR_DEMUXER 0
+++#define CONFIG_STL_DEMUXER 0
+++#define CONFIG_SUBVIEWER1_DEMUXER 0
+++#define CONFIG_SUBVIEWER_DEMUXER 0
+++#define CONFIG_SUP_DEMUXER 0
+++#define CONFIG_SVAG_DEMUXER 0
+++#define CONFIG_SVS_DEMUXER 0
+++#define CONFIG_SWF_DEMUXER 0
+++#define CONFIG_TAK_DEMUXER 0
+++#define CONFIG_TEDCAPTIONS_DEMUXER 0
+++#define CONFIG_THP_DEMUXER 0
+++#define CONFIG_THREEDOSTR_DEMUXER 0
+++#define CONFIG_TIERTEXSEQ_DEMUXER 0
+++#define CONFIG_TMV_DEMUXER 0
+++#define CONFIG_TRUEHD_DEMUXER 0
+++#define CONFIG_TTA_DEMUXER 0
+++#define CONFIG_TXD_DEMUXER 0
+++#define CONFIG_TTY_DEMUXER 0
+++#define CONFIG_TY_DEMUXER 0
+++#define CONFIG_USM_DEMUXER 0
+++#define CONFIG_V210_DEMUXER 0
+++#define CONFIG_V210X_DEMUXER 0
+++#define CONFIG_VAG_DEMUXER 0
+++#define CONFIG_VC1_DEMUXER 0
+++#define CONFIG_VC1T_DEMUXER 0
+++#define CONFIG_VIVIDAS_DEMUXER 0
+++#define CONFIG_VIVO_DEMUXER 0
+++#define CONFIG_VMD_DEMUXER 0
+++#define CONFIG_VOBSUB_DEMUXER 0
+++#define CONFIG_VOC_DEMUXER 0
+++#define CONFIG_VPK_DEMUXER 0
+++#define CONFIG_VPLAYER_DEMUXER 0
+++#define CONFIG_VQF_DEMUXER 0
+++#define CONFIG_VVC_DEMUXER 0
+++#define CONFIG_W64_DEMUXER 0
+++#define CONFIG_WADY_DEMUXER 0
+++#define CONFIG_WAVARC_DEMUXER 0
+++#define CONFIG_WAV_DEMUXER 1
+++#define CONFIG_WC3_DEMUXER 0
+++#define CONFIG_WEBM_DASH_MANIFEST_DEMUXER 0
+++#define CONFIG_WEBVTT_DEMUXER 0
+++#define CONFIG_WSAUD_DEMUXER 0
+++#define CONFIG_WSD_DEMUXER 0
+++#define CONFIG_WSVQA_DEMUXER 0
+++#define CONFIG_WTV_DEMUXER 0
+++#define CONFIG_WVE_DEMUXER 0
+++#define CONFIG_WV_DEMUXER 0
+++#define CONFIG_XA_DEMUXER 0
+++#define CONFIG_XBIN_DEMUXER 0
+++#define CONFIG_XMD_DEMUXER 0
+++#define CONFIG_XMV_DEMUXER 0
+++#define CONFIG_XVAG_DEMUXER 0
+++#define CONFIG_XWMA_DEMUXER 0
+++#define CONFIG_YOP_DEMUXER 0
+++#define CONFIG_YUV4MPEGPIPE_DEMUXER 0
+++#define CONFIG_IMAGE_BMP_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_CRI_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_DDS_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_DPX_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_EXR_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_GEM_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_GIF_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_HDR_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_J2K_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_JPEG_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_JPEGLS_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_JPEGXL_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PAM_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PBM_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PCX_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PFM_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PGMYUV_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PGM_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PGX_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PHM_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PHOTOCD_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PICTOR_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PNG_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PPM_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_PSD_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_QDRAW_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_QOI_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_SGI_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_SVG_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_SUNRAST_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_TIFF_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_VBN_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_WEBP_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_XBM_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_XPM_PIPE_DEMUXER 0
+++#define CONFIG_IMAGE_XWD_PIPE_DEMUXER 0
+++#define CONFIG_LIBGME_DEMUXER 0
+++#define CONFIG_LIBMODPLUG_DEMUXER 0
+++#define CONFIG_LIBOPENMPT_DEMUXER 0
+++#define CONFIG_VAPOURSYNTH_DEMUXER 0
+++#define CONFIG_A64_MUXER 0
+++#define CONFIG_AC3_MUXER 0
+++#define CONFIG_AC4_MUXER 0
+++#define CONFIG_ADTS_MUXER 0
+++#define CONFIG_ADX_MUXER 0
+++#define CONFIG_AIFF_MUXER 0
+++#define CONFIG_ALP_MUXER 0
+++#define CONFIG_AMR_MUXER 0
+++#define CONFIG_AMV_MUXER 0
+++#define CONFIG_APM_MUXER 0
+++#define CONFIG_APNG_MUXER 0
+++#define CONFIG_APTX_MUXER 0
+++#define CONFIG_APTX_HD_MUXER 0
+++#define CONFIG_ARGO_ASF_MUXER 0
+++#define CONFIG_ARGO_CVG_MUXER 0
+++#define CONFIG_ASF_MUXER 0
+++#define CONFIG_ASS_MUXER 0
+++#define CONFIG_AST_MUXER 0
+++#define CONFIG_ASF_STREAM_MUXER 0
+++#define CONFIG_AU_MUXER 0
+++#define CONFIG_AVI_MUXER 0
+++#define CONFIG_AVIF_MUXER 0
+++#define CONFIG_AVM2_MUXER 0
+++#define CONFIG_AVS2_MUXER 0
+++#define CONFIG_AVS3_MUXER 0
+++#define CONFIG_BIT_MUXER 0
+++#define CONFIG_CAF_MUXER 0
+++#define CONFIG_CAVSVIDEO_MUXER 0
+++#define CONFIG_CODEC2_MUXER 0
+++#define CONFIG_CODEC2RAW_MUXER 0
+++#define CONFIG_CRC_MUXER 0
+++#define CONFIG_DASH_MUXER 0
+++#define CONFIG_DATA_MUXER 0
+++#define CONFIG_DAUD_MUXER 0
+++#define CONFIG_DFPWM_MUXER 0
+++#define CONFIG_DIRAC_MUXER 0
+++#define CONFIG_DNXHD_MUXER 0
+++#define CONFIG_DTS_MUXER 0
+++#define CONFIG_DV_MUXER 0
+++#define CONFIG_EAC3_MUXER 0
+++#define CONFIG_EVC_MUXER 0
+++#define CONFIG_F4V_MUXER 0
+++#define CONFIG_FFMETADATA_MUXER 0
+++#define CONFIG_FIFO_MUXER 0
+++#define CONFIG_FIFO_TEST_MUXER 0
+++#define CONFIG_FILMSTRIP_MUXER 0
+++#define CONFIG_FITS_MUXER 0
+++#define CONFIG_FLAC_MUXER 0
+++#define CONFIG_FLV_MUXER 0
+++#define CONFIG_FRAMECRC_MUXER 0
+++#define CONFIG_FRAMEHASH_MUXER 0
+++#define CONFIG_FRAMEMD5_MUXER 0
+++#define CONFIG_G722_MUXER 0
+++#define CONFIG_G723_1_MUXER 0
+++#define CONFIG_G726_MUXER 0
+++#define CONFIG_G726LE_MUXER 0
+++#define CONFIG_GIF_MUXER 0
+++#define CONFIG_GSM_MUXER 0
+++#define CONFIG_GXF_MUXER 0
+++#define CONFIG_H261_MUXER 0
+++#define CONFIG_H263_MUXER 0
+++#define CONFIG_H264_MUXER 0
+++#define CONFIG_HASH_MUXER 0
+++#define CONFIG_HDS_MUXER 0
+++#define CONFIG_HEVC_MUXER 0
+++#define CONFIG_HLS_MUXER 0
+++#define CONFIG_IAMF_MUXER 0
+++#define CONFIG_ICO_MUXER 0
+++#define CONFIG_ILBC_MUXER 0
+++#define CONFIG_IMAGE2_MUXER 0
+++#define CONFIG_IMAGE2PIPE_MUXER 0
+++#define CONFIG_IPOD_MUXER 0
+++#define CONFIG_IRCAM_MUXER 0
+++#define CONFIG_ISMV_MUXER 0
+++#define CONFIG_IVF_MUXER 0
+++#define CONFIG_JACOSUB_MUXER 0
+++#define CONFIG_KVAG_MUXER 0
+++#define CONFIG_LATM_MUXER 0
+++#define CONFIG_LRC_MUXER 0
+++#define CONFIG_M4V_MUXER 0
+++#define CONFIG_MD5_MUXER 0
+++#define CONFIG_MATROSKA_MUXER 0
+++#define CONFIG_MATROSKA_AUDIO_MUXER 0
+++#define CONFIG_MICRODVD_MUXER 0
+++#define CONFIG_MJPEG_MUXER 0
+++#define CONFIG_MLP_MUXER 0
+++#define CONFIG_MMF_MUXER 0
+++#define CONFIG_MOV_MUXER 0
+++#define CONFIG_MP2_MUXER 0
+++#define CONFIG_MP3_MUXER 0
+++#define CONFIG_MP4_MUXER 0
+++#define CONFIG_MPEG1SYSTEM_MUXER 0
+++#define CONFIG_MPEG1VCD_MUXER 0
+++#define CONFIG_MPEG1VIDEO_MUXER 0
+++#define CONFIG_MPEG2DVD_MUXER 0
+++#define CONFIG_MPEG2SVCD_MUXER 0
+++#define CONFIG_MPEG2VIDEO_MUXER 0
+++#define CONFIG_MPEG2VOB_MUXER 0
+++#define CONFIG_MPEGTS_MUXER 0
+++#define CONFIG_MPJPEG_MUXER 0
+++#define CONFIG_MXF_MUXER 0
+++#define CONFIG_MXF_D10_MUXER 0
+++#define CONFIG_MXF_OPATOM_MUXER 0
+++#define CONFIG_NULL_MUXER 0
+++#define CONFIG_NUT_MUXER 0
+++#define CONFIG_OBU_MUXER 0
+++#define CONFIG_OGA_MUXER 0
+++#define CONFIG_OGG_MUXER 0
+++#define CONFIG_OGV_MUXER 0
+++#define CONFIG_OMA_MUXER 0
+++#define CONFIG_OPUS_MUXER 0
+++#define CONFIG_PCM_ALAW_MUXER 0
+++#define CONFIG_PCM_MULAW_MUXER 0
+++#define CONFIG_PCM_VIDC_MUXER 0
+++#define CONFIG_PCM_F64BE_MUXER 0
+++#define CONFIG_PCM_F64LE_MUXER 0
+++#define CONFIG_PCM_F32BE_MUXER 0
+++#define CONFIG_PCM_F32LE_MUXER 0
+++#define CONFIG_PCM_S32BE_MUXER 0
+++#define CONFIG_PCM_S32LE_MUXER 0
+++#define CONFIG_PCM_S24BE_MUXER 0
+++#define CONFIG_PCM_S24LE_MUXER 0
+++#define CONFIG_PCM_S16BE_MUXER 0
+++#define CONFIG_PCM_S16LE_MUXER 0
+++#define CONFIG_PCM_S8_MUXER 0
+++#define CONFIG_PCM_U32BE_MUXER 0
+++#define CONFIG_PCM_U32LE_MUXER 0
+++#define CONFIG_PCM_U24BE_MUXER 0
+++#define CONFIG_PCM_U24LE_MUXER 0
+++#define CONFIG_PCM_U16BE_MUXER 0
+++#define CONFIG_PCM_U16LE_MUXER 0
+++#define CONFIG_PCM_U8_MUXER 0
+++#define CONFIG_PSP_MUXER 0
+++#define CONFIG_RAWVIDEO_MUXER 0
+++#define CONFIG_RCWT_MUXER 0
+++#define CONFIG_RM_MUXER 0
+++#define CONFIG_ROQ_MUXER 0
+++#define CONFIG_RSO_MUXER 0
+++#define CONFIG_RTP_MUXER 0
+++#define CONFIG_RTP_MPEGTS_MUXER 0
+++#define CONFIG_RTSP_MUXER 0
+++#define CONFIG_SAP_MUXER 0
+++#define CONFIG_SBC_MUXER 0
+++#define CONFIG_SCC_MUXER 0
+++#define CONFIG_SEGAFILM_MUXER 0
+++#define CONFIG_SEGMENT_MUXER 0
+++#define CONFIG_STREAM_SEGMENT_MUXER 0
+++#define CONFIG_SMJPEG_MUXER 0
+++#define CONFIG_SMOOTHSTREAMING_MUXER 0
+++#define CONFIG_SOX_MUXER 0
+++#define CONFIG_SPX_MUXER 0
+++#define CONFIG_SPDIF_MUXER 0
+++#define CONFIG_SRT_MUXER 0
+++#define CONFIG_STREAMHASH_MUXER 0
+++#define CONFIG_SUP_MUXER 0
+++#define CONFIG_SWF_MUXER 0
+++#define CONFIG_TEE_MUXER 0
+++#define CONFIG_TG2_MUXER 0
+++#define CONFIG_TGP_MUXER 0
+++#define CONFIG_MKVTIMESTAMP_V2_MUXER 0
+++#define CONFIG_TRUEHD_MUXER 0
+++#define CONFIG_TTA_MUXER 0
+++#define CONFIG_TTML_MUXER 0
+++#define CONFIG_UNCODEDFRAMECRC_MUXER 0
+++#define CONFIG_VC1_MUXER 0
+++#define CONFIG_VC1T_MUXER 0
+++#define CONFIG_VOC_MUXER 0
+++#define CONFIG_VVC_MUXER 0
+++#define CONFIG_W64_MUXER 0
+++#define CONFIG_WAV_MUXER 0
+++#define CONFIG_WEBM_MUXER 0
+++#define CONFIG_WEBM_DASH_MANIFEST_MUXER 0
+++#define CONFIG_WEBM_CHUNK_MUXER 0
+++#define CONFIG_WEBP_MUXER 0
+++#define CONFIG_WEBVTT_MUXER 0
+++#define CONFIG_WSAUD_MUXER 0
+++#define CONFIG_WTV_MUXER 0
+++#define CONFIG_WV_MUXER 0
+++#define CONFIG_YUV4MPEGPIPE_MUXER 0
+++#define CONFIG_CHROMAPRINT_MUXER 0
+++#define CONFIG_ASYNC_PROTOCOL 0
+++#define CONFIG_BLURAY_PROTOCOL 0
+++#define CONFIG_CACHE_PROTOCOL 0
+++#define CONFIG_CONCAT_PROTOCOL 0
+++#define CONFIG_CONCATF_PROTOCOL 0
+++#define CONFIG_CRYPTO_PROTOCOL 0
+++#define CONFIG_DATA_PROTOCOL 0
+++#define CONFIG_FD_PROTOCOL 0
+++#define CONFIG_FFRTMPCRYPT_PROTOCOL 0
+++#define CONFIG_FFRTMPHTTP_PROTOCOL 0
+++#define CONFIG_FILE_PROTOCOL 0
+++#define CONFIG_FTP_PROTOCOL 0
+++#define CONFIG_GOPHER_PROTOCOL 0
+++#define CONFIG_GOPHERS_PROTOCOL 0
+++#define CONFIG_HLS_PROTOCOL 0
+++#define CONFIG_HTTP_PROTOCOL 0
+++#define CONFIG_HTTPPROXY_PROTOCOL 0
+++#define CONFIG_HTTPS_PROTOCOL 0
+++#define CONFIG_ICECAST_PROTOCOL 0
+++#define CONFIG_MMSH_PROTOCOL 0
+++#define CONFIG_MMST_PROTOCOL 0
+++#define CONFIG_MD5_PROTOCOL 0
+++#define CONFIG_PIPE_PROTOCOL 0
+++#define CONFIG_PROMPEG_PROTOCOL 0
+++#define CONFIG_RTMP_PROTOCOL 0
+++#define CONFIG_RTMPE_PROTOCOL 0
+++#define CONFIG_RTMPS_PROTOCOL 0
+++#define CONFIG_RTMPT_PROTOCOL 0
+++#define CONFIG_RTMPTE_PROTOCOL 0
+++#define CONFIG_RTMPTS_PROTOCOL 0
+++#define CONFIG_RTP_PROTOCOL 0
+++#define CONFIG_SCTP_PROTOCOL 0
+++#define CONFIG_SRTP_PROTOCOL 0
+++#define CONFIG_SUBFILE_PROTOCOL 0
+++#define CONFIG_TEE_PROTOCOL 0
+++#define CONFIG_TCP_PROTOCOL 0
+++#define CONFIG_TLS_PROTOCOL 0
+++#define CONFIG_UDP_PROTOCOL 0
+++#define CONFIG_UDPLITE_PROTOCOL 0
+++#define CONFIG_UNIX_PROTOCOL 0
+++#define CONFIG_LIBAMQP_PROTOCOL 0
+++#define CONFIG_LIBRIST_PROTOCOL 0
+++#define CONFIG_LIBRTMP_PROTOCOL 0
+++#define CONFIG_LIBRTMPE_PROTOCOL 0
+++#define CONFIG_LIBRTMPS_PROTOCOL 0
+++#define CONFIG_LIBRTMPT_PROTOCOL 0
+++#define CONFIG_LIBRTMPTE_PROTOCOL 0
+++#define CONFIG_LIBSRT_PROTOCOL 0
+++#define CONFIG_LIBSSH_PROTOCOL 0
+++#define CONFIG_LIBSMBCLIENT_PROTOCOL 0
+++#define CONFIG_LIBZMQ_PROTOCOL 0
+++#define CONFIG_IPFS_GATEWAY_PROTOCOL 0
+++#define CONFIG_IPNS_GATEWAY_PROTOCOL 0
+++#endif /* FFMPEG_CONFIG_COMPONENTS_H */
++diff --git a/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c b/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c
++new file mode 100644
++index 0000000000000000000000000000000000000000..7ff70c6e2d601734d335e33114f18ef17a6cf74b
++--- /dev/null
+++++ b/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c
++@@ -0,0 +1,2 @@
+++static const FFBitStreamFilter * const bitstream_filters[] = {
+++    NULL };
++diff --git a/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c b/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c
++new file mode 100644
++index 0000000000000000000000000000000000000000..7d9debfe612ea4c467ac4f1100ecf345d8f7a109
++--- /dev/null
+++++ b/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c
++@@ -0,0 +1,15 @@
+++static const FFCodec * const codec_list[] = {
+++    &ff_flac_decoder,
+++    &ff_mp3_decoder,
+++    &ff_vorbis_decoder,
+++    &ff_pcm_alaw_decoder,
+++    &ff_pcm_f32le_decoder,
+++    &ff_pcm_mulaw_decoder,
+++    &ff_pcm_s16be_decoder,
+++    &ff_pcm_s16le_decoder,
+++    &ff_pcm_s24be_decoder,
+++    &ff_pcm_s24le_decoder,
+++    &ff_pcm_s32le_decoder,
+++    &ff_pcm_u8_decoder,
+++    &ff_libopus_decoder,
+++    NULL };
++diff --git a/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c b/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c
++new file mode 100644
++index 0000000000000000000000000000000000000000..fdc533b38ff936e05c2295a224799806dddb62d7
++--- /dev/null
+++++ b/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c
++@@ -0,0 +1,7 @@
+++static const AVCodecParser * const parser_list[] = {
+++    &ff_flac_parser,
+++    &ff_mpegaudio_parser,
+++    &ff_opus_parser,
+++    &ff_vorbis_parser,
+++    &ff_vp9_parser,
+++    NULL };
++diff --git a/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c b/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c
++new file mode 100644
++index 0000000000000000000000000000000000000000..1908ba19e7797a0f80bab27c2cc41d27746e2691
++--- /dev/null
+++++ b/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c
++@@ -0,0 +1,8 @@
+++static const AVInputFormat * const demuxer_list[] = {
+++    &ff_flac_demuxer,
+++    &ff_matroska_demuxer,
+++    &ff_mov_demuxer,
+++    &ff_mp3_demuxer,
+++    &ff_ogg_demuxer,
+++    &ff_wav_demuxer,
+++    NULL };
++diff --git a/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c b/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c
++new file mode 100644
++index 0000000000000000000000000000000000000000..ae54c39f23d86d82a59e5c06ac66f9d5cc99056a
++--- /dev/null
+++++ b/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c
++@@ -0,0 +1,2 @@
+++static const FFOutputFormat * const muxer_list[] = {
+++    NULL };
++diff --git a/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c b/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c
++new file mode 100644
++index 0000000000000000000000000000000000000000..247e1e4c3a2895996fbe9d6bc51ac6fcca38f751
++--- /dev/null
+++++ b/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c
++@@ -0,0 +1,2 @@
+++static const URLProtocol * const url_protocols[] = {
+++    NULL };
++diff --git a/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h b/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h
++new file mode 100644
++index 0000000000000000000000000000000000000000..c289fbb551c1f89b72e8090b81139d8fb745af08
++--- /dev/null
+++++ b/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h
++@@ -0,0 +1,6 @@
+++/* Generated by ffmpeg configure */
+++#ifndef AVUTIL_AVCONFIG_H
+++#define AVUTIL_AVCONFIG_H
+++#define AV_HAVE_BIGENDIAN 0
+++#define AV_HAVE_FAST_UNALIGNED 1
+++#endif /* AVUTIL_AVCONFIG_H */
++diff --git a/chromium/config/Chromium/linux/loong64/libavutil/ffversion.h b/chromium/config/Chromium/linux/loong64/libavutil/ffversion.h
++new file mode 100644
++index 0000000000000000000000000000000000000000..52b8160ee44f281b642188e868efa395c8666d39
++--- /dev/null
+++++ b/chromium/config/Chromium/linux/loong64/libavutil/ffversion.h
++@@ -0,0 +1,5 @@
+++/* Automatically generated by version.sh, do not manually edit! */
+++#ifndef AVUTIL_FFVERSION_H
+++#define AVUTIL_FFVERSION_H
+++#define FFMPEG_VERSION "n5.0.1"
+++#endif /* AVUTIL_FFVERSION_H */
++diff --git a/ffmpeg_generated.gni b/ffmpeg_generated.gni
++index 37155be221758952c853e8d716ebfa644aedc2c4..5ec1097c1ad2d2f9ca4a182fb21c3323578a5221 100644
++--- a/ffmpeg_generated.gni
+++++ b/ffmpeg_generated.gni
++@@ -279,6 +279,7 @@ if ((is_apple && current_cpu == "x64" && ffmpeg_branding == "Chrome") ||
++ 
++ if ((current_cpu == "arm64" && ffmpeg_branding == "Chrome") ||
++     (current_cpu == "x64" && ffmpeg_branding == "Chrome") ||
+++    (current_cpu == "loong64" && ffmpeg_branding == "Chrome") ||
++     (is_android && current_cpu == "arm" && arm_use_neon &&
++      ffmpeg_branding == "Chrome") ||
++     (is_android && current_cpu == "x86" && ffmpeg_branding == "Chrome") ||
++@@ -363,6 +364,19 @@ if (current_cpu == "x64" || (is_android && current_cpu == "x86") ||
++   ]
++ }
++ 
+++if ((use_linux_config && current_cpu == "loong64")) {
+++  ffmpeg_c_sources += [
+++    "libavutil/loongarch/cpu.c",
+++    "libavcodec/loongarch/vp8dsp_init_loongarch.c",
+++    "libavcodec/loongarch/h264chroma_init_loongarch.c",
+++    "libavcodec/loongarch/h264dsp_init_loongarch.c",
+++    "libavcodec/loongarch/h264qpel_init_loongarch.c",
+++    "libavcodec/loongarch/videodsp_init.c",
+++    "libavcodec/loongarch/h264_intrapred_init_loongarch.c",
+++    "libavcodec/loongarch/hpeldsp_init_loongarch.c",
+++  ]
+++}
+++
++ if ((is_android && current_cpu == "arm" && arm_use_neon) ||
++     (use_linux_config && current_cpu == "arm" && arm_use_neon) ||
++     (use_linux_config && current_cpu == "arm")) {
+diff --git a/patches/skia/.patches b/patches/skia/.patches
+index 35c0761967..1b67584ff1 100644
+--- a/patches/skia/.patches
++++ b/patches/skia/.patches
+@@ -1 +1,2 @@
+ sksl_rp_prevent_overflow_when_computing_slot_allocation_size.patch
++loong64_support.patch
+diff --git a/patches/skia/loong64_support.patch b/patches/skia/loong64_support.patch
+new file mode 100644
+index 0000000000..24ce65754b
+--- /dev/null
++++ b/patches/skia/loong64_support.patch
+@@ -0,0 +1,23 @@
++From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
++From: darkyzhou <me@zqy.io>
++Date: Mon, 18 Nov 2024 16:20:14 +0000
++Subject: loong64 support
++
++Co-authored-by: Jiajie Chen <c@jia.je>
++
++diff --git a/src/opts/SkOpts_SetTarget.h b/src/opts/SkOpts_SetTarget.h
++index 525cfcb862ae96bf8573d00b67dc9e5e23c10d22..5f72a27db99d2b1e1ef6f7c54198f7bbfb9380e3 100644
++--- a/src/opts/SkOpts_SetTarget.h
+++++ b/src/opts/SkOpts_SetTarget.h
++@@ -135,9 +135,10 @@
++         #define SK_OPTS_NS lasx
++         // The intrinsic from lasxintrin.h is wrapped by the __loongarch_asx macro, so we need to define it.
++         #define __loongarch_asx
+++        #define __loongarch_sx
++ 
++         #if defined(__clang__)
++-          #pragma clang attribute push(__attribute__((target("lasx"))), apply_to=function)
+++          #pragma clang attribute push(__attribute__((target("lsx,lasx"))), apply_to=function)
++         #endif
++ 
++     #else
+diff --git a/patches/swiftshader/.patches b/patches/swiftshader/.patches
+new file mode 100644
+index 0000000000..ea62e0c740
+--- /dev/null
++++ b/patches/swiftshader/.patches
+@@ -0,0 +1 @@
++loong64_support.patch
+diff --git a/patches/swiftshader/loong64_support.patch b/patches/swiftshader/loong64_support.patch
+new file mode 100644
+index 0000000000..fb204b355e
+--- /dev/null
++++ b/patches/swiftshader/loong64_support.patch
+@@ -0,0 +1,165 @@
++From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
++From: darkyzhou <me@zqy.io>
++Date: Mon, 18 Nov 2024 15:49:06 +0000
++Subject: loong64 support
++
++Co-authored-by: Jiajie Chen <c@jia.je>
++
++diff --git a/src/Reactor/BUILD.gn b/src/Reactor/BUILD.gn
++index 67dfeb0ec..c9683912e 100644
++--- a/src/Reactor/BUILD.gn
+++++ b/src/Reactor/BUILD.gn
++@@ -307,7 +307,11 @@ if (supports_subzero) {
++ 
++ if (supports_llvm) {
++   swiftshader_source_set("swiftshader_llvm_reactor") {
++-    llvm_dir = "../../third_party/llvm-10.0"
+++    if (current_cpu == "loong64") {
+++      llvm_dir = "../../third_party/llvm-16.0"
+++    } else {
+++      llvm_dir = "../../third_party/llvm-10.0"
+++    }
++ 
++     deps = [
++       ":swiftshader_reactor_base",
++diff --git a/third_party/llvm-16.0/configs/linux/include/llvm/Config/AsmParsers.def b/third_party/llvm-16.0/configs/linux/include/llvm/Config/AsmParsers.def
++index 2af3e28e8..521454bdf 100644
++--- a/third_party/llvm-16.0/configs/linux/include/llvm/Config/AsmParsers.def
+++++ b/third_party/llvm-16.0/configs/linux/include/llvm/Config/AsmParsers.def
++@@ -45,6 +45,9 @@ LLVM_ASM_PARSER(PowerPC)
++ #if defined(__riscv)
++ LLVM_ASM_PARSER(RISCV)
++ #endif
+++#if defined(__loongarch__)
+++LLVM_ASM_PARSER(LoongArch)
+++#endif
++ 
++ 
++ #undef LLVM_ASM_PARSER
++diff --git a/third_party/llvm-16.0/configs/linux/include/llvm/Config/AsmPrinters.def b/third_party/llvm-16.0/configs/linux/include/llvm/Config/AsmPrinters.def
++index 2f675be26..28eb68ec4 100644
++--- a/third_party/llvm-16.0/configs/linux/include/llvm/Config/AsmPrinters.def
+++++ b/third_party/llvm-16.0/configs/linux/include/llvm/Config/AsmPrinters.def
++@@ -45,6 +45,9 @@ LLVM_ASM_PRINTER(PowerPC)
++ #if defined(__riscv)
++ LLVM_ASM_PRINTER(RISCV)
++ #endif
+++#if defined(__loongarch__)
+++LLVM_ASM_PRINTER(LoongArch)
+++#endif
++ 
++ 
++ #undef LLVM_ASM_PRINTER
++diff --git a/third_party/llvm-16.0/configs/linux/include/llvm/Config/Disassemblers.def b/third_party/llvm-16.0/configs/linux/include/llvm/Config/Disassemblers.def
++index 80e3a1374..26ff566ff 100644
++--- a/third_party/llvm-16.0/configs/linux/include/llvm/Config/Disassemblers.def
+++++ b/third_party/llvm-16.0/configs/linux/include/llvm/Config/Disassemblers.def
++@@ -45,6 +45,9 @@ LLVM_DISASSEMBLER(PowerPC)
++ #if defined(__riscv)
++ LLVM_DISASSEMBLER(RISCV)
++ #endif
+++#if defined(__loongarch__)
+++LLVM_DISASSEMBLER(LoongArch)
+++#endif
++ 
++ 
++ #undef LLVM_DISASSEMBLER
++diff --git a/third_party/llvm-16.0/configs/linux/include/llvm/Config/Targets.def b/third_party/llvm-16.0/configs/linux/include/llvm/Config/Targets.def
++index d34b0eaee..91e9c2778 100644
++--- a/third_party/llvm-16.0/configs/linux/include/llvm/Config/Targets.def
+++++ b/third_party/llvm-16.0/configs/linux/include/llvm/Config/Targets.def
++@@ -44,6 +44,9 @@ LLVM_TARGET(PowerPC)
++ #if defined(__riscv)
++ LLVM_TARGET(RISCV)
++ #endif
+++#if defined(__loongarch__)
+++LLVM_TARGET(LoongArch)
+++#endif
++ 
++ 
++ #undef LLVM_TARGET
++diff --git a/third_party/llvm-16.0/configs/linux/include/llvm/Config/llvm-config.h b/third_party/llvm-16.0/configs/linux/include/llvm/Config/llvm-config.h
++index d9cce40e4..1be6ba950 100644
++--- a/third_party/llvm-16.0/configs/linux/include/llvm/Config/llvm-config.h
+++++ b/third_party/llvm-16.0/configs/linux/include/llvm/Config/llvm-config.h
++@@ -47,6 +47,8 @@
++ #define LLVM_DEFAULT_TARGET_TRIPLE "powerpc64le-unknown-linux-gnu"
++ #elif defined(__riscv)
++ #define LLVM_DEFAULT_TARGET_TRIPLE "riscv64-unknown-linux-gnu"
+++#elif defined(__loongarch__)
+++#define LLVM_DEFAULT_TARGET_TRIPLE "loongarch64-unknown-linux-gnu"
++ #else
++ #error "unknown architecture"
++ #endif
++@@ -76,6 +78,8 @@
++ #define LLVM_HOST_TRIPLE "powerpc64le-unknown-linux-gnu"
++ #elif defined(__riscv)
++ #define LLVM_HOST_TRIPLE "riscv64-unknown-linux-gnu"
+++#elif defined(__loongarch__)
+++#define LLVM_HOST_TRIPLE "loongarch64-unknown-linux-gnu"
++ #else
++ #error "unknown architecture"
++ #endif
++@@ -95,6 +99,8 @@
++ #define LLVM_NATIVE_ARCH PowerPC
++ #elif defined(__riscv)
++ #define LLVM_NATIVE_ARCH RISCV
+++#elif defined(__loongarch__)
+++#define LLVM_NATIVE_ARCH LoongArch
++ #else
++ #error "unknown architecture"
++ #endif
++@@ -114,6 +120,8 @@
++ #define LLVM_NATIVE_ASMPARSER LLVMInitializePowerPCAsmParser
++ #elif defined(__riscv)
++ #define LLVM_NATIVE_ASMPARSER LLVMInitializeRISCVAsmParser
+++#elif defined(__loongarch__)
+++#define LLVM_NATIVE_ASMPARSER LLVMInitializeLoongArchAsmParser
++ #else
++ #error "unknown architecture"
++ #endif
++@@ -133,6 +141,8 @@
++ #define LLVM_NATIVE_ASMPRINTER LLVMInitializePowerPCAsmPrinter
++ #elif defined(__riscv)
++ #define LLVM_NATIVE_ASMPRINTER LLVMInitializeRISCVAsmPrinter
+++#elif defined(__loongarch__)
+++#define LLVM_NATIVE_ASMPRINTER LLVMInitializeLoongArchAsmPrinter
++ #else
++ #error "unknown architecture"
++ #endif
++@@ -152,6 +162,8 @@
++ #define LLVM_NATIVE_DISASSEMBLER LLVMInitializePowerPCDisassembler
++ #elif defined(__riscv)
++ #define LLVM_NATIVE_DISASSEMBLER LLVMInitializeRISCVDisassembler
+++#elif defined(__loongarch__)
+++#define LLVM_NATIVE_DISASSEMBLER LLVMInitializeLoongArchDisassembler
++ #else
++ #error "unknown architecture"
++ #endif
++@@ -171,6 +183,8 @@
++ #define LLVM_NATIVE_TARGET LLVMInitializePowerPCTarget
++ #elif defined(__riscv)
++ #define LLVM_NATIVE_TARGET LLVMInitializeRISCVTarget
+++#elif defined(__loongarch__)
+++#define LLVM_NATIVE_TARGET LLVMInitializeLoongArchTarget
++ #else
++ #error "unknown architecture"
++ #endif
++@@ -190,6 +204,8 @@
++ #define LLVM_NATIVE_TARGETINFO LLVMInitializePowerPCTargetInfo
++ #elif defined(__riscv)
++ #define LLVM_NATIVE_TARGETINFO LLVMInitializeRISCVTargetInfo
+++#elif defined(__loongarch__)
+++#define LLVM_NATIVE_TARGETINFO LLVMInitializeLoongArchTargetInfo
++ #else
++ #error "unknown architecture"
++ #endif
++@@ -209,6 +225,8 @@
++ #define LLVM_NATIVE_TARGETMC LLVMInitializePowerPCTargetMC
++ #elif defined(__riscv)
++ #define LLVM_NATIVE_TARGETMC LLVMInitializeRISCVTargetMC
+++#elif defined(__loongarch__)
+++#define LLVM_NATIVE_TARGETMC LLVMInitializeLoongArchTargetMC
++ #else
++ #error "unknown architecture"
++ #endif
+diff --git a/shell/browser/extensions/api/runtime/electron_runtime_api_delegate.cc b/shell/browser/extensions/api/runtime/electron_runtime_api_delegate.cc
+index be69be338f..ebb86dbcf3 100644
+--- a/shell/browser/extensions/api/runtime/electron_runtime_api_delegate.cc
++++ b/shell/browser/extensions/api/runtime/electron_runtime_api_delegate.cc
+@@ -68,6 +68,8 @@ bool ElectronRuntimeAPIDelegate::GetPlatformInfo(PlatformInfo* info) {
+     info->arch = extensions::api::runtime::PlatformArch::kX86_32;
+   } else if (strcmp(arch, "x64") == 0) {
+     info->arch = extensions::api::runtime::PlatformArch::kX86_64;
++  } else if (strcmp(arch, "loong64") == 0) {
++    info->arch = extensions::api::runtime::PlatformArch::kLoong64;
+   } else {
+     NOTREACHED();
+   }
+@@ -79,6 +81,8 @@ bool ElectronRuntimeAPIDelegate::GetPlatformInfo(PlatformInfo* info) {
+     info->nacl_arch = extensions::api::runtime::PlatformNaclArch::kX86_32;
+   } else if (strcmp(nacl_arch, "x86-64") == 0) {
+     info->nacl_arch = extensions::api::runtime::PlatformNaclArch::kX86_64;
++  } else if (strcmp(nacl_arch, "loong64") == 0) {
++    info->nacl_arch = extensions::api::runtime::PlatformNaclArch::kLoong64;
+   } else {
+     NOTREACHED();
+   }

--- a/electron32/loong.patch
+++ b/electron32/loong.patch
@@ -1,0 +1,59 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 755595a..96d7dac 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -456,6 +456,17 @@ prepare() {
+   sed -i "s|@ELECTRON@|${pkgname}|" electron.desktop
+   sed -i "s|@ELECTRON_NAME@|Electron ${_major_ver}|" electron.desktop
+ 
++  # Patching makepkg-source-roller-orig.py
++  cp "${srcdir}/makepkg-source-roller.py" "makepkg-source-roller-new.py"
++  patch "makepkg-source-roller-new.py" -i "${srcdir}/makepkg-source-roller.py.diff"
++  mv -f "makepkg-source-roller-new.py" "makepkg-source-roller.py"
++
++  # Apply in advance to so that makepkg-source-roller.py will not throw error
++  patch -p1 -d chromium-mirror_third_party_depot_tools -i "${srcdir}/depot_tools-loong64-support.patch"
++  patch -p1 -d electron -i "${srcdir}/electron-add-loong64-support.patch"
++  # Get the binary from the npm package
++  npm install @esbuild/linux-loong64@0.14.54
++
+   cp -r chromium-mirror_third_party_depot_tools depot_tools
+   export PATH+=":$PWD/depot_tools" DEPOT_TOOLS_UPDATE=0
+   #export VPYTHON_BYPASS='manually managed python not supported by chrome operations'
+@@ -464,6 +475,9 @@ prepare() {
+   # Generate gclient gn args file and prepare-electron-source-tree.sh
+   python makepkg-source-roller.py generate electron/DEPS $pkgname
+   rbash prepare-electron-source-tree.sh "$CARCH"
++  # Add esbuild binary manually
++  mkdir -p src/third_party/devtools-frontend/src/third_party/esbuild
++  cp node_modules/@esbuild/linux-loong64/bin/esbuild src/third_party/devtools-frontend/src/third_party/esbuild/esbuild
+   mv electron src/electron
+ 
+   echo "Running hooks..."
+@@ -509,7 +523,10 @@ prepare() {
+   patch -Np1 -i ../allow-ANGLEImplementation-kVulkan.patch
+ 
+   # Allow libclang_rt.builtins from compiler-rt >= 16 to be used
+-  patch -Np1 -i ../compiler-rt-adjust-paths.patch
++  #patch -Np1 -i ../compiler-rt-adjust-paths.patch
++  # Loong64 has another patch applied that has conflicts
++  # So we need to adjust the patch
++  patch -Np1 -i ../compiler-rt-adjust-paths-loong64.patch
+ 
+   # Increase _FORTIFY_SOURCE level to match Arch's default flags
+   patch -Np1 -i ../increase-fortify-level.patch
+@@ -662,3 +679,14 @@ package() {
+   install -Dm644 src/electron/default_app/icon.png \
+           "${pkgdir}/usr/share/pixmaps/${pkgname}.png"  # hicolor has no 1024x1024
+ }
++
++# The fix patch uses system's libyuv
++depends+=(libyuv)
++source+=("depot_tools-loong64-support.patch"
++         "makepkg-source-roller.py.diff"
++         "electron-add-loong64-support.patch"
++         "compiler-rt-adjust-paths-loong64.patch")
++sha256sums+=('731ce1a98a181d0c22eb4a6f2e1dbb5417471a6ee17049603b3201ef5e931bd3'
++             '1cc70217edd60e77c3395a1f7b957921ebc69f3e472856c95afbf9aced4a4105'
++             '9173a753aa6a0965eb9828942c610c83c683a3fefb601cc91a855efc5711b254'
++             '636fe51fa5f36d76d2c3d24bf786fadba163b2a777440f2e70ad8ab1798ddbec')

--- a/electron32/makepkg-source-roller.py.diff
+++ b/electron32/makepkg-source-roller.py.diff
@@ -1,0 +1,11 @@
+@@ -400,7 +400,9 @@ if __name__ == "__main__":
+                     True,
+                 ),  # only for new electron versions (probably >= 29)
+                 # The esbuild version 0.14.13 is not compatible with the system one
+-                ("src/third_party/devtools-frontend/src/third_party/esbuild", False),
++                # Not suitable for loong64 since the package is missing
++                # Need another workaround
++                #("src/third_party/devtools-frontend/src/third_party/esbuild", False),
+             ],
+         )
+         # gcs dependencies are usually binary blobs. They are not handled yet.


### PR DESCRIPTION
* Add loong64 support in `depot_tools`
  * Apply this patch in advance since archlinux's `makepkg-source-roller.py` needs it
* Use `esbuild` binary from npm to replace chromium's `src/third_party/devtools-frontend/src/third_party/esbuild`
  * Google's fork doesn't support loong64
* Adjust llvm path to build with llvm 18+
* Modify and clean [patch from darkyzhou](https://github.com/darkyzhou/electron-loong64/blob/32.2.7/electron.patch) and then apply it
  * Remove changes to electron `DEPS` (file) and `build` (directory)
* Temporarily depends on system's `libyuv`

Ref: https://github.com/darkyzhou/electron-loong64