### PR TITLE
updpatch: blender, ver=17:4.4.3-3

### DIFF
--- a/blender/add-loong64-support.patch
+++ b/blender/add-loong64-support.patch
@@ -1,0 +1,45 @@
+From 0353d8225644784eb5838d9d02c6e9fb4c9bb697 Mon Sep 17 00:00:00 2001
+From: wszqkzqk <wszqkzqk@qq.com>
+Date: Mon, 25 Nov 2024 22:42:56 +0800
+Subject: [PATCH] BLI: Add loong64 support in BLI_build_config.h
+
+Signed-off-by: Zhou Qiankang <wszqkzqk@qq.com>
+---
+ source/blender/blenlib/BLI_build_config.h | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/source/blender/blenlib/BLI_build_config.h b/source/blender/blenlib/BLI_build_config.h
+index c45d5b065f4..2ccfcb71787 100644
+--- a/source/blender/blenlib/BLI_build_config.h
++++ b/source/blender/blenlib/BLI_build_config.h
+@@ -354,6 +354,11 @@
+ #  else
+ #    define ARCH_CPU_BIG_ENDIAN 1
+ #  endif
++#elif defined(__loongarch_lp64)
++#  define ARCH_CPU_LOONG_FAMILY 1
++#  define ARCH_CPU_LOONG64 1
++#  define ARCH_CPU_64_BITS 1
++#  define ARCH_CPU_LITTLE_ENDIAN 1
+ #else
+ #  error Please add support for your architecture in BLI_build_config.h
+ #endif
+@@ -396,6 +401,9 @@
+ #if !defined(ARCH_CPU_RISCV_FAMILY)
+ #  define ARCH_CPU_RISCV_FAMILY 0
+ #endif
++#if !defined(ARCH_CPU_LOONG_FAMILY)
++#  define ARCH_CPU_LOONG_FAMILY 0
++#endif
+ 
+ #if !defined(ARCH_CPU_ARM64)
+ #  define ARCH_CPU_ARM64 0
+@@ -439,5 +447,8 @@
+ #if !defined(ARCH_CPU_RISCV128)
+ #  define ARCH_CPU_RISCV128 0
+ #endif
++#if !defined(ARCH_CPU_LOONG64)
++#  define ARCH_CPU_LOONG64 0
++#endif
+ 
+ /** \} */

--- a/blender/loong.patch
+++ b/blender/loong.patch
@@ -1,3 +1,5 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index d919f18..d62c066 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
 @@ -30,7 +30,6 @@ depends=(
@@ -94,7 +96,7 @@
      -G Ninja
      -S "$pkgname"
      -W no-dev
-@@ -194,7 +185,11 @@ package() {
+@@ -194,7 +185,12 @@ package() {
  
    # Move OneAPI AOT lib to proper place
    mkdir "${pkgdir}"/usr/lib/
@@ -104,6 +106,7 @@
    install -vDm 644 doc/license/{BSD-{2,3}-Clause,MIT,Zlib}-license.txt -t "$pkgdir/usr/share/licenses/$pkgname/"
  }
 +
-+source+=("add-loong64-support.patch::https://projects.blender.org/blender/blender/commit/0353d8225644784eb5838d9d02c6e9fb4c9bb697.patch")
++# https://projects.blender.org/blender/blender/pulls/130916
++source+=("add-loong64-support.patch")
 +sha512sums+=('8655061b1fb68167ec1afc04d36050bd12e6f92caf8484612f7eb19352dec9e91bda669809cd7fd2a8fc001e8a6d0fbafb0854afcc2d7af6f751e9f7f83b0769')
 +makedepends+=(vulkan-headers)


### PR DESCRIPTION
* Store the patch in our repo instead of download it from the link since run curl to get the link will probably get a http page