### PR TITLE
updpatch: linux-zen, ver=6.13.5.zen1-1

### DIFF
--- a/linux-zen/loong.patch
+++ b/linux-zen/loong.patch
@@ -1,8 +1,8 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 49f5f51..af59ee5 100644
+index b3636d3..944c5db 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -76,6 +76,10 @@ prepare() {
+@@ -79,6 +79,10 @@ prepare() {
  
    echo "Setting config..."
    cp ../config .config
@@ -13,7 +13,7 @@ index 49f5f51..af59ee5 100644
    make olddefconfig
    diff -u ../config .config || :
  
-@@ -142,7 +146,11 @@ _package-headers() {
+@@ -145,7 +149,11 @@ _package-headers() {
    install -Dt "$builddir" -m644 .config Makefile Module.symvers System.map \
      localversion.* version vmlinux tools/bpf/bpftool/vmlinux.h
    install -Dt "$builddir/kernel" -m644 kernel/Makefile
@@ -26,7 +26,7 @@ index 49f5f51..af59ee5 100644
    cp -t "$builddir" -a scripts
    ln -srt "$builddir" "$builddir/scripts/gdb/vmlinux-gdb.py"
  
-@@ -154,8 +162,13 @@ _package-headers() {
+@@ -157,8 +165,13 @@ _package-headers() {
  
    echo "Installing headers..."
    cp -t "$builddir" -a include
@@ -42,7 +42,7 @@ index 49f5f51..af59ee5 100644
  
    install -Dt "$builddir/drivers/md" -m644 drivers/md/*.h
    install -Dt "$builddir/net/mac80211" -m644 net/mac80211/*.h
-@@ -177,7 +190,11 @@ _package-headers() {
+@@ -180,7 +193,11 @@ _package-headers() {
    echo "Removing unneeded architectures..."
    local arch
    for arch in "$builddir"/arch/*/; do
@@ -55,21 +55,24 @@ index 49f5f51..af59ee5 100644
      echo "Removing $(basename "$arch")"
      rm -r "$arch"
    done
-@@ -245,4 +262,17 @@ for _p in "${pkgname[@]}"; do
+@@ -248,4 +265,20 @@ for _p in "${pkgname[@]}"; do
    }"
  done
  
 +source+=('loong-addition.config'
 +         '0001-LOONGARCH-drm-radeon-Call-mmiowb-at-the-end-of-radeon_ring_commit.patch'
 +         '0002-LOONGARCH-drm-xe-fix-build-on-non-4K-kernels.patch'
-+         '0003-LOONGARCH-from-AOSCOS-more-fixes-for-Xe-on-LoongArch.patch')
++         '0003-LOONGARCH-from-AOSCOS-more-fixes-for-Xe-on-LoongArch.patch'
++         'rust-gcc-loong64.patch')
 +sha256sums+=('d604e6329f38f2fdd33365f705489e9c3f16f2e0576e225c1f1736775eeaeea7'
 +             'd146728a3b3c722f433e310cad21e93c53e64a7afe948b5b43b077e962750941'
 +             'bdebc71b258565eafb34bd35be181e1d76f93f532774670073cd7bff177fa61d'
-+             'fb058222b06a3cee7984c554a18ce4475f3d71f9ade030e3fe6e3841222fad1b')
++             'fb058222b06a3cee7984c554a18ce4475f3d71f9ade030e3fe6e3841222fad1b'
++             '61a19086ee5ef2504772b7ccf8cadfa0438bbbdef1bc2decb798d30390e8b20c')
 +b2sums+=('bd756d5284581fd0e4c404c7fb1bef8d8edfa6363c056b90bcdf017e138b8f71674075621709eac10c2a850cb3c550ad265e04e43b911083636fdcb329d1f304'
 +         '4a0b268f1a28d4bfa37d9b644477c75a5215083414fe5cc5d637e2edc4895aace9e42b3b33ac0b3e2a15a18340bec651511fa3c347c1c3e347ed3418c033582c'
 +         '032f5bb14ed5f55102c128ac08f64613d56320625f6bc60f165b6a0dd18a000292486edb8995902934885790f9d3dc61f390ae049efe0cf7a5eeedb81d4b2d29'
-+         '0c9d8e9814d29e30ae71f4301fb1b7d6cd3285edcdb5c18c43933b853332c1cba72adc70d1086c7087364ef5ce6b364e9e531d8f0a81b26aadd1777b781fa906')
++         '0c9d8e9814d29e30ae71f4301fb1b7d6cd3285edcdb5c18c43933b853332c1cba72adc70d1086c7087364ef5ce6b364e9e531d8f0a81b26aadd1777b781fa906'
++         '01c3d3f65733f0ae0fbdb71d836b656e99c78d167a78212ae15fac66d10d16c6ff582be1a1361acc53635bf69214f74d440c64d019c9e8021b57a26b19e5db9a')
 +
  # vim:set ts=8 sts=2 sw=2 et:

--- a/linux-zen/rust-gcc-loong64.patch
+++ b/linux-zen/rust-gcc-loong64.patch
@@ -1,0 +1,20 @@
+--- a/rust/Makefile
++++ b/rust/Makefile
+@@ -230,7 +230,8 @@
+ 	-mfunction-return=thunk-extern -mrecord-mcount -mabi=lp64 \
+ 	-mindirect-branch-cs-prefix -mstack-protector-guard% -mtraceback=no \
+ 	-mno-pointers-to-nested-functions -mno-string \
+-	-mno-strict-align -mstrict-align \
++	-mno-strict-align -mstrict-align -mdirect-extern-access \
++	-mexplicit-relocs -mno-check-zero-division \
+ 	-fconserve-stack -falign-jumps=% -falign-loops=% \
+ 	-femit-struct-debug-baseonly -fno-ipa-cp-clone -fno-ipa-sra \
+ 	-fno-partial-inlining -fplugin-arg-arm_ssp_per_task_plugin-% \
+@@ -244,6 +245,7 @@
+ # Derived from `scripts/Makefile.clang`.
+ BINDGEN_TARGET_x86	:= x86_64-linux-gnu
+ BINDGEN_TARGET_arm64	:= aarch64-linux-gnu
++BINDGEN_TARGET_loongarch:= loongarch64-linux-gnusf
+ BINDGEN_TARGET		:= $(BINDGEN_TARGET_$(SRCARCH))
+ 
+ # All warnings are inhibited since GCC builds are very experimental,


### PR DESCRIPTION
* Fix to build with gcc when enabling rust in kernel on loong64