### PR TITLE
addpatch: zigbee2mqtt, ver=2.4.0-1

### DIFF
--- a/zigbee2mqtt/loong.patch
+++ b/zigbee2mqtt/loong.patch
@@ -1,0 +1,10 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 5c445cd..01b713d 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -92,3 +92,5 @@ package() {
+   fi
+ 
+ }
++
++makedepends+=(python)


### PR DESCRIPTION
* Add python to makedepends to fix build
    ```
    npm error code 1
    npm error path /build/zigbee2mqtt/src/zigbee2mqtt/node_modules/@serialport/bindings-cpp
    npm error command failed
    npm error command sh -c node-gyp-build
    npm error gyp info it worked if it ends with ok
    npm error gyp info using node-gyp@11.2.0
    npm error gyp info using node@23.11.1 | linux | loong64
    npm error gyp ERR! find Python 
    npm error gyp ERR! find Python Python is not set from command line or npm configuration
    npm error gyp ERR! find Python Python is not set from environment variable PYTHON
    npm error gyp ERR! find Python checking if "python3" can be used
    npm error gyp ERR! find Python - executable path is ""
    npm error gyp ERR! find Python - "" could not be run
    npm error gyp ERR! find Python checking if "python" can be used
    npm error gyp ERR! find Python - executable path is ""
    npm error gyp ERR! find Python - "" could not be run
    npm error gyp ERR! find Python 
    npm error gyp ERR! find Python **********************************************************
    npm error gyp ERR! find Python You need to install the latest version of Python.
    npm error gyp ERR! find Python Node-gyp should be able to find and use Python. If not,
    npm error gyp ERR! find Python you can try one of the following options:
    npm error gyp ERR! find Python - Use the switch --python="/path/to/pythonexecutable"
    npm error gyp ERR! find Python (accepted by both node-gyp and npm)
    npm error gyp ERR! find Python - Set the environment variable PYTHON
    npm error gyp ERR! find Python - Set the npm configuration variable python:
    npm error gyp ERR! find Python npm config set python "/path/to/pythonexecutable"
    npm error gyp ERR! find Python For more information consult the documentation at:
    npm error gyp ERR! find Python https://github.com/nodejs/node-gyp#installation
    npm error gyp ERR! find Python **********************************************************
    npm error gyp ERR! find Python 
    npm error gyp ERR! configure error 
    npm error gyp ERR! stack Error: Could not find any Python installation to use
    npm error gyp ERR! stack at PythonFinder.fail (/usr/lib/node_modules/node-gyp/lib/find-python.js:306:11)
    npm error gyp ERR! stack at PythonFinder.findPython (/usr/lib/node_modules/node-gyp/lib/find-python.js:164:17)
    npm error gyp ERR! stack at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    npm error gyp ERR! stack at async configure (/usr/lib/node_modules/node-gyp/lib/configure.js:27:18)
    npm error gyp ERR! stack at async run (/usr/lib/node_modules/node-gyp/bin/node-gyp.js:81:18)
    npm error gyp ERR! System Linux 6.14.6-arch1-1
    npm error gyp ERR! command "/usr/bin/node" "/usr/lib/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
    npm error gyp ERR! cwd /build/zigbee2mqtt/src/zigbee2mqtt/node_modules/@serialport/bindings-cpp
    npm error gyp ERR! node -v v23.11.1
    npm error gyp ERR! node-gyp -v v11.2.0
    npm error gyp ERR! not ok
    npm error A complete log of this run can be found in: /build/.npm/_logs/2025-06-02T23_56_54_840Z-debug-0.log
    ```