### PR TITLE
updpatch: chromium, ver=138.0.7204.49-1

### DIFF
--- a/chromium/chromium-loong64-support.patch
+++ b/chromium/chromium-loong64-support.patch
@@ -1,81 +1,3 @@
-diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/base/allocator/partition_allocator/partition_alloc.gni b/base/allocator/partition_allocator/partition_alloc.gni
---- a/base/allocator/partition_allocator/partition_alloc.gni	2000-01-01 00:00:00.000000000 +0800
-+++ b/base/allocator/partition_allocator/partition_alloc.gni	2000-01-01 00:00:00.000000000 +0800
-@@ -363,7 +363,7 @@ declare_args() {
- 
- stack_scan_supported =
-     current_cpu == "x64" || current_cpu == "x86" || current_cpu == "arm" ||
--    current_cpu == "arm64" || current_cpu == "riscv64"
-+    current_cpu == "arm64" || current_cpu == "riscv64" || current_cpu == "loong64"
- 
- # We want to provide assertions that guard against inconsistent build
- # args, but there is no point in having them fire if we're not building
-diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/base/allocator/partition_allocator/src/partition_alloc/BUILD.gn b/base/allocator/partition_allocator/src/partition_alloc/BUILD.gn
---- a/base/allocator/partition_allocator/src/partition_alloc/BUILD.gn	2000-01-01 00:00:00.000000000 +0800
-+++ b/base/allocator/partition_allocator/src/partition_alloc/BUILD.gn	2000-01-01 00:00:00.000000000 +0800
-@@ -523,6 +523,9 @@ if (is_clang_or_gcc) {
-     } else if (current_cpu == "riscv64") {
-       assert(stack_scan_supported)
-       sources += [ "stack/asm/riscv64/push_registers_asm.cc" ]
-+    } else if (current_cpu == "loong64") {
-+      assert(stack_scan_supported)
-+      sources += [ "stack/asm/loong64/push_registers_asm.cc" ]
-     } else {
-       # To support a trampoline for another arch, please refer to v8/src/heap/base.
-       assert(!stack_scan_supported)
-diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/base/allocator/partition_allocator/src/partition_alloc/stack/asm/loong64/push_registers_asm.cc b/base/allocator/partition_allocator/src/partition_alloc/stack/asm/loong64/push_registers_asm.cc
---- a/base/allocator/partition_allocator/src/partition_alloc/stack/asm/loong64/push_registers_asm.cc	2000-01-01 00:00:00.000000000 +0800
-+++ b/base/allocator/partition_allocator/src/partition_alloc/stack/asm/loong64/push_registers_asm.cc	2000-01-01 00:00:00.000000000 +0800
-@@ -0,0 +1,49 @@
-+// Copyright 2023 The Chromium Authors
-+// Use of this source code is governed by a BSD-style license that can be
-+// found in the LICENSE file.
-+
-+// Push all callee-saved registers to get them on the stack for conservative
-+// stack scanning.
-+//
-+// See asm/x64/push_registers_asm.cc for why the function is not generated
-+// using clang.
-+//
-+// Calling convention source:
-+// https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
-+asm(".global PAPushAllRegistersAndIterateStack             \n"
-+    ".type PAPushAllRegistersAndIterateStack, %function    \n"
-+    ".hidden PAPushAllRegistersAndIterateStack             \n"
-+    "PAPushAllRegistersAndIterateStack:                    \n"
-+    // Push all callee-saved registers and save return address.
-+    "  addi.d $sp, $sp, -96                              \n"
-+    // Save return address.
-+    "  st.d $ra, $sp, 88                                 \n"
-+    // sp is callee-saved.
-+    "  st.d $sp, $sp, 80                                 \n"
-+    // s0-s9(fp) are callee-saved.
-+    "  st.d $fp, $sp, 72                                 \n"
-+    "  st.d $s8, $sp, 64                                 \n"
-+    "  st.d $s7, $sp, 56                                 \n"
-+    "  st.d $s6, $sp, 48                                 \n"
-+    "  st.d $s5, $sp, 40                                 \n"
-+    "  st.d $s4, $sp, 32                                 \n"
-+    "  st.d $s3, $sp, 24                                 \n"
-+    "  st.d $s2, $sp, 16                                 \n"
-+    "  st.d $s1, $sp, 8                                  \n"
-+    "  st.d $s0, $sp, 0                                  \n"
-+    // Maintain frame pointer(fp is s9).
-+    "  move $fp, $sp                                     \n"
-+    // Pass 1st parameter (a0) unchanged (Stack*).
-+    // Pass 2nd parameter (a1) unchanged (StackVisitor*).
-+    // Save 3rd parameter (a2; IterateStackCallback) to a3.
-+    "  move $a3, $a2                                     \n"
-+    // Pass 3rd parameter as sp (stack pointer).
-+    "  move $a2, $sp                                     \n"
-+    // Call the callback.
-+    "  jirl $ra, $a3, 0                                  \n"
-+    // Load return address.
-+    "  ld.d $ra, $sp, 88                                 \n"
-+    // Restore frame pointer.
-+    "  ld.d $fp, $sp, 72                                 \n"
-+    "  addi.d $sp, $sp, 96                               \n"
-+    "  jr $ra                                            \n");
 diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/base/system/sys_info.cc b/base/system/sys_info.cc
 --- a/base/system/sys_info.cc	2000-01-01 00:00:00.000000000 +0800
 +++ b/base/system/sys_info.cc	2000-01-01 00:00:00.000000000 +0800
@@ -100,28 +22,6 @@ diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/bu
      loongarch64_use_lasx = false
    }
  }
-diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/build/config/rust.gni b/build/config/rust.gni
---- a/build/config/rust.gni	2000-01-01 00:00:00.000000000 +0800
-+++ b/build/config/rust.gni	2000-01-01 00:00:00.000000000 +0800
-@@ -213,6 +213,9 @@ if (is_linux || is_chromeos) {
-   } else if (current_cpu == "riscv64") {
-     rust_abi_target = "riscv64gc-unknown-linux-gnu"
-     cargo_target_abi = ""
-+  } else if (current_cpu == "loong64") {
-+    rust_abi_target = "loongarch64-unknown-linux-gnu"
-+    cargo_target_abi = ""
-   } else {
-     # Best guess for other future platforms.
-     rust_abi_target = current_cpu + "-unknown-linux-gnu"
-@@ -368,6 +371,8 @@ if (current_cpu == "x86") {
-   rust_target_arch = "powerpc64"
- } else if (current_cpu == "riscv64") {
-   rust_target_arch = "riscv64"
-+} else if (current_cpu == "loong64") {
-+  rust_target_arch = "loongarch64"
- }
- 
- assert(!toolchain_has_rust || rust_target_arch != "")
 diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/chrome/browser/extensions/api/runtime/chrome_runtime_api_delegate.cc b/chrome/browser/extensions/api/runtime/chrome_runtime_api_delegate.cc
 --- a/chrome/browser/extensions/api/runtime/chrome_runtime_api_delegate.cc	2000-01-01 00:00:00.000000000 +0800
 +++ b/chrome/browser/extensions/api/runtime/chrome_runtime_api_delegate.cc	2000-01-01 00:00:00.000000000 +0800
@@ -245,7 +145,7 @@ diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/gp
        ]
 +    },
 +    {
-+      "id": 184,
++      "id": 23333,
 +      "description": "Corrupted webpage rendering on Loongson LG100/110 graphics with 2D acceleration enabled",
 +      "os": {
 +        "type" : "linux"
@@ -261,16 +161,12 @@ diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/gp
 diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/features.gni b/sandbox/features.gni
 --- a/sandbox/features.gni	2000-01-01 00:00:00.000000000 +0800
 +++ b/sandbox/features.gni	2000-01-01 00:00:00.000000000 +0800
-@@ -9,7 +9,7 @@
+@@ -9,4 +9,4 @@
  use_seccomp_bpf = (is_linux || is_chromeos || is_android) &&
                    (current_cpu == "x86" || current_cpu == "x64" ||
                     current_cpu == "arm" || current_cpu == "arm64" ||
 -                   current_cpu == "mipsel" || current_cpu == "mips64el")
-+                   current_cpu == "mipsel" || current_cpu == "mips64el" || current_cpu == "loong64")
- 
- # SSBD (Speculative Store Bypass Disable) is a mitigation of Spectre Variant 4.
- # As Spectre Variant 4 can be mitigated by site isolation, opt-out SSBD on site
-diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/bpf_dsl/linux_syscall_ranges.h b/sandbox/linux/bpf_dsl/linux_syscall_ranges.h
++                   current_cpu == "mipsel" || current_cpu == "mips64el"  || current_cpu == "loong64")
 --- a/sandbox/linux/bpf_dsl/linux_syscall_ranges.h	2000-01-01 00:00:00.000000000 +0800
 +++ b/sandbox/linux/bpf_dsl/linux_syscall_ranges.h	2000-01-01 00:00:00.000000000 +0800
 @@ -56,6 +56,13 @@
