### PR TITLE
updpatch: gcc, ver=14.2.1+r753+g1cd744a6828f-1.2

### DIFF
--- a/gcc/LoongArch-Support-Q-suffix-for-__float128.patch
+++ b/gcc/LoongArch-Support-Q-suffix-for-__float128.patch
@@ -1,0 +1,71 @@
+In r14-3635 supports `__float128`, but does not support the 'q/Q' suffix.
+
+	PR target/119408
+
+gcc/ChangeLog:
+
+	* config/loongarch/loongarch.cc
+	(loongarch_c_mode_for_suffix): New.
+	(TARGET_C_MODE_FOR_SUFFIX): Define.
+
+gcc/testsuite/ChangeLog:
+
+	* gcc.target/loongarch/pr119408.c: New test.
+
+---
+ gcc/config/loongarch/loongarch.cc             | 13 +++++++++++++
+ gcc/testsuite/gcc.target/loongarch/pr119408.c | 12 ++++++++++++
+ 2 files changed, 25 insertions(+)
+ create mode 100644 gcc/testsuite/gcc.target/loongarch/pr119408.c
+
+diff --git a/gcc/config/loongarch/loongarch.cc b/gcc/config/loongarch/loongarch.cc
+index 01f048664b5..7533e53839f 100644
+--- a/gcc/config/loongarch/loongarch.cc
++++ b/gcc/config/loongarch/loongarch.cc
+@@ -11206,6 +11206,16 @@ loongarch_asm_code_end (void)
+ #undef DUMP_FEATURE
+ }
+ 
++/* Target hook for c_mode_for_suffix.  */
++static machine_mode
++loongarch_c_mode_for_suffix (char suffix)
++{
++  if (suffix == 'q')
++    return TFmode;
++
++  return VOIDmode;
++}
++
+ /* Initialize the GCC target structure.  */
+ #undef TARGET_ASM_ALIGNED_HI_OP
+ #define TARGET_ASM_ALIGNED_HI_OP "\t.half\t"
+@@ -11477,6 +11487,9 @@ loongarch_asm_code_end (void)
+ #undef TARGET_OPTION_VALID_ATTRIBUTE_P
+ #define TARGET_OPTION_VALID_ATTRIBUTE_P loongarch_option_valid_attribute_p
+ 
++#undef TARGET_C_MODE_FOR_SUFFIX
++#define TARGET_C_MODE_FOR_SUFFIX loongarch_c_mode_for_suffix
++
+ struct gcc_target targetm = TARGET_INITIALIZER;
+ 
+ #include "gt-loongarch.h"
+diff --git a/gcc/testsuite/gcc.target/loongarch/pr119408.c b/gcc/testsuite/gcc.target/loongarch/pr119408.c
+new file mode 100644
+index 00000000000..f46399aa0b5
+--- /dev/null
++++ b/gcc/testsuite/gcc.target/loongarch/pr119408.c
+@@ -0,0 +1,12 @@
++/* { dg-do compile } */
++/* { dg-options "-O2 -Wno-pedantic" } */
++
++__float128 a;
++__float128 b;
++void
++test (void)
++{
++  a = 1.11111111Q;
++  b = 1.434345q;	
++}
++
+-- 
+2.34.1

