### PR TITLE
updpatch: composable-kernel, ver=6.4.0-1

### DIFF
--- a/composable-kernel/loong.patch
+++ b/composable-kernel/loong.patch
@@ -1,16 +1,8 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 804b0f0..6451684 100644
+index 61a88b7..c0b79a8 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -17,6 +17,7 @@ options=(!lto !buildflags)
- _dirname="$(basename "$url")-$(basename "${source[0]}" .tar.gz)"
- 
- prepare() {
-+    patch -Np1 -d $_dirname -i "${srcdir}/composable_kernel_loongarch.patch"
-     # Remove tests as they require a supported AMD GPU to run
-     sed -i '/add_subdirectory(test)/d' "$_dirname/CMakeLists.txt"
- }
-@@ -34,6 +35,8 @@ build() {
+@@ -34,6 +34,8 @@ build() {
      -D CMAKE_HIP_ARCHITECTURES="gfx900;gfx906:xnack-;gfx908:xnack-;gfx90a:xnack+;gfx90a:xnack-;gfx940;gfx941;gfx942;gfx1010;gfx1012;gfx1030;gfx1100;gfx1101;gfx1102;gfx1151"
      -D BUILD_DEV=OFF
      -D INSTANCES_ONLY=ON
@@ -19,10 +11,3 @@ index 804b0f0..6451684 100644
    )
    cmake "${_cmake_args[@]}"
    cmake --build build
-@@ -44,3 +47,6 @@ package() {
- 
-   install -Dm644 "$_dirname/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
- }
-+
-+source+=("composable_kernel_loongarch.patch::https://raw.githubusercontent.com/loongarch-moe/rocm-loongarch/228273601fa054e40056547339012e6d698c2855/stage5/4.rocm-composable_kernel/composable_kernel_loongarch.patch")
-+sha256sums+=('195a78775026d34bafda436ab77374f6a3b86ea162e0c90fda75cf285dca2918')


### PR DESCRIPTION
* llvm19 has fp16 support on loong64 so some of the patches are not needed
* Remain the patch to change code model