### PR TITLE
updpkg: devtools-loong64, ver=1.4.0.patch2-1

### DIFF
--- a/devtools-loong64/.SRCINFO
+++ b/devtools-loong64/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = devtools-loong64
 	pkgdesc = Tools for Arch Linux LoongArch package maintainers
-	pkgver = 1.4.0.patch1
-	pkgrel = 2
+	pkgver = 1.4.0.patch2
+	pkgrel = 1
 	url = https://gitlab.archlinux.org/archlinux/devtools
 	arch = loong64
 	arch = x86_64
@@ -40,7 +40,7 @@ pkgbase = devtools-loong64
 	sha256sums = 3e048911fb330cd92d88c330c91232d8e271c892aa239c82d979ffedc20c215c
 	sha256sums = 820cb7964fd724b88b3a4df87f3ca86b53c3d3e5c314024599dfc50afdcbc7a0
 	sha256sums = a33135cf0adf39bc93076928eade0a9b2efb24d8bdc692d61bd1a00552c74d7a
-	sha256sums = 0bd5e25fe219fd913e820e49f1de170089d641dafe7dc4167601d10efaaaab54
+	sha256sums = 7615da05acd2dd0783ea7c63f287fca9e66bd3b2d8f945b512c214d1372733c8
 	sha256sums = 9510b27d5f3f360bc57d6911d061ac3a5cca24a824ed2c3f215da80ac05e528e
 	sha256sums = 0fa4957e6a2097a288036d18953969ff765912518f5b6a01f983a3d2f7f6a8e1
 

--- a/devtools-loong64/PKGBUILD
+++ b/devtools-loong64/PKGBUILD
@@ -1,10 +1,10 @@
 # Maintainer: wszqkzqk <wszqkzqk@qq.com>
 
 _pkgver=1.4.0
-_patchver=1
+_patchver=2
 pkgname=devtools-loong64
 pkgver=${_pkgver}.patch${_patchver}
-pkgrel=2
+pkgrel=1
 pkgdesc='Tools for Arch Linux LoongArch package maintainers'
 arch=('loong64' 'x86_64' 'riscv64' 'aarch64')
 license=('GPL-3.0-or-later')
@@ -40,7 +40,7 @@ sha256sums=('7b9efdecfe9b770cedf9f8a7039aad31842454167caddb63315ec58949edaf24'
             '3e048911fb330cd92d88c330c91232d8e271c892aa239c82d979ffedc20c215c'
             '820cb7964fd724b88b3a4df87f3ca86b53c3d3e5c314024599dfc50afdcbc7a0'
             'a33135cf0adf39bc93076928eade0a9b2efb24d8bdc692d61bd1a00552c74d7a'
-            '0bd5e25fe219fd913e820e49f1de170089d641dafe7dc4167601d10efaaaab54'
+            '7615da05acd2dd0783ea7c63f287fca9e66bd3b2d8f945b512c214d1372733c8'
             '9510b27d5f3f360bc57d6911d061ac3a5cca24a824ed2c3f215da80ac05e528e'
             '0fa4957e6a2097a288036d18953969ff765912518f5b6a01f983a3d2f7f6a8e1')
 

--- a/devtools-loong64/get-loong64-pkg
+++ b/devtools-loong64/get-loong64-pkg
@@ -313,7 +313,7 @@ def main() -> None:
         os.chdir(pkgbase)
         if os.path.isfile(PATCH_FILE):
             print(f"Applying patch {PATCH_FILE}...")
-            subprocess.run(["patch", "-p1", "-i", PATCH_FILE])
+            subprocess.run(["patch", "-Np1", "-i", PATCH_FILE])
         else:
             print(f"No '{PATCH_FILE}' found.")
             sys.exit(1)


### PR DESCRIPTION
* fix: add -N flag to patch in get-loong64-pkg to ignore reverse patches