### PR TITLE
addpatch: rustup, ver=1.28.1-1

### DIFF
--- a/rustup/loong.patch
+++ b/rustup/loong.patch
@@ -1,0 +1,11 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 26172ab..b984c48 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -57,4 +57,6 @@ package() {
+   install -Dm644 LICENSE-APACHE "${pkgdir}"/usr/share/licenses/$pkgname/LICENSE-APACHE
+ }
+ 
++makedepends+=(cmake clang)
++
+ # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
* Add clang and cmake to makedepends until aws-lc-rs' pregenerated riscv64 binding is ready
* See https://github.com/felixonmars/archriscv-packages/commit/f472a0d300a374ffc4b06b1c2d4d2b88785d8903