### PR TITLE
addpatch: rocm-opencl-runtime, ver=6.2.4-1

### DIFF
--- a/rocm-opencl-runtime/loong.patch
+++ b/rocm-opencl-runtime/loong.patch
@@ -1,0 +1,15 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 9f649e8..e06e332 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -40,3 +40,10 @@ package() {
+     echo '/opt/rocm/lib/libamdocl64.so' > 'amdocl64.icd'
+     install -Dm644 'amdocl64.icd' "$pkgdir/etc/OpenCL/vendors/amdocl64.icd"
+ }
++
++prepare() {
++  patch -Np1 -d "$_dirname" -i "$srcdir/clr-loong64.patch"
++}
++
++source+=("clr-loong64.patch::https://raw.githubusercontent.com/loongarch-moe/rocm-loongarch/refs/heads/rocm-6.2.x/stage2/7.rocm-clr/clr.patch")
++sha256sums+=('ba79185ba985f41ff8079d17c54dc5b615f631adac4066f129235928fa24adf2')


### PR DESCRIPTION
* Apply https://github.com/loongarch-moe/rocm-loongarch/blob/rocm-6.2.x/stage2/7.rocm-clr/clr.patch to build on loong64