### PR TITLE
addpatch: rocprim, ver=6.2.4-1

### DIFF
--- a/rocprim/loong.patch
+++ b/rocprim/loong.patch
@@ -1,0 +1,18 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 1535e95..54ea976 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -15,6 +15,7 @@ sha256sums=('c567aa5e3209dd00aefe5052dde8ceb5bcc3a4aeeeb3ad8dc322f8d0791fc07f')
+ _dirname="$(basename "$_git")-$(basename "${source[0]}" ".tar.gz")"
+ 
+ build() {
++  export LDFLAGS="${LDFLAGS} -fuse-ld=mold"
+   # -fcf-protection is not supported by HIP, see
+   # https://rocm.docs.amd.com/projects/llvm-project/en/latest/reference/rocmcc.html#support-status-of-other-clang-options
+   local cmake_args=(
+@@ -35,3 +36,5 @@ package() {
+ 
+   install -Dm644 "$_dirname/LICENSE.txt" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+ }
++
++makedepends+=(mold)


### PR DESCRIPTION
* Switch to mold to avoid lld's errror
  * `unknown relocation (102) against symbol`