### PR TITLE
updpatch: firefox-developer-edition, ver=137.0b7-1

### DIFF
--- a/firefox-developer-edition/loong.patch
+++ b/firefox-developer-edition/loong.patch
@@ -1,16 +1,8 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 126932f..945fad4 100644
+index cdfac15..f52a188 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -127,7 +127,6 @@ ac_add_options --enable-optimize
- ac_add_options --enable-rust-simd
- ac_add_options --enable-linker=lld
- ac_add_options --disable-install-strip
--ac_add_options --disable-elf-hack
- ac_add_options --disable-bootstrap
- ac_add_options --with-wasi-sysroot=/usr/share/wasi-sysroot
- 
-@@ -153,7 +152,7 @@ ac_add_options --with-system-nss
+@@ -152,7 +152,7 @@ ac_add_options --with-system-nss
  # Features
  ac_add_options --enable-alsa
  ac_add_options --enable-jack


### PR DESCRIPTION
* Arch Linux upstream doesn't enable elf-hack now