### PR TITLE
addpatch: python-pandas, ver=2.3.1-1

### DIFF
--- a/python-pandas/loong.patch
+++ b/python-pandas/loong.patch
@@ -1,0 +1,10 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index c2521f1..a241075 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -131,3 +131,5 @@ package() {
+   python -m installer --destdir="$pkgdir" dist/*.whl
+   install -Dm644 LICENSE "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
+ }
++
++checkdepends=($(printf "%s\n" "${checkdepends[@]}" | grep -Ev '^(python-numba)$'))


### PR DESCRIPTION
* Remove python-numba from checkdepends
* python-numba is blocked by python-llvmlite
* python-llvmlite is blocked by llvm15
* llvm15 doesn't support loong64