### PR TITLE
addpatch: java-openjdk, ver=24.0.ls.27.0-1

### DIFF
--- a/java-openjdk/loong.patch
+++ b/java-openjdk/loong.patch
@@ -1,0 +1,44 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 8d20fe4..565012b 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -38,6 +38,7 @@ sha256sums=('1fb3cebfeeedc83f94442e25d8f321e28da34c09fc0fe21b4b700bcdb2ed0ee4'
+ case "${CARCH}" in
+   x86_64) _JARCH='x86_64';;
+   i686)   _JARCH='x86';;
++  loong64) _JARCH='loongarch64';;
+ esac
+ 
+ _jvmdir=/usr/lib/jvm/java-${_majorver}-openjdk
+@@ -120,7 +121,7 @@ build() {
+     ${NUM_PROC_OPT}
+     #--disable-javac-server
+ 
+-  make images legacy-jre-image docs
++  make images legacy-jre-image # docs
+ 
+   # https://bugs.openjdk.java.net/browse/JDK-8173610
+   find "${srcdir}/${_imgdir}" -iname '*.so' -exec chmod +x {} \;
+@@ -351,10 +352,21 @@ package_openjdk-doc() {
+   provides=("openjdk${_majorver}-doc=${pkgver}-${pkgrel}")
+ 
+   install -dm 755 "${pkgdir}/usr/share/doc"
+-  cp -r ${_imgdir}/docs "${pkgdir}/usr/share/doc/${pkgbase}"
++  #cp -r ${_imgdir}/docs "${pkgdir}/usr/share/doc/${pkgbase}"
+ 
+   install -dm 755 "${pkgdir}/usr/share/licenses"
+   ln -s ${pkgbase} "${pkgdir}/usr/share/licenses/${pkgname}"
+ }
+ 
++# We cannot use upstream's version control
++# Reset some versions
++_loongfixver=27
++pkgver=${_majorver}.${_minorver}.ls.${_loongfixver}.0
++_jdkdir=jdk-jdk-${_majorver}-${_loongfixver}-ls-0
++_imgdir=${_jdkdir}/build/linux-${_JARCH}-server-release/images
++
++source+=("https://github.com/loongson/jdk/archive//refs/tags/jdk-${_majorver}+${_loongfixver}-ls-0.tar.gz")
++sha256sums+=('5d9e4a83c6c72fb1fd721db4f550a326fa3b49b4328c6a8d088c1e1d38f7b4f9')
++makedepends=($(printf "%s\n" "${makedepends[@]}" | grep -Ev '^(pandoc)$'))
++
+ # vim: ts=2 sw=2 et:


### PR DESCRIPTION
* Switch to loongson's source tree: https://github.com/loongson/jdk
* Adapt the version control to loongson's
  * It's impossible for us to follow the upstream version control now