@@ -2544,23 +2440,6 @@ diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sa
    } else {
      return handle_via_broker;
    }
-diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/blink/renderer/build/scripts/gperf.py b/third_party/blink/renderer/build/scripts/gperf.py
---- a/third_party/blink/renderer/build/scripts/gperf.py	2000-01-01 00:00:00.000000000 +0800
-+++ b/third_party/blink/renderer/build/scripts/gperf.py	2000-01-01 00:00:00.000000000 +0800
-@@ -37,8 +37,11 @@ def generate_gperf(gperf_path, gperf_inp
-         # -Wimplicit-fallthrough needs an explicit fallthrough statement,
-         # so replace gperf's /*FALLTHROUGH*/ comment with the statement.
-         # https://savannah.gnu.org/bugs/index.php?53029
--        gperf_output = gperf_output.replace('/*FALLTHROUGH*/',
--                                            '  [[fallthrough]];')
-+        # so replace gperf 3.1's /*FALLTHROUGH*/ comment with the statement.
-+        # https://savannah.gnu.org/bugs/index.php?53029 (fixed in 3.2)
-+        if '/* C++ code produced by gperf version 3.1 */' in gperf_output:
-+            gperf_output = gperf_output.replace('/*FALLTHROUGH*/',
-+                                                '  [[fallthrough]];')
-         # -Wpointer-to-int-cast warns about casting pointers to smaller ints
-         # Replace {(int)(long)&(foo), bar} with
-         # {static_cast<int>(reinterpret_cast<uintptr_t>(&(foo)), bar}
 diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/blink/renderer/platform/graphics/cpu/loongarch64/webgl_image_conversion_lsx.h b/third_party/blink/renderer/platform/graphics/cpu/loongarch64/webgl_image_conversion_lsx.h
 --- a/third_party/blink/renderer/platform/graphics/cpu/loongarch64/webgl_image_conversion_lsx.h	2000-01-01 00:00:00.000000000 +0800
 +++ b/third_party/blink/renderer/platform/graphics/cpu/loongarch64/webgl_image_conversion_lsx.h	2000-01-01 00:00:00.000000000 +0800

--- a/chromium/compiler-rt-adjust-paths-loong64.patch
+++ b/chromium/compiler-rt-adjust-paths-loong64.patch
@@ -1,27 +1,33 @@
-diff --git a/build/config/clang/BUILD.gn b/build/config/clang/BUILD.gn
-index 890bf91c43e40..888804b675c7d 100644
 --- a/build/config/clang/BUILD.gn
 +++ b/build/config/clang/BUILD.gn
-@@ -164,16 +164,17 @@ template("clang_lib") {
-         _dir = "darwin"
+@@ -210,14 +210,18 @@
        } else if (is_linux || is_chromeos) {
          if (current_cpu == "x64") {
--          _dir = "x86_64-unknown-linux-gnu"
+           _dir = "x86_64-unknown-linux-gnu"
 +          _suffix = "-x86_64"
          } else if (current_cpu == "x86") {
--          _dir = "i386-unknown-linux-gnu"
--        } else if (current_cpu == "arm") {
--          _dir = "armv7-unknown-linux-gnueabihf"
+           _dir = "i386-unknown-linux-gnu"
 +          _suffix = "-i386"
+         } else if (current_cpu == "arm") {
+           _dir = "armv7-unknown-linux-gnueabihf"
          } else if (current_cpu == "arm64") {
--          _dir = "aarch64-unknown-linux-gnu"
+           _dir = "aarch64-unknown-linux-gnu"
 +          _suffix = "-aarch64"
-+        } else if (current_cpu == "loong64") {
+         } else if (current_cpu == "loong64") {
+           _dir = "loongarch64-unknown-linux-gnu"
 +          _suffix = "-loongarch64"
          } else {
            assert(false)  # Unhandled cpu type
          }
+@@ -248,6 +252,11 @@
+         assert(false)  # Unhandled target platform
+       }
+ 
++      # Bit of a hack to make this find builtins from compiler-rt >= 16
++      if (is_linux || is_chromeos) {
 +        _dir = "linux"
-       } else if (is_fuchsia) {
-         if (current_cpu == "x64") {
-           _dir = "x86_64-unknown-fuchsia"
++      }
++
+       _lib_file = "${_prefix}clang_rt.${_libname}${_suffix}.${_ext}"
+       libs = [ "$_clang_lib_dir/$_dir/$_lib_file" ]
+ 

--- a/chromium/loong.patch
+++ b/chromium/loong.patch
@@ -1,9 +1,9 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 15a7da1..3730628 100644
+index 1eaca90..0e94155 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -116,7 +116,13 @@ prepare() {
-   patch -Np1 -i ../chromium-136-drop-nodejs-ver-check.patch
+@@ -111,7 +111,13 @@ prepare() {
+   patch -Np1 -i ../chromium-138-nodejs-version-check.patch
  
    # Allow libclang_rt.builtins from compiler-rt >= 16 to be used
 -  patch -Np1 -i ../compiler-rt-adjust-paths.patch
@@ -17,7 +17,7 @@ index 15a7da1..3730628 100644
  
    # Increase _FORTIFY_SOURCE level to match Arch's default flags
    patch -Np1 -i ../increase-fortify-level.patch
-@@ -211,7 +217,7 @@ build() {
+@@ -204,7 +210,7 @@ build() {
        'clang_base_path="/usr"'
        'clang_use_chrome_plugins=false'
        "clang_version=\"$_clang_version\""
@@ -26,15 +26,27 @@ index 15a7da1..3730628 100644
      )
  
      # Allow the use of nightly features with stable Rust compiler
-@@ -328,4 +334,11 @@ package() {
+@@ -245,6 +251,8 @@ build() {
+   # https://crbug.com/957519#c122
+   CXXFLAGS=${CXXFLAGS/-Wp,-D_GLIBCXX_ASSERTIONS}
+ 
++  # Disable xnnpack on loong64
++  _flags+=('build_tflite_with_xnnpack=false')
+   gn gen out/Release --args="${_flags[*]}"
+   ninja -C out/Release chrome chrome_sandbox chromedriver.unstripped
+ }
+@@ -321,4 +329,14 @@ package() {
    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/chromium/LICENSE"
  }
  
 +source+=("chromium-loong64-support.patch"
 +         "compiler-rt-adjust-paths-loong64.patch"
 +         "allow-sched_getaffinity-in-seccomp-for-loong64.patch")
-+sha256sums+=('eb2ff43f15d569b6a91eec2a0a12836638e549b82d0bd72edcc448ea8095c328'
-+             '56e8d50b7c744f51953990aefceeae5b7dd08063baaf06df98ddeec02a2d4690'
++sha256sums+=('ef7484bf4c7aa821100f96f6d9503bb8e9d15da32965bc2c8fbcd3e67f0f41bb'
++             '640ea1fa9cd6eac337afc41520184061fe60dd994613da7ba992e0e73f88057d'
 +             'b48d40e93f020b5e8861f1f320437984d8f7d62c568ad1995af78e49e88de7a9')
++# nodejs 24 is broken upstream
++makedepends=($(printf "%s\n" "${makedepends[@]}" | grep -Ev '^(nodejs)$'))
++makedepends+=(nodejs-lts-jod)
 +
  # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
* Streamline loong64 support patch by removing upstreamed or no longer needed changes (e.g., partition_alloc, rust.gni, gperf.py related adjustments).
* Adjust compiler-rt paths for loongarch64 to support newer compiler-rt versions (>= 16).
* Disable xnnpack for tflite builds on loong64.
* Switch makedepends from `nodejs` to `nodejs-lts-jod` due to issues with Node.js 24.