### PR TITLE
addpatch: hipsparse, ver=6.2.4-1

### DIFF
--- a/hipsparse/loong.patch
+++ b/hipsparse/loong.patch
@@ -1,0 +1,19 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 153f49e..31df5c3 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -28,6 +28,8 @@ build() {
+     -D CMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc
+     -D CMAKE_CXX_FLAGS="${CXXFLAGS} -fcf-protection=none"
+     -D CMAKE_INSTALL_PREFIX=/opt/rocm
++    -D CMAKE_EXE_LINKER_FLAGS=-fuse-ld=mold
++    -D CMAKE_SHARED_LINKER_FLAGS=-fuse-ld=mold
+   )
+   HIP_PATH=/opt/rocm cmake "${cmake_args[@]}"
+   cmake --build build
+@@ -38,3 +40,5 @@ package() {
+ 
+   install -Dm644 "$srcdir/$_dirname/LICENSE.md" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+ }
++
++makedepends+=(mold)


### PR DESCRIPTION
* Switch to mold to avoid lld's errror
  * `unknown relocation (102) against symbol`