### PR TITLE
addpatch: mkinitcpio-archiso, ver=72-1

### DIFF
--- a/mkinitcpio-archiso/loong.patch
+++ b/mkinitcpio-archiso/loong.patch
@@ -1,0 +1,19 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index bb7fe49..e757e78 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -33,9 +33,14 @@ validpgpkeys=(
+   'BB8E6F1B81CF0BB301D74D1CBF425A01E68B38EF'  # nl6720 <nl6720@archlinux.org>
+ )
+ 
++# Skip check since `shellcheck` is not ready
++checkdepends=()
++# Use a "multi-line comment" to keep patch from rotting
++: <<COMMENT_SEPARATOR
+ check() {
+   make -k check -C $pkgname
+ }
++COMMENT_SEPARATOR
+ 
+ package() {
+   make DESTDIR="$pkgdir/" PREFIX=/usr install -C $pkgname


### PR DESCRIPTION
* Skip check since checkdepends `shellcheck` is not ready