### PR TITLE
updpatch: rocm-cmake, ver=6.2.4-1

### DIFF
--- a/rocm-cmake/loong.patch
+++ b/rocm-cmake/loong.patch
@@ -1,11 +1,14 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 035ecbe..e3f9060 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -11,7 +11,7 @@ arch=('any')
- url='https://github.com/ROCm/rocm-cmake'
- license=('MIT')
- depends=('rocm-core' 'cmake')
--checkdepends=('git' 'rocm-llvm')
-+checkdepends=('git')
- source=("${pkgname}-${pkgver}.tar.gz::$url/archive/rocm-$pkgver.tar.gz"
-         "${pkgname}-old-policy-cmp0079.patch")
- sha256sums=('7bd3ff971b1a898b8cf06b0ed9fac45891e2523ae651c3194ba36050ab45f869'
+@@ -21,6 +21,9 @@ sha256sums=('76bfac6fba31a9c4ec196d9b9b2d5ec51b8b68840b3fba8686aa42323d76a425'
+ _dirname="$(basename "$url")-$(basename "${source[0]}" .tar.gz)"
+ 
+ prepare() {
++    # clang on loong64 doesn't support `-fstack-clash-protection` and will cause Werror in `check()`
++    export CXXFLAGS="${CXXFLAGS//-fstack-clash-protection/}"
++    export CFLAGS="${CFLAGS//-fstack-clash-protection/}"
+     cd "$_dirname"
+     # Git version tests fail because we're not working in a local git checkout
+     rm test/pass/{version-norepo.cmake,version-parent.cmake}


### PR DESCRIPTION
* rocm-llvm is ready now
* Remove `-fstack-clash-protection` from CFLAGS and CXXFLAGS to avoid Werror in check()