### PR TITLE
updpatch: hipblaslt, ver=6.4.1-1

### DIFF
--- a/hipblaslt/loong.patch
+++ b/hipblaslt/loong.patch
@@ -1,19 +1,10 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 4f9cb0f..09922d2 100644
+index f94b12b..c9c80bf 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -30,6 +30,8 @@ build() {
-     -D CMAKE_CXX_COMPILER=/opt/rocm/bin/hipcc
-     -D CMAKE_INSTALL_PREFIX=/opt/rocm
-     -D Tensile_CODE_OBJECT_VERSION=default
-+    -D CMAKE_EXE_LINKER_FLAGS="-fuse-ld=mold"
-+    -D CMAKE_SHARED_LINKER_FLAGS="-fuse-ld=mold"
-   )
-   # -fcf-protection is not supported by HIP, see
-   # https://rocm.docs.amd.com/projects/llvm-project/en/latest/reference/rocmcc.html#support-status-of-other-clang-options
-@@ -42,3 +44,5 @@ package() {
+@@ -46,3 +46,5 @@ package() {
  
    install -Dm644 "$_dirname/LICENSE.md" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
  }
 +
-+makedepends+=(mold rust)
++makedepends+=('python-simplejson' 'python-ujson' 'python-orjson')


### PR DESCRIPTION
* No need mold anymore
* Add python dependencies to makedepends