### PR TITLE
updpkg: devtools-loong64, ver=1.3.1.patch1-1

### DIFF
--- a/devtools-loong64/.SRCINFO
+++ b/devtools-loong64/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = devtools-loong64
 	pkgdesc = Tools for Arch Linux LoongArch package maintainers
-	pkgver = 1.3.0.patch4
+	pkgver = 1.3.1.patch1
 	pkgrel = 1
 	url = https://gitlab.archlinux.org/archlinux/devtools
 	arch = loong64
@@ -10,7 +10,7 @@ pkgbase = devtools-loong64
 	license = GPL-3.0-or-later
 	depends = bash
 	depends = coreutils
-	depends = devtools>=1:1.3.0
+	depends = devtools>=1:1.3.1
 	depends = grep
 	depends = git
 	depends = patch
@@ -38,7 +38,7 @@ pkgbase = devtools-loong64
 	sha256sums = 3e048911fb330cd92d88c330c91232d8e271c892aa239c82d979ffedc20c215c
 	sha256sums = 820cb7964fd724b88b3a4df87f3ca86b53c3d3e5c314024599dfc50afdcbc7a0
 	sha256sums = a33135cf0adf39bc93076928eade0a9b2efb24d8bdc692d61bd1a00552c74d7a
-	sha256sums = 74dac200d66221f0ddf56d07905d3edcfb09a9b1c6ebfa4662d65387afda017f
+	sha256sums = 49f74d45a8fa942cab400d6c8f74d601ece449a1872b2acfbcab80444faae575
 	sha256sums = b0d95a78ea22f28dc9d0c450e7c7f376a8772e15b7140be034d4c0538a95f63c
 	sha256sums = 0fa4957e6a2097a288036d18953969ff765912518f5b6a01f983a3d2f7f6a8e1
 

--- a/devtools-loong64/PKGBUILD
+++ b/devtools-loong64/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: wszqkzqk <wszqkzqk@qq.com>
 
-_pkgver=1.3.0
-_patchver=4
+_pkgver=1.3.1
+_patchver=1
 pkgname=devtools-loong64
 pkgver=${_pkgver}.patch${_patchver}
 pkgrel=1
@@ -38,7 +38,7 @@ sha256sums=('7d596664948b82aaef8f0c6149f00ebbce830433216b504e58fbe6fa0ea4cf63'
             '3e048911fb330cd92d88c330c91232d8e271c892aa239c82d979ffedc20c215c'
             '820cb7964fd724b88b3a4df87f3ca86b53c3d3e5c314024599dfc50afdcbc7a0'
             'a33135cf0adf39bc93076928eade0a9b2efb24d8bdc692d61bd1a00552c74d7a'
-            '74dac200d66221f0ddf56d07905d3edcfb09a9b1c6ebfa4662d65387afda017f'
+            '49f74d45a8fa942cab400d6c8f74d601ece449a1872b2acfbcab80444faae575'
             'b0d95a78ea22f28dc9d0c450e7c7f376a8772e15b7140be034d4c0538a95f63c'
             '0fa4957e6a2097a288036d18953969ff765912518f5b6a01f983a3d2f7f6a8e1')
 

--- a/devtools-loong64/get-loong64-pkg
+++ b/devtools-loong64/get-loong64-pkg
@@ -104,11 +104,11 @@ def update_status(mirror_x86: str) -> None:
         mirror_x86 (str): The base URL of the x86_64 package mirror
     """
     if os.path.isdir(PATCH_REPO_PATH):
-        print(f"Updating existing {PATCH_REPO_PATH}...")
+        print(f"Updating cached patch set repository...")
         subprocess.run(["git", "-C", PATCH_REPO_PATH, "fetch", "--all"])
         subprocess.run(["git", "-C", PATCH_REPO_PATH, "reset", "--hard", "origin/master"])
     else:
-        print(f"Cloning PATCH_REPO_PATH to {PATCH_REPO_PATH}...")
+        print(f"Cloning patch set repository...")
         os.makedirs(os.path.dirname(PATCH_REPO_PATH), exist_ok=True)
         subprocess.run(["git", "clone", PATCH_GIT, PATCH_REPO_PATH])
 
@@ -223,14 +223,19 @@ def main() -> None:
         help='Checkout a specific version of the package may be "stable", "testing", "staging", '
         '"main" , commit hash or a specific version pkgver-pkgrel, default is the current stable version',
         metavar='VERSION')
+    parser.add_argument('--skip-update',
+        help='Skip updating patch repository and package database cache',
+        action='store_true')
 
     args: argparse.Namespace = parser.parse_args()
 
     mirror_x86: str = args.mirror
     pkgbase: str = args.pkgbase
     version: Optional[str] = args.checkout
+    skip_update: bool = args.skip_update
 
-    update_status(mirror_x86)
+    if not skip_update:
+        update_status(mirror_x86)
 
     patch_dir: str = os.path.join(PATCH_REPO_PATH, pkgbase)
 


### PR DESCRIPTION
* feat/get-loong64-pkg: add an option to skip to update patch set and upstream dbs