### PR TITLE
addpatch: hsa-rocr, ver=6.2.1-1

### DIFF
--- a/hsa-rocr/loong.patch
+++ b/hsa-rocr/loong.patch
@@ -1,0 +1,26 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index f3d711f..929372f 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -20,6 +20,12 @@ sha256sums=('dbe477b323df636f5e3221471780da156c938ec00dda4b50639aa8d7fb9248f4')
+ _dirname="$(basename "$url")-$(basename "${source[0]}" .tar.gz)"
+ options=(!lto)
+ 
++prepare() {
++  cd "$_dirname"
++  patch -Np1 -i ../rocr-unsupport.patch
++  export CC=clang CXX=clang++
++}
++
+ build() {
+   # Silence warnings on optional libraries with -DNDEBUG,
+   # https://github.com/RadeonOpenCompute/ROCR-Runtime/issues/89#issuecomment-613788944
+@@ -39,3 +45,8 @@ package() {
+   DESTDIR="$pkgdir" cmake --install build
+   install -Dm644 "$_dirname/LICENSE.txt" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+ }
++
++source+=("rocr-unsupport.patch::https://raw.githubusercontent.com/loongarch-moe/rocm-loongarch/refs/heads/rocm-6.2.x/stage2/3.rocm-rocr-runtime/rocr-unsupport.patch")
++sha256sums+=('523d7f93daca6e7272578ff0fced94a79421fef0ccd7f202425881543d4bcb56')
++# gcc doesn't support `mm_malloc.h` on loong64
++makedepends+=(clang)


### PR DESCRIPTION
* Switch to clang since our gcc miss `mm_malloc.h` (WHY?)
* Apply https://github.com/loongarch-moe/rocm-loongarch/blob/rocm-6.2.x/stage2/3.rocm-rocr-runtime/rocr-unsupport.patch to build on loong64