### PR TITLE
addpatch: miopen-hip, ver=6.2.4-1

### DIFF
--- a/miopen-hip/loong.patch
+++ b/miopen-hip/loong.patch
@@ -1,0 +1,31 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 8c88590..7c0c7b5 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -26,6 +26,8 @@ _dirname="$(basename "$_git")-$(basename "${source[0]}" .tar.gz)"
+ _mlirname="$(basename "$_mlir")-$(basename "${source[1]}" .tar.gz)"
+ 
+ prepare() {
++    patch -Np1 -d "${_mlirname}" -i "${srcdir}/fix-RocMLIRPasses.h.inc.patch"
++    patch -Np1 -d "${_mlirname}" -i "${srcdir}/fix-cmake-dependency-for-transforms.patch"
+     # Disable tests as they require an AMD GPU at build time
+     sed -i '/add_subdirectory(test)/d' "$_dirname/CMakeLists.txt"
+ }
+@@ -33,6 +35,7 @@ prepare() {
+ build() {
+   export CC=/opt/rocm/llvm/bin/clang
+   export CXX=/opt/rocm/llvm/bin/clang++
++  export LDFLAGS="${LDFLAGS} -fuse-ld=mold"
+   # -fcf-protection is not supported by HIP, see
+   # https://rocm.docs.amd.com/projects/llvm-project/en/latest/reference/rocmcc.html#support-status-of-other-clang-options
+   # Set ROCm test chipset to Vega in order to pass the configuration step.
+@@ -74,3 +77,9 @@ package() {
+ 
+   install -Dm644 "$_dirname/LICENSE.txt" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+ }
++
++makedepends+=(mold)
++source+=("fix-RocMLIRPasses.h.inc.patch::https://github.com/ROCm/rocMLIR/commit/8f43885b05c8c398225c1b702570391f67dd65f9.patch"
++         "fix-cmake-dependency-for-transforms.patch::https://github.com/ROCm/rocMLIR/commit/17a9ebe5c7878d62546d44c8889202aa05acd0db.patch")
++sha256sums+=('b2f6b4fbecc9de29cbbbe92eff18ddb6b567b6d481993e40ef266cb639dbad88'
++             '8012518e23d97bb1c954d2d108752779631131937af74c12c8303dd15a8d9b80')


### PR DESCRIPTION
* Back port upstream fix for missing RocMLIRPasses.h.inc
* Switch to mold to avoid lld's error
  * `unknown relocation (102) against symbol`