### PR TITLE
addpatch: runc, ver=1.2.6-1.1

### DIFF
--- a/runc/loong.patch
+++ b/runc/loong.patch
@@ -1,0 +1,22 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index f8064f6..4cb52ca 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -30,6 +30,8 @@ sha256sums=('39695adb39b0284a4fc4b184d764772d886121bf30378f9614a3abfbdc5ff11a'
+ prepare() {
+   mkdir -p src/github.com/opencontainers
+   cp -r runc-${pkgver} src/github.com/opencontainers/runc
++  patch -Np1 -d "src/github.com/opencontainers/runc" -i "${srcdir}/runc-update-libseccomp-golang-to-support-loong64.patch"
++  patch -Np1 -d "src/github.com/opencontainers/runc" -i "${srcdir}/runc-add-loong64-support.patch"
+ }
+ 
+ build() {
+@@ -54,3 +56,8 @@ package() {
+   install -d "$pkgdir/usr/share/man/man8"
+   install -m644 man/man8/*.8 "$pkgdir/usr/share/man/man8"
+ }
++
++source+=("runc-update-libseccomp-golang-to-support-loong64.patch"
++         "runc-add-loong64-support.patch::https://raw.githubusercontent.com/loong64/containerd-packaging/cf63b409783d871271293a483e569ae7c99c9b91/runc.patch")
++sha256sums+=('1e6b305d9061f39585708a4af040f141d45a59ee9356b14c6a5808c51bfb0b54'
++             '66e3182fe01d241b55e4dd1011f10b1ad99d26fdefb7af535d342f848a3ceef8')

--- a/runc/runc-update-libseccomp-golang-to-support-loong64.patch
+++ b/runc/runc-update-libseccomp-golang-to-support-loong64.patch
@@ -1,0 +1,39 @@
+diff --git a/go.mod b/go.mod
+index f6c33ef51dd..98f01319b8a 100644
+--- a/go.mod
++++ b/go.mod
+@@ -21,7 +21,7 @@ require (
+ 	github.com/mrunalp/fileutils v0.5.1
+ 	github.com/opencontainers/runtime-spec v1.2.0
+ 	github.com/opencontainers/selinux v1.11.0
+-	github.com/seccomp/libseccomp-golang v0.10.0
++	github.com/seccomp/libseccomp-golang v0.10.1-0.20250313232351-5143533fa9ea
+ 	github.com/sirupsen/logrus v1.9.3
+ 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
+ 	github.com/urfave/cli v1.22.14
+diff --git a/go.sum b/go.sum
+index dc5fd75ae5e..9bb7691be78 100644
+--- a/go.sum
++++ b/go.sum
+@@ -58,6 +58,8 @@ github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf
+ github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+ github.com/seccomp/libseccomp-golang v0.10.0 h1:aA4bp+/Zzi0BnWZ2F1wgNBs5gTpm+na2rWM6M9YjLpY=
+ github.com/seccomp/libseccomp-golang v0.10.0/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
++github.com/seccomp/libseccomp-golang v0.10.1-0.20250313232351-5143533fa9ea h1:ItmAb2WRFw1N8lQzKRFeWWZnYuKqzzOJeGrEUvRnDUI=
++github.com/seccomp/libseccomp-golang v0.10.1-0.20250313232351-5143533fa9ea/go.mod h1:5m1Lk8E9OwgZTTVz4bBOer7JuazaBa+xTkM895tDiWc=
+ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+ github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
+ github.com/spf13/cobra v1.5.0/go.mod h1:dWXEIy2H428czQCjInthrTRUg7yKbok+2Qi/yBIJoUM=
+diff --git a/vendor/modules.txt b/vendor/modules.txt
+index c1088f55909..e4f12fb3bb7 100644
+--- a/vendor/modules.txt
++++ b/vendor/modules.txt
+@@ -58,7 +58,7 @@ github.com/opencontainers/selinux/pkg/pwalkdir
+ # github.com/russross/blackfriday/v2 v2.1.0
+ ## explicit
+ github.com/russross/blackfriday/v2
+-# github.com/seccomp/libseccomp-golang v0.10.0
++# github.com/seccomp/libseccomp-golang v0.10.1-0.20250313232351-5143533fa9ea
+ ## explicit; go 1.14
+ github.com/seccomp/libseccomp-golang
+ # github.com/sirupsen/logrus v1.9.3


### PR DESCRIPTION
* Add loong64 defs
* Update libseccomp-golang to support loong64