### PR TITLE
addpatch: electron32, ver=32.3.0-1.1

### DIFF
--- a/electron32/allow-sched_getaffinity-in-seccomp-for-loong64.patch
+++ b/electron32/allow-sched_getaffinity-in-seccomp-for-loong64.patch
@@ -1,0 +1,16 @@
+diff --git a/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc b/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
+index 7bde501115bdf..027738ea01793 100644
+--- a/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
++++ b/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
+@@ -229,7 +229,11 @@ ResultExpr EvaluateSyscallImpl(int fs_denied_errno,
+   // abseil. See for example https://crbug.com/1370394.
+   if (sysno == __NR_sched_getaffinity || sysno == __NR_sched_getparam ||
+       sysno == __NR_sched_getscheduler || sysno == __NR_sched_setscheduler) {
++#if defined(ARCH_CPU_LOONGARCH64)
++    return Allow();
++#else
+     return RestrictSchedTarget(current_pid, sysno);
++#endif
+   }
+ 
+   if (sysno == __NR_getrandom) {

--- a/electron32/loong.patch
+++ b/electron32/loong.patch
@@ -1,5 +1,5 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index f4b0b2e..b514d70 100644
+index f4b0b2e..5df3a96 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
 @@ -456,6 +456,16 @@ prepare() {
@@ -51,20 +51,21 @@ index f4b0b2e..b514d70 100644
  
    # Increase _FORTIFY_SOURCE level to match Arch's default flags
    patch -Np1 -i ../increase-fortify-level.patch
-@@ -532,6 +547,12 @@ prepare() {
+@@ -532,6 +547,13 @@ prepare() {
    patch -Np1 -i "${srcdir}/use-system-libraries-in-node.patch"
    # patch -Np1 -i "${srcdir}/default_app-icon.patch"  # Icon from .desktop file
  
 +  # Add loong64 support for chromium
 +  patch -Np1 -i "${srcdir}/chromium-loong64-support.patch"
 +  patch -Np1 -i "${srcdir}/extensions-common-api-runtime.json-add-loong64.patch"
++  patch -Np1 -i "${srcdir}/allow-sched_getaffinity-in-seccomp-for-loong64.patch"
 +  # Add loong64 support for electron
 +  patch -Np1 -d electron -i "${srcdir}/electron_runtime_api_dalagate-add-loong64-support.patch"
 +
    # Allow building against system libraries in official builds
    echo "Patching Chromium for using system libraries..."
    sed -i 's/OFFICIAL_BUILD/GOOGLE_CHROME_BUILD/' \
-@@ -592,7 +613,7 @@ build() {
+@@ -592,7 +614,7 @@ build() {
      'clang_base_path="/usr"'
      'clang_use_chrome_plugins=false'
      "clang_version=\"$_clang_version\""
@@ -73,7 +74,7 @@ index f4b0b2e..b514d70 100644
    )
  
    # Allow the use of nightly features with stable Rust compiler
-@@ -661,3 +682,16 @@ package() {
+@@ -661,3 +683,18 @@ package() {
    install -Dm644 src/electron/default_app/icon.png \
            "${pkgdir}/usr/share/pixmaps/${pkgname}.png"  # hicolor has no 1024x1024
  }
@@ -83,10 +84,12 @@ index f4b0b2e..b514d70 100644
 +         "compiler-rt-adjust-paths-loong64.patch"
 +         "chromium-loong64-support.patch"
 +         "extensions-common-api-runtime.json-add-loong64.patch"
-+         "electron_runtime_api_dalagate-add-loong64-support.patch")
++         "electron_runtime_api_dalagate-add-loong64-support.patch"
++         "allow-sched_getaffinity-in-seccomp-for-loong64.patch")
 +sha256sums+=('731ce1a98a181d0c22eb4a6f2e1dbb5417471a6ee17049603b3201ef5e931bd3'
 +             '1cc70217edd60e77c3395a1f7b957921ebc69f3e472856c95afbf9aced4a4105'
 +             '56e8d50b7c744f51953990aefceeae5b7dd08063baaf06df98ddeec02a2d4690'
 +             'db6addaa7c4248856f70351ecff0950f75af3030810f8a4364041c24039d0ac2'
 +             '2f3662096c15de8797113a60afda4cd746ca64bfb7f901fe976eb3d29389c659'
-+             '0e9152849d7ff20e54eea3e71f6cecedbfd923579557e81158369577e047c5d9')
++             '0e9152849d7ff20e54eea3e71f6cecedbfd923579557e81158369577e047c5d9'
++             'b48d40e93f020b5e8861f1f320437984d8f7d62c568ad1995af78e49e88de7a9')


### PR DESCRIPTION
* Allow `sched_getaffinity` in sandbox's `seccomp` to avoid `SIGSEGV` in loong64