### PR TITLE
updpatch: rocm-opencl-runtime, ver=6.3.2-1

### DIFF
--- a/rocm-opencl-runtime/loong.patch
+++ b/rocm-opencl-runtime/loong.patch
@@ -1,15 +1,16 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 9f649e8..e06e332 100644
+index ceb19e5..2a68354 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -40,3 +40,10 @@ package() {
+@@ -40,3 +40,11 @@ package() {
      echo '/opt/rocm/lib/libamdocl64.so' > 'amdocl64.icd'
      install -Dm644 'amdocl64.icd' "$pkgdir/etc/OpenCL/vendors/amdocl64.icd"
  }
 +
 +prepare() {
-+  patch -Np1 -d "$_dirname" -i "$srcdir/clr-loong64.patch"
++  patch -Np1 -d "$_dirname" -i "$srcdir/clr-loong64-support.patch"
++  sed -i 's!x86_64-unknown-linux-gnu!loongarch64-unknown-linux-gnu!g' "$srcdir/$_dirname"/hipamd/src/hip_embed_pch.sh
 +}
 +
-+source+=("clr-loong64.patch::https://raw.githubusercontent.com/loongarch-moe/rocm-loongarch/refs/heads/rocm-6.2.x/stage2/7.rocm-clr/clr.patch")
-+sha256sums+=('ba79185ba985f41ff8079d17c54dc5b615f631adac4066f129235928fa24adf2')
++source+=("clr-loong64-support.patch::https://raw.githubusercontent.com/loongarch-moe/rocm-loongarch/refs/tags/6.3.1a3/stage2/5.rocm-clr/clr.patch")
++sha256sums+=('8626dda69a2579f38b4e43895e73d02cd31d7bf33b731b6ad06218eb7584e811')


### PR DESCRIPTION
* Rebase to 6.3