### PR TITLE
updpatch: rccl, ver=6.3.2-1

### DIFF
--- a/rccl/loong.patch
+++ b/rccl/loong.patch
@@ -1,25 +1,19 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 67d439a..d71c9d2 100644
+index aa8c33a..8cd4adc 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -31,6 +31,8 @@ build() {
-     -D CMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc
-     -D CMAKE_CXX_FLAGS="${CXXFLAGS} -fcf-protection=none"
-     -D CMAKE_INSTALL_PREFIX=/opt/rocm
-+    -D CMAKE_EXE_LINKER_FLAGS="-fuse-ld=mold"
-+    -D CMAKE_SHARED_LINKER_FLAGS="-fuse-ld=mold"
-   )
-   cmake "${cmake_args[@]}"
-   cmake --build build
-@@ -41,3 +43,11 @@ package() {
+@@ -29,6 +29,7 @@ prepare() {
+   git config submodule."ext-src/mscclpp".url "${srcdir}/${pkgname}"-mscclpp
  
-   install -Dm644 "$srcdir/$_dirname/LICENSE.txt" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+   git -c protocol.file.allow=always submodule update --init --recursive
++  patch -p1 -d "${srcdir}/${pkgname}" -i "${srcdir}/rccl-loongarch64-support.patch"
+ }
+ 
+ build() {
+@@ -59,3 +60,6 @@ package() {
+ 
+   install -Dm644 "$srcdir/$pkgname/LICENSE.txt" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
  }
 +
-+prepare() {
-+  patch -p1 -d "$_dirname" -i "${srcdir}/rccl-loongarch64.patch"
-+}
-+
-+makedepends+=(mold)
-+source+=("rccl-loongarch64.patch::https://raw.githubusercontent.com/loongarch-moe/rocm-loongarch/refs/heads/rocm-6.2.x/stage3/8.rocm-rccl/rccl-loongarch64.patch")
-+sha256sums+=('df003299d666894b6c2223707440d26b8dd7df1935cb713d87dea306810b0a8f')
++source+=("rccl-loongarch64-support.patch::https://raw.githubusercontent.com/loongarch-moe/rocm-loongarch/refs/tags/6.3.1a3/stage4/6.rocm-rccl/rccl-loongarch64.patch")
++sha256sums+=('a2c08bf49d1b5cb463a89e4ec8ad7f1f1f4a83c405f8526d5c3881edd7e53bcd')


### PR DESCRIPTION
* Apply https://github.com/loongarch-moe/rocm-loongarch/blob/6.3.1a3/stage4/6.rocm-rccl/rccl-loongarch64.patch to build on loong64