### PR TITLE
addpatch: rocm-llvm, ver=6.2.4-1

### DIFF
--- a/rocm-llvm/loong.patch
+++ b/rocm-llvm/loong.patch
@@ -1,0 +1,25 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 3523ba3..e591452 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -27,10 +27,7 @@ build() {
+         -DLLVM_HOST_TRIPLE=$CHOST
+         -DLLVM_ENABLE_PROJECTS='llvm;clang;lld;compiler-rt;clang-tools-extra'
+         -DCLANG_ENABLE_AMDCLANG=ON
+-        -DLLVM_ENABLE_RUNTIMES='libcxx;libcxxabi;libunwind'
+-        -DLIBCXX_ENABLE_STATIC=ON
+-        -DLIBCXXABI_ENABLE_STATIC=ON
+-        -DLLVM_TARGETS_TO_BUILD='AMDGPU;NVPTX;X86'
++        -DLLVM_TARGETS_TO_BUILD='AMDGPU;NVPTX;LoongArch'
+         -DCLANG_DEFAULT_LINKER=lld
+         -DLLVM_INSTALL_UTILS=ON
+         -DLLVM_ENABLE_BINDINGS=OFF
+@@ -85,7 +82,7 @@ package_rocm-llvm() {
+ 
+     # Fix rpath to avoid error when running amdclang and friends
+     # (error while loading shared libraries: libunwind.so.1: cannot open shared object file: No such file or directory)
+-    patchelf --set-rpath '$ORIGIN' "$pkgdir/opt/rocm/lib/llvm/lib/libc++abi.so"
++    #patchelf --set-rpath '$ORIGIN' "$pkgdir/opt/rocm/lib/llvm/lib/libc++abi.so"
+ 
+     # https://bugs.archlinux.org/task/28479
+     install -d "$pkgdir/opt/rocm/lib/llvm/lib/bfd-plugins"


### PR DESCRIPTION
* Set `LLVM_TARGETS_TO_BUILD` to LoongArch
* Disable runtime including libunwind to workaround the error:
  ```
  CMake Error at /build/rocm-llvm/src/rocm-llvm/libunwind/src/CMakeLists.txt:102 (message):
  Compiler doesn't support generation of unwind tables if exception support
  is disabled.  Building libunwind DSO with runtime dependency on C++ ABI
  library is not supported.
  ```
  https://gitlab.kitware.com/cmake/cmake/-/issues/24561