### PR TITLE
updpatch: electron34, ver=34.1.0-1

### DIFF
--- a/electron34/allow-sched_getaffinity-in-seccomp-for-loong64.patch
+++ b/electron34/allow-sched_getaffinity-in-seccomp-for-loong64.patch
@@ -1,0 +1,16 @@
+diff --git a/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc b/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
+index 7bde501115bdf..027738ea01793 100644
+--- a/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
++++ b/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
+@@ -229,7 +229,11 @@ ResultExpr EvaluateSyscallImpl(int fs_denied_errno,
+   // abseil. See for example https://crbug.com/1370394.
+   if (sysno == __NR_sched_getaffinity || sysno == __NR_sched_getparam ||
+       sysno == __NR_sched_getscheduler || sysno == __NR_sched_setscheduler) {
++#if defined(ARCH_CPU_LOONGARCH64)
++    return Allow();
++#else
+     return RestrictSchedTarget(current_pid, sysno);
++#endif
+   }
+ 
+   if (sysno == __NR_getrandom) {

--- a/electron34/loong.patch
+++ b/electron34/loong.patch
@@ -1,5 +1,5 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 21386c9..9f87118 100644
+index 680eec5..975238c 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
 @@ -457,6 +457,16 @@ prepare() {
@@ -91,20 +91,21 @@ index 21386c9..9f87118 100644
  
    # Fixes for building with libstdc++ instead of libc++
    patch -Np1 -i ../chromium-patches-*/chromium-130-interference-size.patch
-@@ -526,6 +577,12 @@ prepare() {
+@@ -526,6 +577,13 @@ prepare() {
    patch -Np1 -i "${srcdir}/use-system-libraries-in-node.patch"
    # patch -Np1 -i "${srcdir}/default_app-icon.patch"  # Icon from .desktop file
  
 +  # Add loong64 support for chromium
 +  patch -Np1 -i "${srcdir}/chromium-loong64-support.patch"
 +  patch -Np1 -i "${srcdir}/extensions-common-api-runtime.json-add-loong64.patch"
++  patch -Np1 -i "${srcdir}/allow-sched_getaffinity-in-seccomp-for-loong64.patch"
 +  # Add loong64 support for electron
 +  patch -Np1 -d electron -i "${srcdir}/electron_runtime_api_dalagate-add-loong64-support.patch"
 +
    # Allow building against system libraries in official builds
    echo "Patching Chromium for using system libraries..."
    sed -i 's/OFFICIAL_BUILD/GOOGLE_CHROME_BUILD/' \
-@@ -586,7 +643,7 @@ build() {
+@@ -586,7 +644,7 @@ build() {
      'clang_base_path="/usr"'
      'clang_use_chrome_plugins=false'
      "clang_version=\"$_clang_version\""
@@ -113,7 +114,7 @@ index 21386c9..9f87118 100644
    )
  
    # Allow the use of nightly features with stable Rust compiler
-@@ -655,3 +712,17 @@ package() {
+@@ -655,3 +713,19 @@ package() {
    install -Dm644 src/electron/default_app/icon.png \
            "${pkgdir}/usr/share/pixmaps/${pkgname}.png"  # hicolor has no 1024x1024
  }
@@ -124,10 +125,12 @@ index 21386c9..9f87118 100644
 +         "compiler-rt-adjust-paths-loong64.patch"
 +         "chromium-loong64-support.patch"
 +         "extensions-common-api-runtime.json-add-loong64.patch"
-+         "electron_runtime_api_dalagate-add-loong64-support.patch")
++         "electron_runtime_api_dalagate-add-loong64-support.patch"
++         "allow-sched_getaffinity-in-seccomp-for-loong64.patch")
 +sha256sums+=('731ce1a98a181d0c22eb4a6f2e1dbb5417471a6ee17049603b3201ef5e931bd3'
 +             '1cc70217edd60e77c3395a1f7b957921ebc69f3e472856c95afbf9aced4a4105'
 +             '56e8d50b7c744f51953990aefceeae5b7dd08063baaf06df98ddeec02a2d4690'
 +             '341be25d397923be5cfdcf9b59a4d8ff714a5d2861f8a171be6a3391a9a30428'
 +             '2f3662096c15de8797113a60afda4cd746ca64bfb7f901fe976eb3d29389c659'
-+             '0e9152849d7ff20e54eea3e71f6cecedbfd923579557e81158369577e047c5d9')
++             '0e9152849d7ff20e54eea3e71f6cecedbfd923579557e81158369577e047c5d9'
++             'b48d40e93f020b5e8861f1f320437984d8f7d62c568ad1995af78e49e88de7a9')


### PR DESCRIPTION
* Allow `sched_getaffinity` in sandbox's `seccomp` to avoid `SIGSEGV` in loong64
* See also: https://github.com/lcpu-club/loongarch-packages/pull/417