### PR TITLE
addpatch: rocthrust, ver=6.2.4-1

### DIFF
--- a/rocthrust/loong.patch
+++ b/rocthrust/loong.patch
@@ -1,0 +1,19 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index bc6e801..0d9c672 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -25,6 +25,8 @@ build() {
+     -D CMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc
+     -D CMAKE_CXX_FLAGS="${CXXFLAGS} -fcf-protection=none"
+     -D CMAKE_INSTALL_PREFIX=/opt/rocm
++    -D CMAKE_EXE_LINKER_FLAGS="-fuse-ld=mold"
++    -D CMAKE_SHARED_LINKER_FLAGS="-fuse-ld=mold"
+   )
+   cmake "${cmake_args[@]}"
+   cmake --build build
+@@ -33,3 +35,5 @@ build() {
+ package() {
+   DESTDIR="$pkgdir" cmake --install build
+ }
++
++makedepends+=(mold)


### PR DESCRIPTION
* Switch to mold to avoid lld's errror
  * `unknown relocation (102) against symbol`