### PR TITLE
updpatch: ldc, ver=3:1.40.0-2

### DIFF
--- a/ldc/loong.patch
+++ b/ldc/loong.patch
@@ -1,10 +1,13 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index fe2148c..d139bba 100644
+index c07c678..21e19e4 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -52,6 +52,7 @@ build() {
+@@ -50,8 +50,9 @@ build() {
+     -DBUILD_SHARED_LIBS=BOTH \
+     -DBUILD_LTO_LIBS=ON \
      -DLDC_WITH_LLD=OFF \
-     -DD_COMPILER_FLAGS="-link-defaultlib-shared=false -linker=lld --flto=thin" \
+-    -DD_COMPILER_FLAGS="-link-defaultlib-shared=false -linker=lld --flto=thin" \
++    -DD_COMPILER_FLAGS="-link-defaultlib-shared=false -linker=lld --flto=thin -L--plugin-opt=-mattr=+d" \
      -DADDITIONAL_DEFAULT_LDC_SWITCHES="\"-link-defaultlib-shared\"," \
 +    -DLD_FLAGS="-Wl,--no-as-needed -latomic -Wl,--as-needed" \
      ..


### PR DESCRIPTION
* Workaround for LLVM 19's bug
  * LLVM 19's `generic-la64` doesn't have float point support and is therefore ABI incompatible with binary objects on the system
  * Use `-mattr=+d` to enable FP
  * This will be fixed in LLVM 20
* Otherwise, it will fail with:
```
CMake Error at cmake/Modules/ExtractDMDSystemLinker.cmake:42 (message): Failed to link empty D program using '/usr/bin/ldmd2 -link-defaultlib-shared=false -linker=lld --flto=thin -wi':

warning: the triple-implied ABI is invalid, ignoring and using feature-implied ABI

ld.lld: error: cmakeExtractDMDSystemLinker.lto.cmakeExtractDMDSystemLinker.o: cannot link object files with different ABI from /usr/lib/gcc/loongarch64-unknown-linux-gnu/14.2.1/../../../Scrt1.o

collect2: error: ld returned 1 exit status

Error: /usr/bin/cc failed with status: 1 Call Stack (most recent call first): CMakeLists.txt:636 (include)
```