### PR TITLE
updpatch: chromium, ver=131.0.6778.204-1

### DIFF
--- a/chromium/compiler-rt-adjust-paths-loong64.patch
+++ b/chromium/compiler-rt-adjust-paths-loong64.patch
@@ -1,23 +1,27 @@
+diff --git a/build/config/clang/BUILD.gn b/build/config/clang/BUILD.gn
+index 890bf91c43e40..888804b675c7d 100644
 --- a/build/config/clang/BUILD.gn
 +++ b/build/config/clang/BUILD.gn
-@@ -190,17 +190,15 @@
-       } else if (is_apple) {
+@@ -164,16 +164,17 @@ template("clang_lib") {
          _dir = "darwin"
        } else if (is_linux || is_chromeos) {
-+        _dir = "linux"
          if (current_cpu == "x64") {
 -          _dir = "x86_64-unknown-linux-gnu"
-           _suffix = "-x86_64"
++          _suffix = "-x86_64"
          } else if (current_cpu == "x86") {
 -          _dir = "i386-unknown-linux-gnu"
-           _suffix = "-i386"
 -        } else if (current_cpu == "arm") {
 -          _dir = "armv7-unknown-linux-gnueabihf"
++          _suffix = "-i386"
          } else if (current_cpu == "arm64") {
 -          _dir = "aarch64-unknown-linux-gnu"
-           _suffix = "-aarch64"
-+        }  else if (current_cpu == "loong64") {
++          _suffix = "-aarch64"
++        } else if (current_cpu == "loong64") {
 +          _suffix = "-loongarch64"
          } else {
            assert(false)  # Unhandled cpu type
          }
++        _dir = "linux"
+       } else if (is_fuchsia) {
+         if (current_cpu == "x64") {
+           _dir = "x86_64-unknown-fuchsia"

--- a/chromium/loong.patch
+++ b/chromium/loong.patch
@@ -1,13 +1,20 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 57893e6..57d29be 100644
+index 57893e6..4356ac4 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -123,6 +123,16 @@ prepare() {
+@@ -118,11 +118,22 @@ prepare() {
+   patch -Np1 -i ../const-atomicstring-conversion.patch
+ 
+   # Allow libclang_rt.builtins from compiler-rt >= 16 to be used
+-  patch -Np1 -i ../compiler-rt-adjust-paths.patch
++  # Use another version to support loong64
++  #patch -Np1 -i ../compiler-rt-adjust-paths.patch
+ 
    # Increase _FORTIFY_SOURCE level to match Arch's default flags
    patch -Np1 -i ../increase-fortify-level.patch
  
 +  # Patches for loong64
-+  patch -Np1 -i "${srcdir}/loong64-fix-clang-builtins-path.diff"
++  patch -Np1 -i "${srcdir}/compiler-rt-adjust-paths-loong64.patch"
 +  patch -Np1 -i "${srcdir}/chromium-loong64-support.patch"
 +
 +  # Add ` -mcmodel=medium` to CFLAGS etc.
@@ -19,13 +26,13 @@ index 57893e6..57d29be 100644
    # Fixes for building with libstdc++ instead of libc++
  
    # Link to system tools required by the build
-@@ -330,4 +340,9 @@ package() {
+@@ -330,4 +341,9 @@ package() {
    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/chromium/LICENSE"
  }
  
 +source+=("chromium-loong64-support.patch"
-+         "loong64-fix-clang-builtins-path.diff")
++         "compiler-rt-adjust-paths-loong64.patch")
 +sha256sums+=('355f657028a8afad1707792dd6a52cc1cadd8e71be0569f28f67b58b492ab82e'
-+             'f3da3e04b19163a329510a64e169035dc4915cad3a254919c55ec26751ee3c23')
++             '56e8d50b7c744f51953990aefceeae5b7dd08063baaf06df98ddeec02a2d4690')
 +
  # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
* Directly apply out compiler-rt fix patch to the original source
  * Replace archlinux's with our compiler-rt-adjust-paths-loong64.patch