### PR TITLE
addpatch: python-proton-vpn-local-agent, ver=1.4.3-2

### DIFF
--- a/python-proton-vpn-local-agent/loong.patch
+++ b/python-proton-vpn-local-agent/loong.patch
@@ -1,0 +1,20 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 459a8fd..e31fd47 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -26,6 +26,9 @@ sha256sums=('66224b7958f4532da9ae0962edfb8a07181b8db5f8ed40c90db110d65a538f7b')
+ 
+ prepare() {
+     cd "${srcdir}"/local-agent-rs/python-proton-vpn-local-agent
++    cargo update -p bindgen
++    export CFLAGS=${CFLAGS/-Wp,-D_FORTIFY_SOURCE=3/}
++    export CXXFLAGS=${CXXFLAGS/-Wp,-D_FORTIFY_SOURCE=3/}
+     cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+ }
+ 
+@@ -43,3 +46,5 @@ package() {
+     mkdir -p "${pkgdir}"/usr/lib/python"${_pyver}"/site-packages/proton/vpn
+     install -Dm755 "${srcdir}"/local-agent-rs/python-proton-vpn-local-agent/target/release/libpython_proton_vpn_local_agent.so "${pkgdir}"/usr/lib/python"${_pyver}"/site-packages/proton/vpn/local_agent.abi3.so
+ }
++
++makedepends+=(cmake clang)


### PR DESCRIPTION
* See https://github.com/felixonmars/archriscv-packages/commit/b58f2ca27393719902835e0efca13adf09579e93 and https://github.com/aws/aws-lc-rs/issues/476
* Add CMake and clang to makedepends to build its cargo dependencies from source
* Remove `-D_FORTIFY_SOURCE=3` from CFLAGS and CXXFLAGS to fix assertion in build