### PR TITLE
updpatch: gstreamer, ver=1.26.0-3

### DIFF
--- a/gstreamer/loong.patch
+++ b/gstreamer/loong.patch
@@ -1,5 +1,5 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index de2873b..f836096 100644
+index 09413f6..ae2f662 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
 @@ -179,7 +179,6 @@ makedepends=(
@@ -10,15 +10,22 @@ index de2873b..f836096 100644
    systemd-libs
    taglib
    twolame
-@@ -249,6 +248,7 @@ build() {
-     -D gst-plugins-bad:openni2=disabled
-     -D gst-plugins-bad:opensles=disabled
-     -D gst-plugins-bad:qt6d3d11=disabled
-+    -D gst-plugins-bad:svthevcenc=disabled
-     -D gst-plugins-bad:tinyalsa=disabled
-     -D gst-plugins-bad:voaacenc=disabled
-     -D gst-plugins-bad:voamrwbenc=disabled
-@@ -284,7 +284,7 @@ check() (
+@@ -274,6 +273,14 @@ build() {
+     -D vaapi=enabled
+   )
+ 
++  # To build on loong64
++  meson_options+=(
++    -D gst-plugins-bad:svthevcenc=disabled # x86 only
++    # Temporarily disable dots-viewer
++    # dots-viewer now requires nix 0.23.2 to build, but nix 0.23.2 is too old to build on loong64
++    -D gst-devtools:dots_viewer=disabled
++  )
++
+   # https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/3197
+   export GI_SCANNER_DISABLE_CACHE=1
+ 
+@@ -293,7 +300,7 @@ check() (
  
    # Flaky due to timeouts
    xvfb-run -s "-nolisten local" \
@@ -27,7 +34,7 @@ index de2873b..f836096 100644
  )
  
  _install() {
-@@ -758,7 +758,6 @@ package_gst-plugins-bad() {
+@@ -768,7 +775,6 @@ package_gst-plugins-bad() {
      spandsp
      srt
      svt-av1
@@ -35,7 +42,7 @@ index de2873b..f836096 100644
      webrtc-audio-processing-1
      wildmidi
      x265
-@@ -822,7 +821,6 @@ package_gst-plugins-bad() {
+@@ -832,7 +838,6 @@ package_gst-plugins-bad() {
      usr/lib/gstreamer-1.0/libgstsrt.so
      usr/lib/gstreamer-1.0/libgstsrtp.so
      usr/lib/gstreamer-1.0/libgstsvtav1.so
@@ -43,3 +50,14 @@ index de2873b..f836096 100644
      usr/lib/gstreamer-1.0/libgstteletext.so
      usr/lib/gstreamer-1.0/libgsttimecode.so
      usr/lib/gstreamer-1.0/libgstttmlsubs.so
+@@ -1122,7 +1127,9 @@ package_gst-devtools() {
+     usr/share/icons/hicolor/*/apps/gst-debug-viewer.*
+     usr/share/metainfo/org.freedesktop.GstDebugViewer.appdata.xml
+ 
+-    usr/bin/gst-dots-viewer
++    # Temporarily disable dots-viewer
++    # dots-viewer now requires nix 0.23.2 to build, but nix 0.23.2 is too old to build on loong64
++    #usr/bin/gst-dots-viewer
+   ); _install
+ }
+ 


### PR DESCRIPTION
* Temporarily disable dots-viewer
  * dots-viewer now requires nix 0.23.2 to build, but nix 0.23.2 is too old to build on loong64