### PR TITLE
updpatch: chromium, ver=133.0.6943.53-1

### DIFF
--- a/chromium/allow-sched_getaffinity-in-seccomp-for-loong64.patch
+++ b/chromium/allow-sched_getaffinity-in-seccomp-for-loong64.patch
@@ -1,0 +1,16 @@
+diff --git a/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc b/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
+index 7bde501115bdf..027738ea01793 100644
+--- a/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
++++ b/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
+@@ -229,7 +229,11 @@ ResultExpr EvaluateSyscallImpl(int fs_denied_errno,
+   // abseil. See for example https://crbug.com/1370394.
+   if (sysno == __NR_sched_getaffinity || sysno == __NR_sched_getparam ||
+       sysno == __NR_sched_getscheduler || sysno == __NR_sched_setscheduler) {
++#if defined(ARCH_CPU_LOONGARCH64)
++    return Allow();
++#else
+     return RestrictSchedTarget(current_pid, sysno);
++#endif
+   }
+ 
+   if (sysno == __NR_getrandom) {

--- a/chromium/loong.patch
+++ b/chromium/loong.patch
@@ -1,8 +1,8 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index c4ffa27..619bc2f 100644
+index 61ddd0f..9fcac0a 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -106,11 +106,16 @@ prepare() {
+@@ -106,11 +106,17 @@ prepare() {
    # Upstream fixes
  
    # Allow libclang_rt.builtins from compiler-rt >= 16 to be used
@@ -16,11 +16,12 @@ index c4ffa27..619bc2f 100644
  
 +  # Patches for loong64
 +  patch -Np1 -i "${srcdir}/chromium-loong64-support.patch"
++  patch -Np1 -i "${srcdir}/allow-sched_getaffinity-in-seccomp-for-loong64.patch"
 +
    # Fixes for building with libstdc++ instead of libc++
  
    # Link to system tools required by the build
-@@ -197,7 +202,7 @@ build() {
+@@ -197,7 +203,7 @@ build() {
        'clang_base_path="/usr"'
        'clang_use_chrome_plugins=false'
        "clang_version=\"$_clang_version\""
@@ -29,13 +30,15 @@ index c4ffa27..619bc2f 100644
      )
  
      # Allow the use of nightly features with stable Rust compiler
-@@ -313,4 +318,9 @@ package() {
+@@ -314,4 +320,11 @@ package() {
    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/chromium/LICENSE"
  }
  
 +source+=("chromium-loong64-support.patch"
-+         "compiler-rt-adjust-paths-loong64.patch")
++         "compiler-rt-adjust-paths-loong64.patch"
++         "allow-sched_getaffinity-in-seccomp-for-loong64.patch")
 +sha256sums+=('643554bf6af1e709cbeef3064d24c657e123054c3ccbaeed2434269f5c8c2171'
-+             '56e8d50b7c744f51953990aefceeae5b7dd08063baaf06df98ddeec02a2d4690')
++             '56e8d50b7c744f51953990aefceeae5b7dd08063baaf06df98ddeec02a2d4690'
++             'b48d40e93f020b5e8861f1f320437984d8f7d62c568ad1995af78e49e88de7a9')
 +
  # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
* Allow `sched_getaffinity` in sandbox's `seccomp` to avoid `SIGSEGV` in loong64
* See also: https://github.com/lcpu-club/loongarch-packages/pull/417