### PR TITLE
addpatch: onetbb, ver=2022.2.0-1

### DIFF
--- a/onetbb/loong.patch
+++ b/onetbb/loong.patch
@@ -1,0 +1,19 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 40b401a..e251143 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -36,6 +36,7 @@ prepare() {
+     # https://github.com/uxlfoundation/oneTBB/issues/1735
+     # https://gitlab.archlinux.org/archlinux/packaging/packages/onetbb/-/merge_requests/2
+     patch -d "oneTBB-${pkgver}" -Np1 -i "${srcdir}/010-onetbb-fix-linkage-of-test-malloc-pure-c.patch"
++    patch -d "oneTBB-${pkgver}" -Np1 -i "${srcdir}/only-enable-fcf-protection-on-x86-based-processors.patch"
+ }
+ 
+ build() {
+@@ -60,3 +61,6 @@ package() {
+     cd "oneTBB-${pkgver}/python"
+     TBBROOT="${pkgdir}/usr" python setup.py install --root="$pkgdir"
+ }
++
++source+=("only-enable-fcf-protection-on-x86-based-processors.patch::https://github.com/uxlfoundation/oneTBB/commit/65d46656f56200a7e89168824c4dbe4943421ff9.diff")
++sha512sums+=('1fea30c916b0b476fc26145df10a8a0666d5b9195ce613ee8d23279bbea51737430aadc626c1fc8260081b18284c25e0614f1c1c07d5e034f8399998620f2b97')


### PR DESCRIPTION
* Backport upstream fix for non-x86 arches