### PR TITLE
addpatch: rocfft, ver=6.2.4-1

### DIFF
--- a/rocfft/loong.patch
+++ b/rocfft/loong.patch
@@ -1,0 +1,18 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index c92b408..ba577d9 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -17,6 +17,7 @@ options=(!lto)
+ _dirname="$(basename "$_git")-$(basename "${source[0]}" ".tar.gz")"
+ 
+ build() {
++  export LDFLAGS="${LDFLAGS} -fuse-ld=mold"
+   # Compile source code for supported GPU archs in parallel
+   export HIPCC_COMPILE_FLAGS_APPEND="-parallel-jobs=$(nproc)"
+   export HIPCC_LINK_FLAGS_APPEND="-parallel-jobs=$(nproc)"
+@@ -40,3 +41,5 @@ package() {
+ 
+   install -Dm644 "$srcdir/$_dirname/LICENSE.md" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+ }
++
++makedepends+=(mold)


### PR DESCRIPTION
* Switch to mold to avoid lld's errror
  * `unknown relocation (102) against symbol`