### PR TITLE
addpatch: fsverity-utils, ver=1.6-1

### DIFF
--- a/fsverity-utils/loong.patch
+++ b/fsverity-utils/loong.patch
@@ -1,0 +1,13 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 61ab361..36e22c3 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -9,7 +9,7 @@ url='https://git.kernel.org/pub/scm/fs/fsverity/fsverity-utils.git'
+ license=('MIT')
+ arch=('x86_64')
+ depends=('openssl')
+-makedepends=('pandoc')
++makedepends=()
+ source=("${url}/snapshot/${pkgname}-${pkgver}.tar.gz")
+ sha256sums=('c7aa6b17a8a069224321ff94e46fb91a6426828ca78170a879a52cef2597abb7')
+ 


### PR DESCRIPTION
* Remove pandoc from makedepneds since it's missing
* fsverity-utils is required by ostree so we need to build it now even without doc