### PR TITLE
updpatch: rocm-llvm, ver=6.2.4-1.2

### DIFF
--- a/rocm-llvm/loong.patch
+++ b/rocm-llvm/loong.patch
@@ -1,20 +1,21 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 3523ba3..d82d2e3 100644
+index 3523ba3..773c3f5 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -13,6 +13,11 @@ source=("$pkgbase::git+https://github.com/ROCm/llvm-project#tag=rocm-$pkgver")
+@@ -13,6 +13,12 @@ source=("$pkgbase::git+https://github.com/ROCm/llvm-project#tag=rocm-$pkgver")
  sha256sums=('09cb1afda4d2585b35e12142d4a4a4cab42be6ade7f41be59fd13df86d77ae10')
  options=(staticlibs !lto)
  
 +prepare() {
 +    cd "$pkgbase"
 +    patch -p1 -i "${srcdir}/LoongArch-Allow-f16-codegen-with-expansion-to-libcalls.patch"
++    patch -p1 -i "${srcdir}/LoongArch-Supports-FP_TO_SINT-operation-for-fp16.patch"
 +}
 +
  build() {
      # Build only minimal debug info to reduce size
      CFLAGS+=' -g1'
-@@ -27,10 +32,7 @@ build() {
+@@ -27,10 +33,7 @@ build() {
          -DLLVM_HOST_TRIPLE=$CHOST
          -DLLVM_ENABLE_PROJECTS='llvm;clang;lld;compiler-rt;clang-tools-extra'
          -DCLANG_ENABLE_AMDCLANG=ON
@@ -26,7 +27,7 @@ index 3523ba3..d82d2e3 100644
          -DCLANG_DEFAULT_LINKER=lld
          -DLLVM_INSTALL_UTILS=ON
          -DLLVM_ENABLE_BINDINGS=OFF
-@@ -85,7 +87,7 @@ package_rocm-llvm() {
+@@ -85,7 +88,7 @@ package_rocm-llvm() {
  
      # Fix rpath to avoid error when running amdclang and friends
      # (error while loading shared libraries: libunwind.so.1: cannot open shared object file: No such file or directory)
@@ -35,10 +36,12 @@ index 3523ba3..d82d2e3 100644
  
      # https://bugs.archlinux.org/task/28479
      install -d "$pkgdir/opt/rocm/lib/llvm/lib/bfd-plugins"
-@@ -119,3 +121,6 @@ package_comgr() {
+@@ -119,3 +122,8 @@ package_comgr() {
      cd "$pkgbase/amd/comgr"
      install -Dm644 LICENSE.txt "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
  }
 +
-+source+=("LoongArch-Allow-f16-codegen-with-expansion-to-libcalls.patch::https://github.com/llvm/llvm-project/pull/94456/commits/bbb1854a5a76a8199c50d60a2ae5809163f9d1c5.patch")
-+sha256sums+=('c485df407ab98dd299c80aa2b26f59c18c728b326a8ae32348bec57418515dcb')
++source+=("LoongArch-Allow-f16-codegen-with-expansion-to-libcalls.patch::https://github.com/llvm/llvm-project/pull/94456/commits/bbb1854a5a76a8199c50d60a2ae5809163f9d1c5.patch"
++        "LoongArch-Supports-FP_TO_SINT-operation-for-fp16.patch::https://github.com/llvm/llvm-project/commit/00d8ea3a4c8eba9aa0f14c352192e94cc40f8e2d.patch")
++sha256sums+=('c485df407ab98dd299c80aa2b26f59c18c728b326a8ae32348bec57418515dcb'
++             'f596ceccb1e8a2a222f4261d00f57b81d19ee3da6b3c64b75088ed2f46f12a67')

--- a/rocm-llvm/loong.patch
+++ b/rocm-llvm/loong.patch
@@ -1,21 +1,20 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 3523ba3..773c3f5 100644
+index 3523ba3..10ce853 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -13,6 +13,12 @@ source=("$pkgbase::git+https://github.com/ROCm/llvm-project#tag=rocm-$pkgver")
+@@ -13,6 +13,11 @@ source=("$pkgbase::git+https://github.com/ROCm/llvm-project#tag=rocm-$pkgver")
  sha256sums=('09cb1afda4d2585b35e12142d4a4a4cab42be6ade7f41be59fd13df86d77ae10')
  options=(staticlibs !lto)
  
 +prepare() {
 +    cd "$pkgbase"
-+    patch -p1 -i "${srcdir}/LoongArch-Allow-f16-codegen-with-expansion-to-libcalls.patch"
-+    patch -p1 -i "${srcdir}/LoongArch-Supports-FP_TO_SINT-operation-for-fp16.patch"
++    patch -p1 -i "${srcdir}/rocm-llvm-fix-fp16.patch"
 +}
 +
  build() {
      # Build only minimal debug info to reduce size
      CFLAGS+=' -g1'
-@@ -27,10 +33,7 @@ build() {
+@@ -27,10 +32,7 @@ build() {
          -DLLVM_HOST_TRIPLE=$CHOST
          -DLLVM_ENABLE_PROJECTS='llvm;clang;lld;compiler-rt;clang-tools-extra'
          -DCLANG_ENABLE_AMDCLANG=ON
@@ -27,7 +26,7 @@ index 3523ba3..773c3f5 100644
          -DCLANG_DEFAULT_LINKER=lld
          -DLLVM_INSTALL_UTILS=ON
          -DLLVM_ENABLE_BINDINGS=OFF
-@@ -85,7 +88,7 @@ package_rocm-llvm() {
+@@ -85,7 +87,7 @@ package_rocm-llvm() {
  
      # Fix rpath to avoid error when running amdclang and friends
      # (error while loading shared libraries: libunwind.so.1: cannot open shared object file: No such file or directory)
@@ -36,12 +35,10 @@ index 3523ba3..773c3f5 100644
  
      # https://bugs.archlinux.org/task/28479
      install -d "$pkgdir/opt/rocm/lib/llvm/lib/bfd-plugins"
-@@ -119,3 +122,8 @@ package_comgr() {
+@@ -119,3 +121,6 @@ package_comgr() {
      cd "$pkgbase/amd/comgr"
      install -Dm644 LICENSE.txt "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
  }
 +
-+source+=("LoongArch-Allow-f16-codegen-with-expansion-to-libcalls.patch::https://github.com/llvm/llvm-project/pull/94456/commits/bbb1854a5a76a8199c50d60a2ae5809163f9d1c5.patch"
-+        "LoongArch-Supports-FP_TO_SINT-operation-for-fp16.patch::https://github.com/llvm/llvm-project/commit/00d8ea3a4c8eba9aa0f14c352192e94cc40f8e2d.patch")
-+sha256sums+=('c485df407ab98dd299c80aa2b26f59c18c728b326a8ae32348bec57418515dcb'
-+             'f596ceccb1e8a2a222f4261d00f57b81d19ee3da6b3c64b75088ed2f46f12a67')
++source+=("rocm-llvm-fix-fp16.patch")
++sha256sums+=('b390b7268843e2e7812baa1e13aeaf62712647596b608476b2cec32bdd05afb6')

--- a/rocm-llvm/loong.patch
+++ b/rocm-llvm/loong.patch
@@ -1,5 +1,5 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 3523ba3..10ce853 100644
+index 3523ba3..265d43e 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
 @@ -13,6 +13,11 @@ source=("$pkgbase::git+https://github.com/ROCm/llvm-project#tag=rocm-$pkgver")
@@ -14,31 +14,24 @@ index 3523ba3..10ce853 100644
  build() {
      # Build only minimal debug info to reduce size
      CFLAGS+=' -g1'
-@@ -27,10 +32,7 @@ build() {
+@@ -27,10 +32,11 @@ build() {
          -DLLVM_HOST_TRIPLE=$CHOST
          -DLLVM_ENABLE_PROJECTS='llvm;clang;lld;compiler-rt;clang-tools-extra'
          -DCLANG_ENABLE_AMDCLANG=ON
 -        -DLLVM_ENABLE_RUNTIMES='libcxx;libcxxabi;libunwind'
--        -DLIBCXX_ENABLE_STATIC=ON
--        -DLIBCXXABI_ENABLE_STATIC=ON
++        -DLLVM_ENABLE_RUNTIMES='libcxx;libcxxabi'
++        -DLIBCXXABI_USE_LLVM_UNWINDER=OFF
+         -DLIBCXX_ENABLE_STATIC=ON
+         -DLIBCXXABI_ENABLE_STATIC=ON
 -        -DLLVM_TARGETS_TO_BUILD='AMDGPU;NVPTX;X86'
 +        -DLLVM_TARGETS_TO_BUILD='AMDGPU;NVPTX;LoongArch'
          -DCLANG_DEFAULT_LINKER=lld
          -DLLVM_INSTALL_UTILS=ON
          -DLLVM_ENABLE_BINDINGS=OFF
-@@ -85,7 +87,7 @@ package_rocm-llvm() {
- 
-     # Fix rpath to avoid error when running amdclang and friends
-     # (error while loading shared libraries: libunwind.so.1: cannot open shared object file: No such file or directory)
--    patchelf --set-rpath '$ORIGIN' "$pkgdir/opt/rocm/lib/llvm/lib/libc++abi.so"
-+    #patchelf --set-rpath '$ORIGIN' "$pkgdir/opt/rocm/lib/llvm/lib/libc++abi.so"
- 
-     # https://bugs.archlinux.org/task/28479
-     install -d "$pkgdir/opt/rocm/lib/llvm/lib/bfd-plugins"
-@@ -119,3 +121,6 @@ package_comgr() {
+@@ -119,3 +125,6 @@ package_comgr() {
      cd "$pkgbase/amd/comgr"
      install -Dm644 LICENSE.txt "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
  }
 +
 +source+=("rocm-llvm-fix-fp16.patch")
-+sha256sums+=('b390b7268843e2e7812baa1e13aeaf62712647596b608476b2cec32bdd05afb6')
++sha256sums+=('a0ed008fcc206ce252e0c5ca9898b768429e8fa8de13d2eb4709d1f6a98d08f5')

--- a/rocm-llvm/rocm-llvm-fix-fp16.patch
+++ b/rocm-llvm/rocm-llvm-fix-fp16.patch
@@ -1,0 +1,229 @@
+diff --git a/amd/comgr/CMakeLists.txt b/amd/comgr/CMakeLists.txt
+index 8994b182e4ae..f8dea7f5ff72 100644
+--- a/amd/comgr/CMakeLists.txt
++++ b/amd/comgr/CMakeLists.txt
+@@ -362,7 +362,12 @@ install(FILES
+ 
+ if(TARGET clangFrontendTool)
+   set(CLANG_LIBS
+-    clangFrontendTool)
++    clangFrontendTool
++    clangFrontend
++    clangDriver
++    clangSerialization
++    clangBasic
++    )
+ else()
+   set(CLANG_LIBS
+     clang-cpp)
+@@ -377,6 +382,21 @@ if (LLVM_LINK_LLVM_DYLIB)
+ else()
+   llvm_map_components_to_libnames(LLVM_LIBS
+     ${LLVM_TARGETS_TO_BUILD}
++    Core
++    CodeGen
++    Option
++    MCParser
++    MC
++    TargetParser
++    Support
++    BinaryFormat
++    MCDisassembler
++    Object
++    Linker
++    BitWriter
++    IRReader
++    BitReader
++    Demangle
+     DebugInfoDWARF
+     Symbolize)
+ endif()
+diff --git a/amd/comgr/test/CMakeLists.txt b/amd/comgr/test/CMakeLists.txt
+index f0e4df4bc9e1..65e4d4f85617 100644
+--- a/amd/comgr/test/CMakeLists.txt
++++ b/amd/comgr/test/CMakeLists.txt
+@@ -42,7 +42,7 @@ macro(add_test_input_bitcode name input output)
+   add_custom_command(
+     OUTPUT "${output}"
+     COMMAND "$<TARGET_FILE:clang>" -c -emit-llvm -target amdgcn-amd-amdhsa
+-    -mcpu=gfx900
++    -mcpu=gfx900 -nogpulib
+     ${ARGN} "${CMAKE_CURRENT_SOURCE_DIR}/${input}"
+     -o "${output}"
+     VERBATIM
+diff --git a/amd/hipcc/src/hipBin_amd.h b/amd/hipcc/src/hipBin_amd.h
+index 57d009804cfe..f53ee4a4be9e 100644
+--- a/amd/hipcc/src/hipBin_amd.h
++++ b/amd/hipcc/src/hipBin_amd.h
+@@ -209,7 +209,7 @@ void HipBinAmd::constructCompilerPath() {
+     } else {
+       compilerPath = getRoccmPath();
+       hipClangPath = compilerPath;
+-      hipClangPath /= "lib/llvm/bin";
++      hipClangPath /= "bin";
+     }
+ 
+     compilerPath = hipClangPath.string();
+diff --git a/clang/include/clang/Basic/Builtins.def b/clang/include/clang/Basic/Builtins.def
+index 4dcbaf8a7bea..4fbbd52a92b3 100644
+--- a/clang/include/clang/Basic/Builtins.def
++++ b/clang/include/clang/Basic/Builtins.def
+@@ -175,6 +175,7 @@ BUILTIN(__builtin_nansf, "fcC*" , "FnUE")
+ BUILTIN(__builtin_nansl, "LdcC*", "FnUE")
+ BUILTIN(__builtin_nansf16, "xcC*", "FnUE")
+ BUILTIN(__builtin_nansf128, "LLdcC*", "FnUE")
++BUILTIN(__builtin_nansq, "LLdcC*", "FnUE")
+ BUILTIN(__builtin_powi , "ddi"  , "Fnc")
+ BUILTIN(__builtin_powif, "ffi"  , "Fnc")
+ BUILTIN(__builtin_powil, "LdLdi", "Fnc")
+diff --git a/clang/lib/AST/ExprConstant.cpp b/clang/lib/AST/ExprConstant.cpp
+index 0884988c48b4..104e4ac89721 100644
+--- a/clang/lib/AST/ExprConstant.cpp
++++ b/clang/lib/AST/ExprConstant.cpp
+@@ -14419,6 +14419,7 @@ bool FloatExprEvaluator::VisitCallExpr(const CallExpr *E) {
+   case Builtin::BI__builtin_nansl:
+   case Builtin::BI__builtin_nansf16:
+   case Builtin::BI__builtin_nansf128:
++  case Builtin::BI__builtin_nansq:
+     if (!TryEvaluateBuiltinNaN(Info.Ctx, E->getType(), E->getArg(0),
+                                true, Result))
+       return Error(E);
+diff --git a/clang/lib/AST/Interp/InterpBuiltin.cpp b/clang/lib/AST/Interp/InterpBuiltin.cpp
+index 754ca96b0c64..bb6fabcfee76 100644
+--- a/clang/lib/AST/Interp/InterpBuiltin.cpp
++++ b/clang/lib/AST/Interp/InterpBuiltin.cpp
+@@ -671,6 +671,7 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const Function *F,
+   case Builtin::BI__builtin_nansl:
+   case Builtin::BI__builtin_nansf16:
+   case Builtin::BI__builtin_nansf128:
++  case Builtin::BI__builtin_nansq:
+     if (!interp__builtin_nan(S, OpPC, Frame, F, /*Signaling=*/true))
+       return false;
+     break;
+diff --git a/clang/lib/Basic/Targets/LoongArch.h b/clang/lib/Basic/Targets/LoongArch.h
+index 3313102492cb..09e8d935ec83 100644
+--- a/clang/lib/Basic/Targets/LoongArch.h
++++ b/clang/lib/Basic/Targets/LoongArch.h
+@@ -44,6 +44,8 @@ public:
+     SuitableAlign = 128;
+     WCharType = SignedInt;
+     WIntType = UnsignedInt;
++    HasFloat128 = true;
++    HasFloat16 = true;
+   }
+ 
+   bool setCPU(const std::string &Name) override {
+diff --git a/clang/lib/CodeGen/BackendUtil.cpp b/clang/lib/CodeGen/BackendUtil.cpp
+index 13be9ce72d4d..dec302553269 100644
+--- a/clang/lib/CodeGen/BackendUtil.cpp
++++ b/clang/lib/CodeGen/BackendUtil.cpp
+@@ -273,6 +273,7 @@ getCodeModel(const CodeGenOptions &CodeGenOpts) {
+                            .Case("kernel", llvm::CodeModel::Kernel)
+                            .Case("medium", llvm::CodeModel::Medium)
+                            .Case("large", llvm::CodeModel::Large)
++                           .Case("extreme", llvm::CodeModel::Large)
+                            .Case("default", ~1u)
+                            .Default(~0u);
+   assert(CodeModel != ~0u && "invalid code model!");
+diff --git a/clang/lib/Driver/ToolChains/HIPUtility.cpp b/clang/lib/Driver/ToolChains/HIPUtility.cpp
+index 82f56277bf7d..500908e47d6b 100644
+--- a/clang/lib/Driver/ToolChains/HIPUtility.cpp
++++ b/clang/lib/Driver/ToolChains/HIPUtility.cpp
+@@ -36,7 +36,11 @@ using llvm::dyn_cast;
+ #endif
+ 
+ namespace {
++#if defined(__loongarch_lp64)
++const unsigned HIPCodeObjectAlign = 65536;
++#else
+ const unsigned HIPCodeObjectAlign = 4096;
++#endif
+ } // namespace
+ 
+ // Constructs a triple string for clang offload bundler.
+@@ -292,7 +296,12 @@ void HIP::constructHIPFatbinCommand(Compilation &C, const JobAction &JA,
+ 
+   // ToDo: Remove the dummy host binary entry which is required by
+   // clang-offload-bundler.
++#if defined(__x86_64)
+   std::string BundlerTargetArg = "-targets=host-x86_64-unknown-linux";
++#elif defined(__loongarch64)
++  std::string BundlerTargetArg = "-targets=host-loongarch64-unknown-linux";
++#else
++#endif
+   // AMDGCN:
+   // For code object version 2 and 3, the offload kind in bundle ID is 'hip'
+   // for backward compatibility. For code object version 4 and greater, the
+diff --git a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+index 4e9b5b8ba9f5..f78f6b3b332c 100644
+--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
++++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+@@ -336,15 +336,22 @@ fatbinary(ArrayRef<std::pair<StringRef, StringRef>> InputFiles,
+   SmallVector<StringRef, 16> CmdArgs;
+   CmdArgs.push_back(*OffloadBundlerPath);
+   CmdArgs.push_back("-type=o");
++#if defined(__loongarch64)
++  CmdArgs.push_back("-bundle-align=65536");
++#else
+   CmdArgs.push_back("-bundle-align=4096");
+-
++#endif
+   if (Args.hasArg(OPT_compress))
+     CmdArgs.push_back("-compress");
+   if (auto *Arg = Args.getLastArg(OPT_compression_level_eq))
+     CmdArgs.push_back(
+         Args.MakeArgString(Twine("-compression-level=") + Arg->getValue()));
+-
++#if defined(__x86_64)
+   SmallVector<StringRef> Targets = {"-targets=host-x86_64-unknown-linux"};
++#elif defined(__loongarch64)
++  SmallVector<StringRef> Targets = {"-targets=host-loongarch64-unknown-linux"};
++#else
++#endif
+   for (const auto &[File, Arch] : InputFiles)
+     Targets.push_back(Saver.save("hipv4-amdgcn-amd-amdhsa--" + Arch));
+   CmdArgs.push_back(Saver.save(llvm::join(Targets, ",")));
+@@ -489,6 +496,7 @@ Expected<StringRef> linkDevice(ArrayRef<StringRef> InputFiles,
+   case Triple::aarch64_be:
+   case Triple::ppc64:
+   case Triple::ppc64le:
++  case Triple::loongarch64:
+     return generic::clang(InputFiles, Args);
+   default:
+     return createStringError(inconvertibleErrorCode(),
+diff --git a/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp b/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
+index 70f782b81270..3d06492134b3 100644
+--- a/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
++++ b/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
+@@ -325,6 +325,19 @@ LoongArchTargetLowering::LoongArchTargetLowering(const TargetMachine &TM,
+   setTargetDAGCombine(ISD::OR);
+   setTargetDAGCombine(ISD::SRL);
+ 
++  setOperationAction(ISD::FP16_TO_FP,        MVT::f32,   Expand);
++  setOperationAction(ISD::FP_TO_FP16,        MVT::f32,   Expand);
++  setOperationAction(ISD::FP16_TO_FP,        MVT::f64,   Expand);
++  setOperationAction(ISD::FP_TO_FP16,        MVT::f64,   Expand);
++  setOperationAction(ISD::SPLAT_VECTOR, MVT::f16, Custom);
++  setTruncStoreAction(MVT::f32, MVT::f16, Expand);
++
++  setLoadExtAction(ISD::EXTLOAD, MVT::f32, MVT::f16, Expand);
++  setLibcallName(RTLIB::FPEXT_F16_F32, "__extendhfsf2");
++  setLibcallName(RTLIB::FPROUND_F32_F16, "__truncsfhf2");
++  setLoadExtAction(ISD::EXTLOAD, MVT::f64, MVT::f16, Expand);
++  setTruncStoreAction(MVT::f64, MVT::f16, Expand);
++
+   // Set DAG combine for 'LSX' feature.
+ 
+   if (Subtarget.hasExtLSX())
+diff --git a/llvm/tools/llvm-split/CMakeLists.txt b/llvm/tools/llvm-split/CMakeLists.txt
+index 0579298462d1..1104e3145952 100644
+--- a/llvm/tools/llvm-split/CMakeLists.txt
++++ b/llvm/tools/llvm-split/CMakeLists.txt
+@@ -11,6 +11,7 @@ set(LLVM_LINK_COMPONENTS
+   MC
+   Support
+   Target
++  TargetParser
+   )
+ 
+ add_llvm_tool(llvm-split

--- a/rocm-llvm/rocm-llvm-fix-fp16.patch
+++ b/rocm-llvm/rocm-llvm-fix-fp16.patch
@@ -51,19 +51,6 @@ index f0e4df4bc9e1..65e4d4f85617 100644
      ${ARGN} "${CMAKE_CURRENT_SOURCE_DIR}/${input}"
      -o "${output}"
      VERBATIM
-diff --git a/amd/hipcc/src/hipBin_amd.h b/amd/hipcc/src/hipBin_amd.h
-index 57d009804cfe..f53ee4a4be9e 100644
---- a/amd/hipcc/src/hipBin_amd.h
-+++ b/amd/hipcc/src/hipBin_amd.h
-@@ -209,7 +209,7 @@ void HipBinAmd::constructCompilerPath() {
-     } else {
-       compilerPath = getRoccmPath();
-       hipClangPath = compilerPath;
--      hipClangPath /= "lib/llvm/bin";
-+      hipClangPath /= "bin";
-     }
- 
-     compilerPath = hipClangPath.string();
 diff --git a/clang/include/clang/Basic/Builtins.def b/clang/include/clang/Basic/Builtins.def
 index 4dcbaf8a7bea..4fbbd52a92b3 100644
 --- a/clang/include/clang/Basic/Builtins.def


### PR DESCRIPTION
* Use another FP16 fix
  * Revert path-related changes