### PR TITLE
updpatch: chromium, ver=138.0.7204.183-1

### DIFF
--- a/chromium/loong.patch
+++ b/chromium/loong.patch
@@ -1,8 +1,26 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 01d4648..a5d7978 100644
+index fc49567..ffb9bc5 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -112,7 +112,13 @@ prepare() {
+@@ -8,7 +8,7 @@ pkgname=chromium
+ pkgver=138.0.7204.183
+ pkgrel=1
+ _launcher_ver=8
+-_manual_clone=1
++_manual_clone=0
+ _system_clang=1
+ pkgdesc="A web browser built for speed, simplicity, and security"
+ arch=('x86_64')
+@@ -43,6 +43,8 @@ sha256sums=('720a1196410080056cd97a1f5ec34d68ba216a281d9b5157b7ea81ea018ec661'
+ if (( _manual_clone )); then
+   source[0]=fetch-chromium-release
+   makedepends+=('python-httplib2' 'python-pyparsing' 'python-six' 'npm' 'rsync')
++else
++  sha256sums[0]="$(curl -sL "${source[0]}.hashes" | awk '$1 == "sha256" {print $2; exit}')"
+ fi
+ 
+ # Possible replacements are listed in build/linux/unbundle/replace_gn_files.py
+@@ -112,7 +114,13 @@ prepare() {
    patch -Np1 -i ../chromium-138-nodejs-version-check.patch
  
    # Allow libclang_rt.builtins from compiler-rt >= 16 to be used
@@ -17,16 +35,16 @@ index 01d4648..a5d7978 100644
  
    # Increase _FORTIFY_SOURCE level to match Arch's default flags
    patch -Np1 -i ../increase-fortify-level.patch
-@@ -205,7 +211,7 @@ build() {
-       'clang_base_path="/usr"'
-       'clang_use_chrome_plugins=false'
-       "clang_version=\"$_clang_version\""
--      #'chrome_pgo_phase=0' # needs newer clang to read the bundled PGO profile
-+      'chrome_pgo_phase=0' # Disable PGO since the data is not for loong64
-     )
+@@ -213,7 +221,7 @@ build() {
+       _flags+=('chrome_pgo_phase=0')
+     else
+       _flags+=(
+-        #'chrome_pgo_phase=0' # needs newer clang to read the bundled PGO profile
++        'chrome_pgo_phase=0' # Disable PGO since the data is not for loong64
+       )
+     fi
  
-     # Allow the use of nightly features with stable Rust compiler
-@@ -322,4 +328,14 @@ package() {
+@@ -331,4 +339,14 @@ package() {
    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/chromium/LICENSE"
  }
  


### PR DESCRIPTION
* Upstream switched to manual clone but we have to build from tarball
* Get the hash of the tarball from a command
* See also https://gitlab.archlinux.org/archlinux/packaging/packages/chromium/-/merge_requests/11