### PR TITLE
updpatch: gcc, ver=14.2.1+r753+g1cd744a6828f-1.1

### DIFF
--- a/gcc/0001-LoongArch-Fix-incorrect-reorder-of-__lsx_vldx-and-__.patch
+++ b/gcc/0001-LoongArch-Fix-incorrect-reorder-of-__lsx_vldx-and-__.patch
@@ -1,0 +1,158 @@
+From 6e4ca8b9c4944ffe896f4d8952f29c4cd518df22 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Sun, 2 Mar 2025 19:02:50 +0800
+Subject: [gcc14 PATCH] LoongArch: Fix incorrect reorder of __lsx_vldx and
+ __lasx_xvldx [PR119084]
+
+They could be incorrectly reordered with store instructions like st.b
+because the RTL expression does not have a memory_operand or a (mem)
+expression.  The incorrect reorder has been observed in openh264 LTO
+build.
+
+Expand them to a (mem) expression instead of unspec to fix the issue.
+
+Closes: https://github.com/cisco/openh264/issues/3857
+
+(cherry picked from commit 4856292f7a680ec478e7607f1b71781996d7d542)
+
+Edited to remove the loongarch.cc change which is not needed for gcc-14
+branch.
+
+gcc/ChangeLog:
+
+	PR target/119084
+	* config/loongarch/lasx.md (UNSPEC_LASX_XVLDX): Remove.
+	(lasx_xvldx): Remove.
+	* config/loongarch/lsx.md (UNSPEC_LSX_VLDX): Remove.
+	(lsx_vldx): Remove.
+	* config/loongarch/simd.md (QIVEC): New define_mode_iterator.
+	(<simd_isa>_<x>vldx): New define_expand.
+
+gcc/testsuite/ChangeLog:
+
+	PR target/119084
+	* gcc.target/loongarch/pr119084.c: New test.
+---
+ gcc/config/loongarch/lasx.md                  | 13 ----------
+ gcc/config/loongarch/lsx.md                   | 13 ----------
+ gcc/config/loongarch/simd.md                  | 10 ++++++++
+ gcc/testsuite/gcc.target/loongarch/pr119084.c | 24 +++++++++++++++++++
+ 4 files changed, 34 insertions(+), 26 deletions(-)
+ create mode 100644 gcc/testsuite/gcc.target/loongarch/pr119084.c
+
+diff --git a/gcc/config/loongarch/lasx.md b/gcc/config/loongarch/lasx.md
+index 94bbd0c26bb..fe32194e811 100644
+--- a/gcc/config/loongarch/lasx.md
++++ b/gcc/config/loongarch/lasx.md
+@@ -155,7 +155,6 @@ (define_c_enum "unspec" [
+   UNSPEC_LASX_XVSSRLRN
+   UNSPEC_LASX_XVEXTL_QU_DU
+   UNSPEC_LASX_XVLDI
+-  UNSPEC_LASX_XVLDX
+   UNSPEC_LASX_XVSTX
+   UNSPEC_LASX_VECINIT_MERGE
+   UNSPEC_LASX_VEC_SET_INTERNAL
+@@ -4679,18 +4678,6 @@ (define_insn "lasx_xvldi"
+   [(set_attr "type" "simd_load")
+    (set_attr "mode" "V4DI")])
+ 
+-(define_insn "lasx_xvldx"
+-  [(set (match_operand:V32QI 0 "register_operand" "=f")
+-	(unspec:V32QI [(match_operand:DI 1 "register_operand" "r")
+-		       (match_operand:DI 2 "reg_or_0_operand" "rJ")]
+-		      UNSPEC_LASX_XVLDX))]
+-  "ISA_HAS_LASX"
+-{
+-  return "xvldx\t%u0,%1,%z2";
+-}
+-  [(set_attr "type" "simd_load")
+-   (set_attr "mode" "V32QI")])
+-
+ (define_insn "lasx_xvstx"
+   [(set (mem:V32QI (plus:DI (match_operand:DI 1 "register_operand" "r")
+ 			    (match_operand:DI 2 "reg_or_0_operand" "rJ")))
+diff --git a/gcc/config/loongarch/lsx.md b/gcc/config/loongarch/lsx.md
+index 5ee5845e84b..67ba8e8ad5d 100644
+--- a/gcc/config/loongarch/lsx.md
++++ b/gcc/config/loongarch/lsx.md
+@@ -100,7 +100,6 @@ (define_c_enum "unspec" [
+   UNSPEC_LSX_VSSRLRN
+   UNSPEC_LSX_VLDI
+   UNSPEC_LSX_VSHUF_B
+-  UNSPEC_LSX_VLDX
+   UNSPEC_LSX_VSTX
+   UNSPEC_LSX_VEXTL_QU_DU
+   UNSPEC_LSX_VSETEQZ_V
+@@ -3070,18 +3069,6 @@ (define_insn "lsx_vshuf_b"
+   [(set_attr "type" "simd_shf")
+    (set_attr "mode" "V16QI")])
+ 
+-(define_insn "lsx_vldx"
+-  [(set (match_operand:V16QI 0 "register_operand" "=f")
+-	(unspec:V16QI [(match_operand:DI 1 "register_operand" "r")
+-		       (match_operand:DI 2 "reg_or_0_operand" "rJ")]
+-		      UNSPEC_LSX_VLDX))]
+-  "ISA_HAS_LSX"
+-{
+-  return "vldx\t%w0,%1,%z2";
+-}
+-  [(set_attr "type" "simd_load")
+-   (set_attr "mode" "V16QI")])
+-
+ (define_insn "lsx_vstx"
+   [(set (mem:V16QI (plus:DI (match_operand:DI 1 "register_operand" "r")
+ 			    (match_operand:DI 2 "reg_or_0_operand" "rJ")))
+diff --git a/gcc/config/loongarch/simd.md b/gcc/config/loongarch/simd.md
+index 00ff2823a4e..691e7195636 100644
+--- a/gcc/config/loongarch/simd.md
++++ b/gcc/config/loongarch/simd.md
+@@ -113,6 +113,16 @@ (define_mode_attr bitimm [(V16QI "uimm3") (V32QI "uimm3")
+ ;; instruction here so we can avoid duplicating logics.
+ ;; =======================================================================
+ 
++;; REG + REG load
++
++(define_mode_iterator QIVEC [(V16QI "ISA_HAS_LSX") (V32QI "ISA_HAS_LASX")])
++(define_expand "<simd_isa>_<x>vldx"
++  [(set (match_operand:QIVEC 0 "register_operand" "=f")
++	(mem:QIVEC (plus:DI (match_operand:DI 1 "register_operand")
++			    (match_operand:DI 2 "register_operand"))))]
++  "TARGET_64BIT")
++
++
+ ;;
+ ;; FP vector rounding instructions
+ ;;
+diff --git a/gcc/testsuite/gcc.target/loongarch/pr119084.c b/gcc/testsuite/gcc.target/loongarch/pr119084.c
+new file mode 100644
+index 00000000000..b5943303851
+--- /dev/null
++++ b/gcc/testsuite/gcc.target/loongarch/pr119084.c
+@@ -0,0 +1,24 @@
++/* { dg-do run } */
++/* { dg-options "-O2 -mlsx" } */
++/* { dg-require-effective-target loongarch_sx_hw } */
++
++typedef signed char V16QI __attribute__ ((vector_size (16)));
++static char x[128];
++
++__attribute__ ((noipa)) int
++noopt (int x)
++{
++  return x;
++}
++
++int
++main (void)
++{
++  int t = noopt (32);
++
++  x[32] = 1;
++
++  V16QI y = __builtin_lsx_vldx (x, t);
++  if (y[0] != 1)
++    __builtin_trap ();
++}
+-- 
+2.48.1
+

--- a/gcc/loong.patch
+++ b/gcc/loong.patch
@@ -1,5 +1,5 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 8147682..66f170e 100644
+index 1be6613..3d1ad76 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
 @@ -21,8 +21,6 @@ makedepends=(
@@ -11,26 +11,18 @@ index 8147682..66f170e 100644
    libisl
    libmpc
    python
-@@ -59,6 +57,10 @@ prepare() {
-   [[ ! -d gcc ]] && ln -s gcc-${pkgver/+/-} gcc
-   cd gcc
- 
-+  export CFLAGS="${CFLAGS} -mcmodel=medium"
-+  export CXXFLAGS="${CXXFLAGS} -mcmodel=medium"
-+  export RUSTFLAGS="${RUSTFLAGS} -C code-model=medium"
-+
-   # Do not run fixincludes
-   sed -i 's@\./fixinc\.sh@-c true@' gcc/Makefile.in
- 
-@@ -67,6 +69,7 @@ prepare() {
+@@ -67,6 +65,10 @@ prepare() {
  
    # Reproducible gcc-ada
    patch -Np0 < "$srcdir/gcc-ada-repro.patch"
-+  patch -p1 -i "$srcdir/gcc-lib64-lib.patch"
++  # Fix libdir
++  patch -Np1 -i "$srcdir/gcc-lib64-lib.patch"
++  # Back port fix for __builtin_lsx_vldx
++  patch -Np1 -i "$srcdir/0001-LoongArch-Fix-incorrect-reorder-of-__lsx_vldx-and-__.patch"
  
    mkdir -p "$srcdir/gcc-build"
    mkdir -p "$srcdir/libgccjit-build"
-@@ -95,7 +98,8 @@ build() {
+@@ -95,7 +97,8 @@ build() {
        --enable-link-serialization=1
        --enable-linker-build-id
        --enable-lto
@@ -40,7 +32,7 @@ index 8147682..66f170e 100644
        --enable-plugin
        --enable-shared
        --enable-threads=posix
-@@ -113,7 +117,7 @@ build() {
+@@ -113,7 +116,7 @@ build() {
    CXXFLAGS=${CXXFLAGS/-Werror=format-security/}
  
    "$srcdir/gcc/configure" \
@@ -49,7 +41,7 @@ index 8147682..66f170e 100644
      --enable-bootstrap \
      "${_confflags[@]:?_confflags unset}"
  
-@@ -162,7 +166,7 @@ package_gcc-libs() {
+@@ -162,7 +165,7 @@ package_gcc-libs() {
    pkgdesc='Runtime libraries shipped by GCC'
    depends=('glibc>=2.27')
    options=(!emptydirs !strip)
@@ -58,7 +50,7 @@ index 8147682..66f170e 100644
              libubsan.so libasan.so libtsan.so liblsan.so)
    replaces=($pkgname-multilib libgphobos)
  
-@@ -172,7 +176,6 @@ package_gcc-libs() {
+@@ -172,7 +175,6 @@ package_gcc-libs() {
  
    for lib in libatomic \
               libgfortran \
@@ -66,7 +58,7 @@ index 8147682..66f170e 100644
               libgomp \
               libitm \
               libquadmath \
-@@ -220,22 +223,18 @@ package_gcc() {
+@@ -220,22 +222,18 @@ package_gcc() {
    install -m755 -t "$pkgdir/${_libdir}/" gcc/{cc1,cc1plus,collect2,lto1}
  
    make -C $CHOST/libgcc DESTDIR="$pkgdir" install
@@ -90,7 +82,7 @@ index 8147682..66f170e 100644
  
    make DESTDIR="$pkgdir" install-fixincludes
    make -C gcc DESTDIR="$pkgdir" install-mkheaders
-@@ -252,14 +251,10 @@ package_gcc() {
+@@ -252,14 +250,10 @@ package_gcc() {
    make -C $CHOST/libsanitizer/asan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
    make -C $CHOST/libsanitizer/tsan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
    make -C $CHOST/libsanitizer/lsan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
@@ -107,7 +99,7 @@ index 8147682..66f170e 100644
  
    make -C libcpp DESTDIR="$pkgdir" install
    make -C gcc DESTDIR="$pkgdir" install-po
-@@ -270,7 +265,7 @@ package_gcc() {
+@@ -270,7 +264,7 @@ package_gcc() {
    # create cc-rs compatible symlinks
    # https://github.com/rust-lang/cc-rs/blob/1.0.73/src/lib.rs#L2578-L2581
    for binary in {c++,g++,gcc,gcc-ar,gcc-nm,gcc-ranlib}; do
@@ -116,7 +108,7 @@ index 8147682..66f170e 100644
    done
  
    # POSIX conformance launcher scripts for c89 and c99
-@@ -302,8 +297,6 @@ package_gcc-fortran() {
+@@ -302,8 +296,6 @@ package_gcc-fortran() {
    cd gcc-build
    make -C $CHOST/libgfortran DESTDIR="$pkgdir" install-cafexeclibLTLIBRARIES \
      install-{toolexeclibDATA,nodist_fincludeHEADERS,gfor_cHEADERS}
@@ -125,7 +117,7 @@ index 8147682..66f170e 100644
    make -C $CHOST/libgomp DESTDIR="$pkgdir" install-nodist_fincludeHEADERS
    make -C gcc DESTDIR="$pkgdir" fortran.install-{common,man,info}
    install -Dm755 gcc/f951 "$pkgdir/${_libdir}/f951"
-@@ -348,10 +341,6 @@ package_gcc-ada() {
+@@ -348,10 +340,6 @@ package_gcc-ada() {
    make DESTDIR="${pkgdir}" INSTALL="install" \
      INSTALL_DATA="install -m644" install-libada
  
@@ -136,7 +128,7 @@ index 8147682..66f170e 100644
    ln -s gcc "$pkgdir/usr/bin/gnatgcc"
  
    # insist on dynamic linking, but keep static libraries because gnatmake complains
-@@ -360,12 +349,6 @@ package_gcc-ada() {
+@@ -360,12 +348,6 @@ package_gcc-ada() {
    ln -s libgnat-${pkgver%%.*}.so "$pkgdir/usr/lib/libgnat.so"
    rm -f "$pkgdir"/${_libdir}/adalib/libgna{rl,t}.so
  
@@ -149,16 +141,16 @@ index 8147682..66f170e 100644
    # Install Runtime Library Exception
    install -d "$pkgdir/usr/share/licenses/$pkgname/"
    ln -s /usr/share/licenses/gcc-libs/RUNTIME.LIBRARY.EXCEPTION \
-@@ -512,3 +495,12 @@ package_libgccjit() {
+@@ -512,3 +494,12 @@ package_libgccjit() {
    ln -s /usr/share/licenses/gcc-libs/RUNTIME.LIBRARY.EXCEPTION \
      "$pkgdir/usr/share/licenses/$pkgname/"
  }
 +
-+source+=(gcc-lib64-lib.patch)
-+sha256sums+=('d09cbb949364442a78e886b8f55593f07ad17f1e5369ecc83d6c6826015ba22e')
-+
-+for i in "${!pkgname[@]}"; do
-+  if [[ ${pkgname[$i]} = "lib32-gcc-libs" ]] || [[ ${pkgname[$i]} = "gcc-go" ]]; then
-+    unset 'pkgname[$i]'
-+  fi
-+done
++source+=("gcc-lib64-lib.patch"
++         # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=119084
++         # Fix https://github.com/cisco/openh264/issues/3857
++         "0001-LoongArch-Fix-incorrect-reorder-of-__lsx_vldx-and-__.patch")
++sha256sums+=('d09cbb949364442a78e886b8f55593f07ad17f1e5369ecc83d6c6826015ba22e'
++             '8a4fec2937e22fda73ce549b3f11a70c2bcc343c2dfca2de29217b2708148552')
++pkgname=(${pkgname[@]/lib32-gcc-libs})
++pkgname=(${pkgname[@]/gcc-go})


### PR DESCRIPTION
* Back port fix for `__builtin_lsx_vldx`: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=119084