### PR TITLE
updpatch: devtools-loong64, ver=1.3.1.patch2-1

### DIFF
--- a/devtools-loong64/.SRCINFO
+++ b/devtools-loong64/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = devtools-loong64
 	pkgdesc = Tools for Arch Linux LoongArch package maintainers
-	pkgver = 1.3.1.patch1
+	pkgver = 1.3.1.patch2
 	pkgrel = 1
 	url = https://gitlab.archlinux.org/archlinux/devtools
 	arch = loong64
@@ -31,14 +31,14 @@ pkgbase = devtools-loong64
 	source = get-loong64-pkg
 	source = mirrorlist-loong64
 	source = z-qemu-loong64-static-for-archpkg.conf
-	sha256sums = 7d596664948b82aaef8f0c6149f00ebbce830433216b504e58fbe6fa0ea4cf63
+	sha256sums = 7b9efdecfe9b770cedf9f8a7039aad31842454167caddb63315ec58949edaf24
 	sha256sums = 16bae6549b594284d1e08caa831f67f5aa251447449a40c846ad9ad4701ca252
 	sha256sums = 0bb9058a722971752ec714707eecca6af32f212069bbd2d138bbd4414eaf00c0
 	sha256sums = 4866d3086f6846c070d2aa2add4258baf7111b1fe3d249cdc6a0580fa7e8cc85
 	sha256sums = 3e048911fb330cd92d88c330c91232d8e271c892aa239c82d979ffedc20c215c
 	sha256sums = 820cb7964fd724b88b3a4df87f3ca86b53c3d3e5c314024599dfc50afdcbc7a0
 	sha256sums = a33135cf0adf39bc93076928eade0a9b2efb24d8bdc692d61bd1a00552c74d7a
-	sha256sums = 49f74d45a8fa942cab400d6c8f74d601ece449a1872b2acfbcab80444faae575
+	sha256sums = a73b3b24c7d816d9fdf1e1caed379db0cb4e9081f53b7674c615ef61e90fdb6c
 	sha256sums = b0d95a78ea22f28dc9d0c450e7c7f376a8772e15b7140be034d4c0538a95f63c
 	sha256sums = 0fa4957e6a2097a288036d18953969ff765912518f5b6a01f983a3d2f7f6a8e1
 

--- a/devtools-loong64/PKGBUILD
+++ b/devtools-loong64/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: wszqkzqk <wszqkzqk@qq.com>
 
 _pkgver=1.3.1
-_patchver=1
+_patchver=2
 pkgname=devtools-loong64
 pkgver=${_pkgver}.patch${_patchver}
 pkgrel=1
@@ -31,14 +31,14 @@ source=(makepkg-loong64.patch
         # Following items are unused in loong64
         mirrorlist-loong64
         z-qemu-loong64-static-for-archpkg.conf)
-sha256sums=('7d596664948b82aaef8f0c6149f00ebbce830433216b504e58fbe6fa0ea4cf63'
+sha256sums=('7b9efdecfe9b770cedf9f8a7039aad31842454167caddb63315ec58949edaf24'
             '16bae6549b594284d1e08caa831f67f5aa251447449a40c846ad9ad4701ca252'
             '0bb9058a722971752ec714707eecca6af32f212069bbd2d138bbd4414eaf00c0'
             '4866d3086f6846c070d2aa2add4258baf7111b1fe3d249cdc6a0580fa7e8cc85'
             '3e048911fb330cd92d88c330c91232d8e271c892aa239c82d979ffedc20c215c'
             '820cb7964fd724b88b3a4df87f3ca86b53c3d3e5c314024599dfc50afdcbc7a0'
             'a33135cf0adf39bc93076928eade0a9b2efb24d8bdc692d61bd1a00552c74d7a'
-            '49f74d45a8fa942cab400d6c8f74d601ece449a1872b2acfbcab80444faae575'
+            'a73b3b24c7d816d9fdf1e1caed379db0cb4e9081f53b7674c615ef61e90fdb6c'
             'b0d95a78ea22f28dc9d0c450e7c7f376a8772e15b7140be034d4c0538a95f63c'
             '0fa4957e6a2097a288036d18953969ff765912518f5b6a01f983a3d2f7f6a8e1')
 

--- a/devtools-loong64/get-loong64-pkg
+++ b/devtools-loong64/get-loong64-pkg
@@ -285,7 +285,7 @@ def main() -> None:
             print(f"Applying patch {PATCH_FILE}...")
             subprocess.run(["patch", "-p1", "-i", PATCH_FILE])
         else:
-            print("No 'loong.patch' found.")
+            print(f"No '{PATCH_FILE}' found.")
             sys.exit(1)
     else:
         print(f"No patch of {pkgbase} found.")

--- a/devtools-loong64/makepkg-loong64.patch
+++ b/devtools-loong64/makepkg-loong64.patch
@@ -10,7 +10,7 @@
  #-- Compiler and Linker Flags
  #CPPFLAGS=""
 -CFLAGS="-march=x86-64 -mtune=generic -O2 -pipe -fno-plt -fexceptions \
-+CFLAGS="-mabi=lp64d -march=loongarch64 -mlsx -O2 -pipe -fexceptions \
++CFLAGS="-mabi=lp64d -march=loongarch64 -mlsx -O2 -pipe -fexceptions -mcmodel=medium \
          -Wp,-D_FORTIFY_SOURCE=3 -Wformat -Werror=format-security \
 -        -fstack-clash-protection -fcf-protection \
 -        -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"


### PR DESCRIPTION
Add `-mcmodel=medium` to default `CFLAGS` and `CXXFLAGS`