### PR TITLE
addpatch: openh264, ver=2.6.0-1

### DIFF
--- a/openh264/loong.patch
+++ b/openh264/loong.patch
@@ -1,0 +1,10 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 3aa50f1..c4d9139 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -37,3 +37,5 @@ package() {
+     install -D -m755 "${pkgname}-${pkgver}"/h264{dec,enc} -t "${pkgdir}/usr/bin"
+     install -D -m644 "${pkgname}-${pkgver}/LICENSE" -t "${pkgdir}/usr/share/licenses/${pkgname}"
+ }
++
++options+=(!lto)


### PR DESCRIPTION
* Disable LTO to workaround check failure:
  ```
  [ RUN      ] SVC_ME_FunTest.SumOf8x8SingleBlock_lsx
  test/encoder/EncUT_SVC_me.cpp:143: Failure
  Expected equality of these values:
    iRes[0]
      Which is: 8276
    iRes[1]
      Which is: 7586
  [  FAILED  ] SVC_ME_FunTest.SumOf8x8SingleBlock_lsx (0 ms)
  ```