### PR TITLE
addpatch: rocrand, ver=6.2.4-1

### DIFF
--- a/rocrand/loong.patch
+++ b/rocrand/loong.patch
@@ -1,0 +1,19 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 50b55d0..60cf7d7 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -28,6 +28,8 @@ build() {
+     -D CMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc
+     -D CMAKE_CXX_FLAGS="${CXXFLAGS} -fcf-protection=none"
+     -D CMAKE_INSTALL_PREFIX=/opt/rocm
++    -D CMAKE_EXE_LINKER_FLAGS="-fuse-ld=mold"
++    -D CMAKE_SHARED_LINKER_FLAGS="-fuse-ld=mold"
+   )
+   cmake "${cmake_args[@]}"
+   cmake --build build
+@@ -38,3 +40,5 @@ package() {
+ 
+   install -Dm644 "$_dirname/LICENSE.txt" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+ }
++
++makedepends+=(mold)


### PR DESCRIPTION
* Switch to mold to avoid lld's errror
  * `unknown relocation (102) against symbol`