### PR TITLE
addpatch: boost, ver=1.87.0-2.1

### DIFF
--- a/boost/include-cstdint-in-all-files-using-fix-width-integer-types.patch
+++ b/boost/include-cstdint-in-all-files-using-fix-width-integer-types.patch
@@ -1,0 +1,24 @@
+diff --git a/include/boost/lockfree/detail/freelist.hpp b/include/boost/lockfree/detail/freelist.hpp
+index 31c8c98..2ac6019 100644
+--- a/include/boost/lockfree/detail/freelist.hpp
++++ b/include/boost/lockfree/detail/freelist.hpp
+@@ -10,6 +10,7 @@
+ #define BOOST_LOCKFREE_FREELIST_HPP_INCLUDED
+ 
+ #include <array>
++#include <cstdint>
+ #include <cstring>
+ #include <limits>
+ #include <memory>
+diff --git a/include/boost/lockfree/stack.hpp b/include/boost/lockfree/stack.hpp
+index 19d5e7d..d6646e3 100644
+--- a/include/boost/lockfree/stack.hpp
++++ b/include/boost/lockfree/stack.hpp
+@@ -29,6 +29,7 @@
+ #include <boost/lockfree/detail/uses_optional.hpp>
+ #include <boost/lockfree/lockfree_forward.hpp>
+ 
++#include <cstdint>
+ #include <tuple>
+ #include <type_traits>
+ 

--- a/boost/loong.patch
+++ b/boost/loong.patch
@@ -1,0 +1,22 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 0953dd8..7c9708b 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -30,6 +30,9 @@ prepare() {
+   # fix the smartpointer prints (https://github.com/boostorg/smart_ptr/issues/115)
+   # also see https://github.com/luceneplusplus/LucenePlusPlus/issues/208
+   patch -Np4 -d boost/smart_ptr < ../$pkgname-fix-smart-pointer-output.patch
++
++  # fix missing <cstdint> (https://github.com/boostorg/lockfree/pull/109)
++  patch -Np2 < ../include-cstdint-in-all-files-using-fix-width-integer-types.patch
+ }
+ 
+ build() {
+@@ -159,4 +162,7 @@ package_boost-libs() {
+   cp fakeinstall/lib/boost-python*/mpi.so "$pkgdir"$site_packages/boost/mpi.so
+ }
+ 
++source+=("include-cstdint-in-all-files-using-fix-width-integer-types.patch")
++sha256sums+=('450fbb4f0d42a4fb098ea5ab72ea87e5b4a0921fc80618cded24ebd4b17c9c4a')
++
+ # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
* Back port https://github.com/boostorg/lockfree/pull/109 to fix errors of fix width int types