### PR TITLE
addpatch: hipcub, ver=6.2.4-1

### DIFF
--- a/hipcub/loong.patch
+++ b/hipcub/loong.patch
@@ -1,0 +1,19 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index ce475dc..50c4534 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -25,6 +25,8 @@ build() {
+     -D CMAKE_INSTALL_PREFIX=/opt/rocm
+     -D CMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc
+     -D CMAKE_CXX_FLAGS="${CXXFLAGS} -fcf-protection=none"
++    -D CMAKE_EXE_LINKER_FLAGS="-fuse-ld=mold"
++    -D CMAKE_SHARED_LINKER_FLAGS="-fuse-ld=mold"
+   )
+   cmake "${cmake_args[@]}"
+   cmake --build build
+@@ -34,3 +36,5 @@ package() {
+   DESTDIR="$pkgdir" cmake --install build
+   install -Dm644 "$_dirname/LICENSE.txt" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+ }
++
++makedepends+=(mold)


### PR DESCRIPTION
* Switch to mold to avoid lld's errror
  * `unknown relocation (102) against symbol`