--- a/gcc/loong.patch
+++ b/gcc/loong.patch
@@ -1,5 +1,5 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 1be6613..3d1ad76 100644
+index 1be6613..2fba603 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
 @@ -21,8 +21,6 @@ makedepends=(
@@ -11,18 +11,22 @@ index 1be6613..3d1ad76 100644
    libisl
    libmpc
    python
-@@ -67,6 +65,10 @@ prepare() {
- 
+@@ -68,6 +66,14 @@ prepare() {
    # Reproducible gcc-ada
    patch -Np0 < "$srcdir/gcc-ada-repro.patch"
+ 
++  # Patches for loong64
 +  # Fix libdir
 +  patch -Np1 -i "$srcdir/gcc-lib64-lib.patch"
 +  # Back port fix for __builtin_lsx_vldx
 +  patch -Np1 -i "$srcdir/0001-LoongArch-Fix-incorrect-reorder-of-__lsx_vldx-and-__.patch"
- 
++  # Back port Q suffix for __float128
++  patch -Np1 -i "$srcdir/LoongArch-Support-Q-suffix-for-__float128.patch"
++
    mkdir -p "$srcdir/gcc-build"
    mkdir -p "$srcdir/libgccjit-build"
-@@ -95,7 +97,8 @@ build() {
+ }
+@@ -95,7 +101,8 @@ build() {
        --enable-link-serialization=1
        --enable-linker-build-id
        --enable-lto
@@ -32,7 +36,7 @@ index 1be6613..3d1ad76 100644
        --enable-plugin
        --enable-shared
        --enable-threads=posix
-@@ -113,7 +116,7 @@ build() {
+@@ -113,7 +120,7 @@ build() {
    CXXFLAGS=${CXXFLAGS/-Werror=format-security/}
  
    "$srcdir/gcc/configure" \
@@ -41,7 +45,7 @@ index 1be6613..3d1ad76 100644
      --enable-bootstrap \
      "${_confflags[@]:?_confflags unset}"
  
-@@ -162,7 +165,7 @@ package_gcc-libs() {
+@@ -162,7 +169,7 @@ package_gcc-libs() {
    pkgdesc='Runtime libraries shipped by GCC'
    depends=('glibc>=2.27')
    options=(!emptydirs !strip)
@@ -50,7 +54,7 @@ index 1be6613..3d1ad76 100644
              libubsan.so libasan.so libtsan.so liblsan.so)
    replaces=($pkgname-multilib libgphobos)
  
-@@ -172,7 +175,6 @@ package_gcc-libs() {
+@@ -172,7 +179,6 @@ package_gcc-libs() {
  
    for lib in libatomic \
               libgfortran \
@@ -58,7 +62,7 @@ index 1be6613..3d1ad76 100644
               libgomp \
               libitm \
               libquadmath \
-@@ -220,22 +222,18 @@ package_gcc() {
+@@ -220,22 +226,18 @@ package_gcc() {
    install -m755 -t "$pkgdir/${_libdir}/" gcc/{cc1,cc1plus,collect2,lto1}
  
    make -C $CHOST/libgcc DESTDIR="$pkgdir" install
@@ -82,7 +86,7 @@ index 1be6613..3d1ad76 100644
  
    make DESTDIR="$pkgdir" install-fixincludes
    make -C gcc DESTDIR="$pkgdir" install-mkheaders
-@@ -252,14 +250,10 @@ package_gcc() {
+@@ -252,14 +254,10 @@ package_gcc() {
    make -C $CHOST/libsanitizer/asan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
    make -C $CHOST/libsanitizer/tsan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
    make -C $CHOST/libsanitizer/lsan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
@@ -99,7 +103,7 @@ index 1be6613..3d1ad76 100644
  
    make -C libcpp DESTDIR="$pkgdir" install
    make -C gcc DESTDIR="$pkgdir" install-po
-@@ -270,7 +264,7 @@ package_gcc() {
+@@ -270,7 +268,7 @@ package_gcc() {
    # create cc-rs compatible symlinks
    # https://github.com/rust-lang/cc-rs/blob/1.0.73/src/lib.rs#L2578-L2581
    for binary in {c++,g++,gcc,gcc-ar,gcc-nm,gcc-ranlib}; do
@@ -108,7 +112,7 @@ index 1be6613..3d1ad76 100644
    done
  
    # POSIX conformance launcher scripts for c89 and c99
-@@ -302,8 +296,6 @@ package_gcc-fortran() {
+@@ -302,8 +300,6 @@ package_gcc-fortran() {
    cd gcc-build
    make -C $CHOST/libgfortran DESTDIR="$pkgdir" install-cafexeclibLTLIBRARIES \
      install-{toolexeclibDATA,nodist_fincludeHEADERS,gfor_cHEADERS}
@@ -117,7 +121,7 @@ index 1be6613..3d1ad76 100644
    make -C $CHOST/libgomp DESTDIR="$pkgdir" install-nodist_fincludeHEADERS
    make -C gcc DESTDIR="$pkgdir" fortran.install-{common,man,info}
    install -Dm755 gcc/f951 "$pkgdir/${_libdir}/f951"
-@@ -348,10 +340,6 @@ package_gcc-ada() {
+@@ -348,10 +344,6 @@ package_gcc-ada() {
    make DESTDIR="${pkgdir}" INSTALL="install" \
      INSTALL_DATA="install -m644" install-libada
  
@@ -128,7 +132,7 @@ index 1be6613..3d1ad76 100644
    ln -s gcc "$pkgdir/usr/bin/gnatgcc"
  
    # insist on dynamic linking, but keep static libraries because gnatmake complains
-@@ -360,12 +348,6 @@ package_gcc-ada() {
+@@ -360,12 +352,6 @@ package_gcc-ada() {
    ln -s libgnat-${pkgver%%.*}.so "$pkgdir/usr/lib/libgnat.so"
    rm -f "$pkgdir"/${_libdir}/adalib/libgna{rl,t}.so
  
@@ -141,7 +145,7 @@ index 1be6613..3d1ad76 100644
    # Install Runtime Library Exception
    install -d "$pkgdir/usr/share/licenses/$pkgname/"
    ln -s /usr/share/licenses/gcc-libs/RUNTIME.LIBRARY.EXCEPTION \
-@@ -512,3 +494,12 @@ package_libgccjit() {
+@@ -512,3 +498,14 @@ package_libgccjit() {
    ln -s /usr/share/licenses/gcc-libs/RUNTIME.LIBRARY.EXCEPTION \
      "$pkgdir/usr/share/licenses/$pkgname/"
  }
@@ -149,8 +153,10 @@ index 1be6613..3d1ad76 100644
 +source+=("gcc-lib64-lib.patch"
 +         # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=119084
 +         # Fix https://github.com/cisco/openh264/issues/3857
-+         "0001-LoongArch-Fix-incorrect-reorder-of-__lsx_vldx-and-__.patch")
++         "0001-LoongArch-Fix-incorrect-reorder-of-__lsx_vldx-and-__.patch"
++         "LoongArch-Support-Q-suffix-for-__float128.patch")
 +sha256sums+=('d09cbb949364442a78e886b8f55593f07ad17f1e5369ecc83d6c6826015ba22e'
-+             '8a4fec2937e22fda73ce549b3f11a70c2bcc343c2dfca2de29217b2708148552')
++             '8a4fec2937e22fda73ce549b3f11a70c2bcc343c2dfca2de29217b2708148552'
++             'fabf067e4e5a17480dde6e05af3bdfc5e38e46837538e172d9251b50ec9cc015')
 +pkgname=(${pkgname[@]/lib32-gcc-libs})
 +pkgname=(${pkgname[@]/gcc-go})


### PR DESCRIPTION
* Back port patch to support Q suffix for fp128 literal
* See: https://gcc.gnu.org/pipermail/gcc-patches/2025-March/678874.html