### PR TITLE
addpatch: markuplinkchecker, ver=0.22.0-1

### DIFF
--- a/markuplinkchecker/loong.patch
+++ b/markuplinkchecker/loong.patch
@@ -1,0 +1,13 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 8fea4ff..b66f4aa 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -27,7 +27,7 @@ build() {
+ 
+ check() {
+   cd $_name-$pkgver
+-  cargo test --frozen -- --skip "link_validator::file_system::test::remove_dot"
++  cargo test --frozen -- --skip "link_validator::file_system::test::remove_dot" --skip "throttle_different_hosts"
+ }
+ 
+ package() {


### PR DESCRIPTION
* Skip tests that are not suitable for our network environment
  ```
  assertion failed: duration < Duration::from_millis(THROTTLED_TIME_MS)
  ```