### PR TITLE
updpkg: devtools-loong64, ver=1.4.0.patch1-2

### DIFF
--- a/devtools-loong64/.SRCINFO
+++ b/devtools-loong64/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = devtools-loong64
 	pkgdesc = Tools for Arch Linux LoongArch package maintainers
-	pkgver = 1.3.2.patch3
-	pkgrel = 1
+	pkgver = 1.4.0.patch1
+	pkgrel = 2
 	url = https://gitlab.archlinux.org/archlinux/devtools
 	arch = loong64
 	arch = x86_64
@@ -10,7 +10,7 @@ pkgbase = devtools-loong64
 	license = GPL-3.0-or-later
 	depends = bash
 	depends = coreutils
-	depends = devtools>=1:1.3.2
+	depends = devtools>=1:1.4.0
 	depends = grep
 	depends = git
 	depends = patch
@@ -22,6 +22,7 @@ pkgbase = devtools-loong64
 	provides = pacman-mirrorlist-loong64
 	backup = etc/pacman.d/mirrorlist-loong64
 	source = makepkg-loong64.patch
+	source = fortran-loong64.patch
 	source = pacman-extra-loong64.patch
 	source = pacman-extra-testing-loong64.patch
 	source = pacman-extra-staging-loong64.patch
@@ -32,6 +33,7 @@ pkgbase = devtools-loong64
 	source = mirrorlist-loong64
 	source = z-qemu-loong64-static-for-archpkg.conf
 	sha256sums = 7b9efdecfe9b770cedf9f8a7039aad31842454167caddb63315ec58949edaf24
+	sha256sums = eece7a2beedfd9bf367d5930871296223b8f7ec09541d20719e9f52b61b88254
 	sha256sums = 16bae6549b594284d1e08caa831f67f5aa251447449a40c846ad9ad4701ca252
 	sha256sums = 0bb9058a722971752ec714707eecca6af32f212069bbd2d138bbd4414eaf00c0
 	sha256sums = 4866d3086f6846c070d2aa2add4258baf7111b1fe3d249cdc6a0580fa7e8cc85

--- a/devtools-loong64/PKGBUILD
+++ b/devtools-loong64/PKGBUILD
@@ -1,10 +1,10 @@
 # Maintainer: wszqkzqk <wszqkzqk@qq.com>
 
-_pkgver=1.3.2
-_patchver=3
+_pkgver=1.4.0
+_patchver=1
 pkgname=devtools-loong64
 pkgver=${_pkgver}.patch${_patchver}
-pkgrel=1
+pkgrel=2
 pkgdesc='Tools for Arch Linux LoongArch package maintainers'
 arch=('loong64' 'x86_64' 'riscv64' 'aarch64')
 license=('GPL-3.0-or-later')
@@ -20,6 +20,7 @@ depends=("bash"
          "python-gobject"
          "sed")
 source=(makepkg-loong64.patch
+        fortran-loong64.patch
         pacman-extra-loong64.patch
         pacman-extra-testing-loong64.patch
         pacman-extra-staging-loong64.patch
@@ -32,6 +33,7 @@ source=(makepkg-loong64.patch
         mirrorlist-loong64
         z-qemu-loong64-static-for-archpkg.conf)
 sha256sums=('7b9efdecfe9b770cedf9f8a7039aad31842454167caddb63315ec58949edaf24'
+            'eece7a2beedfd9bf367d5930871296223b8f7ec09541d20719e9f52b61b88254'
             '16bae6549b594284d1e08caa831f67f5aa251447449a40c846ad9ad4701ca252'
             '0bb9058a722971752ec714707eecca6af32f212069bbd2d138bbd4414eaf00c0'
             '4866d3086f6846c070d2aa2add4258baf7111b1fe3d249cdc6a0580fa7e8cc85'
@@ -74,9 +76,11 @@ package() {
 
   install -dm755 "$pkgdir"/usr/share/devtools/makepkg.conf.d/loong64.conf.d
 
-  for conf in fortran.conf rust.conf; do
+  for conf in rust.conf; do
     ln -s '../conf.d/'$conf "$pkgdir"/usr/share/devtools/makepkg.conf.d/loong64.conf.d/$conf
   done
+  patch /usr/share/devtools/makepkg.conf.d/conf.d/fortran.conf -i fortran-loong64.patch -o fortran-loong64.conf
+  install -Dm644 fortran-loong64.conf "$pkgdir"/usr/share/devtools/makepkg.conf.d/loong64.conf.d/fortran.conf
 
   install -Dm755 "${srcdir}/get-loong64-pkg" -t "$pkgdir"/usr/bin/
   install -Dm755 "${srcdir}/export-loong64-patches" -t "$pkgdir"/usr/bin/

--- a/devtools-loong64/fortran-loong64.patch
+++ b/devtools-loong64/fortran-loong64.patch
@@ -1,0 +1,13 @@
+@@ -11,9 +11,9 @@
+ 
+ # Flags used for the Fortran compiler, similar in spirit to CFLAGS. Read
+ # linkman:gfortran[1] for more details on the available flags.
+-FFLAGS="-march=x86-64 -mtune=generic -O2 -pipe -fno-plt \
+-        -Wp,-D_FORTIFY_SOURCE=3 -fstack-clash-protection -fcf-protection \
+-        -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer"
++FFLAGS="-mabi=lp64d -march=loongarch64 -mlsx -O2 -pipe -fexceptions -mcmodel=medium \
++        -Wp,-D_FORTIFY_SOURCE=3 -fstack-clash-protection \
++        -fno-omit-frame-pointer"
+ FCFLAGS="$FFLAGS"
+ 
+ # Additional compiler flags appended to `FFLAGS` and `FCFLAGS` for use in debugging. Usually


### PR DESCRIPTION
* feat: sync with upstream 1.4.0 and add proper fortran support for loong64
* Add and apply fortran-loong64.patch with appropriate FFLAGS for LoongArch64