### PR TITLE
addpatch: cargo-msrv, ver=0.18.3-1

### DIFF
--- a/cargo-msrv/loong.patch
+++ b/cargo-msrv/loong.patch
@@ -1,0 +1,11 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 2d8583c..1dcea04 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -37,4 +37,6 @@ package() {
+   depends+=('rustup')
+ }
+ 
++makedepends+=(cmake clang)
++
+ # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
* Extra makedepends to build aws-lc-sys without pre-generated binding
* See also: https://github.com/felixonmars/archriscv-packages/commit/b644118e2dd9475f8f4e70c978cf62554b1b7a99