### PR TITLE
addpatch: electron37, ver=37.2.6-1

### DIFF
--- a/electron37/allow-sched_getaffinity-in-seccomp-for-loong64.patch
+++ b/electron37/allow-sched_getaffinity-in-seccomp-for-loong64.patch
@@ -1,0 +1,16 @@
+diff --git a/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc b/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
+index 7bde501115bdf..027738ea01793 100644
+--- a/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
++++ b/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
+@@ -229,7 +229,11 @@ ResultExpr EvaluateSyscallImpl(int fs_denied_errno,
+   // abseil. See for example https://crbug.com/1370394.
+   if (sysno == __NR_sched_getaffinity || sysno == __NR_sched_getparam ||
+       sysno == __NR_sched_getscheduler || sysno == __NR_sched_setscheduler) {
++#if defined(ARCH_CPU_LOONGARCH64)
++    return Allow();
++#else
+     return RestrictSchedTarget(current_pid, sysno);
++#endif
+   }
+ 
+   if (sysno == __NR_getrandom) {

--- a/electron37/chromium-loong64-support.patch
+++ b/electron37/chromium-loong64-support.patch
@@ -1,0 +1,9985 @@
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/base/system/sys_info.cc b/base/system/sys_info.cc
+--- a/base/system/sys_info.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/base/system/sys_info.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -256,6 +256,8 @@ std::string SysInfo::ProcessCPUArchitect
+   return "ARM_64";
+ #elif defined(ARCH_CPU_RISCV64)
+   return "RISCV_64";
++#elif defined(ARCH_CPU_LOONGARCH64)
++  return "LOONGARCH_64";
+ #else
+   return std::string();
+ #endif
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/build/config/loongarch64.gni b/build/config/loongarch64.gni
+--- a/build/config/loongarch64.gni	2000-01-01 00:00:00.000000000 +0800
++++ b/build/config/loongarch64.gni	2000-01-01 00:00:00.000000000 +0800
+@@ -7,7 +7,7 @@ import("//build/config/v8_target_cpu.gni
+ if (current_cpu == "loong64") {
+   declare_args() {
+     # LOONGARCH64 SIMD Arch compilation flag.
+-    loongarch64_use_lsx = false
++    loongarch64_use_lsx = true
+     loongarch64_use_lasx = false
+   }
+ }
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/chrome/browser/extensions/api/runtime/chrome_runtime_api_delegate.cc b/chrome/browser/extensions/api/runtime/chrome_runtime_api_delegate.cc
+--- a/chrome/browser/extensions/api/runtime/chrome_runtime_api_delegate.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/chrome/browser/extensions/api/runtime/chrome_runtime_api_delegate.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -346,6 +346,8 @@ bool ChromeRuntimeAPIDelegate::GetPlatfo
+     info->arch = extensions::api::runtime::PlatformArch::kMips;
+   } else if (strcmp(arch, "mips64el") == 0) {
+     info->arch = extensions::api::runtime::PlatformArch::kMips64;
++  } else if (strcmp(arch, "loongarch64") == 0) {
++    info->arch = extensions::api::runtime::PlatformArch::kLoongarch64;
+   } else {
+     NOTREACHED();
+   }
+@@ -361,6 +363,8 @@ bool ChromeRuntimeAPIDelegate::GetPlatfo
+     info->nacl_arch = extensions::api::runtime::PlatformNaclArch::kMips;
+   } else if (strcmp(nacl_arch, "mips64") == 0) {
+     info->nacl_arch = extensions::api::runtime::PlatformNaclArch::kMips64;
++  } else if (strcmp(nacl_arch, "loongarch64") == 0) {
++    info->nacl_arch = extensions::api::runtime::PlatformNaclArch::kLoongarch64;
+   } else {
+     NOTREACHED();
+   }
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/components/embedder_support/user_agent_utils.cc b/components/embedder_support/user_agent_utils.cc
+--- a/components/embedder_support/user_agent_utils.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/components/embedder_support/user_agent_utils.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -757,6 +757,8 @@ std::string GetCpuArchitecture() {
+               cpu_info.substr(2, 2) == "86") ||
+              base::StartsWith(cpu_info, "x86")) {
+     return "x86";
++  } else if (base::StartsWith(cpu_info, "loong")) {
++    return "loongarch";
+   }
+ #elif BUILDFLAG(IS_FUCHSIA)
+   std::string cpu_arch = base::SysInfo::ProcessCPUArchitecture();
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/components/media_router/common/providers/cast/channel/enum_table.h b/components/media_router/common/providers/cast/channel/enum_table.h
+--- a/components/media_router/common/providers/cast/channel/enum_table.h	2000-01-01 00:00:00.000000000 +0800
++++ b/components/media_router/common/providers/cast/channel/enum_table.h	2000-01-01 00:00:00.000000000 +0800
+@@ -12,7 +12,6 @@
+ 
+ #include <cstdint>
+ #include <cstring>
+-#include <new>
+ #include <optional>
+ #include <ostream>
+ #include <string_view>
+@@ -368,7 +367,8 @@ class EnumTable {
+ 
+  private:
+ #ifdef ARCH_CPU_64_BITS
+-  alignas(std::hardware_destructive_interference_size)
++  // Align the data on a cache line boundary.
++  alignas(64)
+ #endif
+       std::initializer_list<Entry> data_;
+   bool is_sorted_;
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/components/metrics/debug/metrics_internals_utils.cc b/components/metrics/debug/metrics_internals_utils.cc
+--- a/components/metrics/debug/metrics_internals_utils.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/components/metrics/debug/metrics_internals_utils.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -72,6 +72,8 @@ std::string CpuArchitectureToString(
+       return "arm32";
+     case variations::Study::TRANSLATED_X86_64:
+       return "translated_x86_64";
++    case variations::Study::LOONGARCH64:
++      return "loongarch64";
+   }
+   NOTREACHED();
+ }
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/components/variations/proto/study.proto b/components/variations/proto/study.proto
+--- a/components/variations/proto/study.proto	2000-01-01 00:00:00.000000000 +0800
++++ b/components/variations/proto/study.proto	2000-01-01 00:00:00.000000000 +0800
+@@ -262,6 +262,8 @@ message Study {
+     // A Mac-only value, indicating an x86-64 binary running on an arm64 host
+     // via "Rosetta 2" binary translation.
+     TRANSLATED_X86_64 = 4;
++
++    LOONGARCH64 = 5;
+   }
+ 
+   // Enum to pass as optional bool.
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/components/variations/service/variations_field_trial_creator_base.cc b/components/variations/service/variations_field_trial_creator_base.cc
+--- a/components/variations/service/variations_field_trial_creator_base.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/components/variations/service/variations_field_trial_creator_base.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -114,6 +114,9 @@ Study::CpuArchitecture GetCurrentCpuArch
+   if (process_arch == "ARM") {
+     return Study::ARM32;
+   }
++  if (process_arch == "LOONGARCH_64") {
++    return Study::LOONGARCH64;
++  }
+   if (process_arch == "x86") {
+     return Study::X86_32;
+   }
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/extensions/common/api/runtime.json b/extensions/common/api/runtime.json
+--- a/extensions/common/api/runtime.json	2000-01-01 00:00:00.000000000 +0800
++++ b/extensions/common/api/runtime.json	2000-01-01 00:00:00.000000000 +0800
+@@ -98,7 +98,8 @@
+             {"name": "x86-32", "description": "Specifies the processer architecture as x86-32."},
+             {"name": "x86-64", "description": "Specifies the processer architecture as x86-64."},
+             {"name": "mips", "description": "Specifies the processer architecture as mips."},
+-            {"name": "mips64", "description": "Specifies the processer architecture as mips64."}
++            {"name": "mips64", "description": "Specifies the processer architecture as mips64."},
++            {"name": "loongarch64", "description": "Specifies the processer architecture as loongarch64."}
+          ],
+         "description": "The machine's processor architecture."
+       },
+@@ -111,7 +112,8 @@
+           {"name": "x86-32", "description": "Specifies the native client architecture as x86-32."},
+           {"name": "x86-64", "description": "Specifies the native client architecture as x86-64."},
+           {"name": "mips", "description": "Specifies the native client architecture as mips."},
+-          {"name": "mips64", "description": "Specifies the native client architecture as mips64."}
++          {"name": "mips64", "description": "Specifies the native client architecture as mips64."},
++          {"name": "loongarch64", "description": "Specifies the native client architecture as loongarch64."}
+         ]
+       },
+       {
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/gpu/config/software_rendering_list.json b/gpu/config/software_rendering_list.json
+--- a/gpu/config/software_rendering_list.json	2000-01-01 00:00:00.000000000 +0800
++++ b/gpu/config/software_rendering_list.json	2000-01-01 00:00:00.000000000 +0800
+@@ -1463,6 +1463,18 @@
+       "features": [
+         "skia_graphite"
+       ]
++    },
++    {
++      "id": 23333,
++      "description": "Corrupted webpage rendering on Loongson LG100/110 graphics with 2D acceleration enabled",
++      "os": {
++        "type" : "linux"
++      },
++      "vendor_id": "0x0014",
++      "device_id": [ "0x7a36" ],
++      "features": [
++        "accelerated_2d_canvas"
++      ]
+     }
+   ]
+ }
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/features.gni b/sandbox/features.gni
+--- a/sandbox/features.gni	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/features.gni	2000-01-01 00:00:00.000000000 +0800
+@@ -9,4 +9,4 @@
+ use_seccomp_bpf = (is_linux || is_chromeos || is_android) &&
+                   (current_cpu == "x86" || current_cpu == "x64" ||
+                    current_cpu == "arm" || current_cpu == "arm64" ||
+-                   current_cpu == "mipsel" || current_cpu == "mips64el")
++                   current_cpu == "mipsel" || current_cpu == "mips64el" || current_cpu == "loong64")
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/bpf_dsl/linux_syscall_ranges.h b/sandbox/linux/bpf_dsl/linux_syscall_ranges.h
+--- a/sandbox/linux/bpf_dsl/linux_syscall_ranges.h	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/linux/bpf_dsl/linux_syscall_ranges.h	2000-01-01 00:00:00.000000000 +0800
+@@ -56,6 +56,13 @@
+ #define MAX_PUBLIC_SYSCALL __NR_syscalls
+ #define MAX_SYSCALL MAX_PUBLIC_SYSCALL
+ 
++#elif defined(__loongarch__)
++
++#include <asm-generic/unistd.h>
++#define MIN_SYSCALL 0u
++#define MAX_PUBLIC_SYSCALL __NR_syscalls
++#define MAX_SYSCALL MAX_PUBLIC_SYSCALL
++
+ #else
+ #error "Unsupported architecture"
+ #endif
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/bpf_dsl/seccomp_macros.h b/sandbox/linux/bpf_dsl/seccomp_macros.h
+--- a/sandbox/linux/bpf_dsl/seccomp_macros.h	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/linux/bpf_dsl/seccomp_macros.h	2000-01-01 00:00:00.000000000 +0800
+@@ -343,6 +343,47 @@ struct regs_struct {
+ #define SECCOMP_PT_PARM4(_regs) (_regs).regs[3]
+ #define SECCOMP_PT_PARM5(_regs) (_regs).regs[4]
+ #define SECCOMP_PT_PARM6(_regs) (_regs).regs[5]
++
++#elif defined(__loongarch__)
++struct regs_struct {
++  unsigned long long regs[32];
++  unsigned long long pc;
++};
++
++#define SECCOMP_ARCH AUDIT_ARCH_LOONGARCH64
++
++#define SECCOMP_REG(_ctx, _reg) ((_ctx)->uc_mcontext.__gregs[_reg])
++
++#define SECCOMP_RESULT(_ctx) SECCOMP_REG(_ctx, 4)
++#define SECCOMP_SYSCALL(_ctx) SECCOMP_REG(_ctx, 11)
++#define SECCOMP_IP(_ctx) (_ctx)->uc_mcontext.__pc
++#define SECCOMP_PARM1(_ctx) SECCOMP_REG(_ctx, 4)
++#define SECCOMP_PARM2(_ctx) SECCOMP_REG(_ctx, 5)
++#define SECCOMP_PARM3(_ctx) SECCOMP_REG(_ctx, 6)
++#define SECCOMP_PARM4(_ctx) SECCOMP_REG(_ctx, 7)
++#define SECCOMP_PARM5(_ctx) SECCOMP_REG(_ctx, 8)
++#define SECCOMP_PARM6(_ctx) SECCOMP_REG(_ctx, 9)
++
++#define SECCOMP_NR_IDX (offsetof(struct arch_seccomp_data, nr))
++#define SECCOMP_ARCH_IDX (offsetof(struct arch_seccomp_data, arch))
++#define SECCOMP_IP_MSB_IDX \
++  (offsetof(struct arch_seccomp_data, instruction_pointer) + 4)
++#define SECCOMP_IP_LSB_IDX \
++  (offsetof(struct arch_seccomp_data, instruction_pointer) + 0)
++#define SECCOMP_ARG_MSB_IDX(nr) \
++  (offsetof(struct arch_seccomp_data, args) + 8 * (nr) + 4)
++#define SECCOMP_ARG_LSB_IDX(nr) \
++  (offsetof(struct arch_seccomp_data, args) + 8 * (nr) + 0)
++
++#define SECCOMP_PT_RESULT(_regs) (_regs).regs[4]
++#define SECCOMP_PT_SYSCALL(_regs) (_regs).regs[11]
++#define SECCOMP_PT_IP(_regs) (_regs).pc
++#define SECCOMP_PT_PARM1(_regs) (_regs).regs[4]
++#define SECCOMP_PT_PARM2(_regs) (_regs).regs[5]
++#define SECCOMP_PT_PARM3(_regs) (_regs).regs[6]
++#define SECCOMP_PT_PARM4(_regs) (_regs).regs[7]
++#define SECCOMP_PT_PARM5(_regs) (_regs).regs[8]
++#define SECCOMP_PT_PARM6(_regs) (_regs).regs[9]
+ #else
+ #error Unsupported target platform
+ 
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc b/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc
+--- a/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/linux/seccomp-bpf-helpers/baseline_policy.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -197,7 +197,7 @@ ResultExpr EvaluateSyscallImpl(int fs_de
+     return RestrictFcntlCommands();
+ #endif
+ 
+-#if !defined(__aarch64__)
++#if !defined(__aarch64__) && !defined(__loongarch__)
+   // fork() is never used as a system call (clone() is used instead), but we
+   // have seen it in fallback code on Android.
+   if (sysno == __NR_fork) {
+@@ -259,7 +259,7 @@ ResultExpr EvaluateSyscallImpl(int fs_de
+   }
+ 
+ #if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
+-    defined(__aarch64__)
++    defined(__aarch64__) || defined(__loongarch__)
+   if (sysno == __NR_mmap)
+     return RestrictMmapFlags();
+ #endif
+@@ -280,7 +280,7 @@ ResultExpr EvaluateSyscallImpl(int fs_de
+     return RestrictPrctl();
+ 
+ #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
+-    defined(__aarch64__)
++    defined(__aarch64__) || defined(__loongarch__)
+   if (sysno == __NR_socketpair) {
+     // Only allow AF_UNIX, PF_UNIX. Crash if anything else is seen.
+     static_assert(AF_UNIX == PF_UNIX,
+@@ -306,6 +306,7 @@ ResultExpr EvaluateSyscallImpl(int fs_de
+     return Allow();
+   }
+ 
++#if !defined(__loongarch__)
+   // The fstatat syscalls are file system syscalls, which will be denied below
+   // with fs_denied_errno. However some allowed fstat syscalls are rewritten by
+   // libc implementations to fstatat syscalls, and we need to rewrite them back.
+@@ -323,6 +324,7 @@ ResultExpr EvaluateSyscallImpl(int fs_de
+     return If(mask == STATX_BASIC_STATS, Error(ENOSYS))
+         .Else(Error(fs_denied_errno));
+   }
++#endif
+ 
+   if (SyscallSets::IsFileSystem(sysno) ||
+       SyscallSets::IsCurrentDirectory(sysno)) {
+@@ -370,7 +372,7 @@ ResultExpr EvaluateSyscallImpl(int fs_de
+   // Allow creating pipes, but don't allow weird flags to pipe2().
+   // O_NOTIFICATION_PIPE (== O_EXCL) can be used to create
+   // "notification pipes", which are rarely used.
+-#if !defined(__aarch64__)
++#if !defined(__aarch64__) && !defined(__loongarch__)
+   if (sysno == __NR_pipe) {
+     return Allow();
+   }
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.cc b/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.cc
+--- a/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/linux/seccomp-bpf-helpers/sigsys_handlers.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -359,6 +359,7 @@ intptr_t SIGSYSSchedHandler(const struct
+ 
+ intptr_t SIGSYSFstatatHandler(const struct arch_seccomp_data& args,
+                               void* fs_denied_errno) {
++#if !defined(__loongarch__)
+   if (args.nr == __NR_fstatat_default) {
+     if (*reinterpret_cast<const char*>(args.args[1]) == '\0' &&
+         args.args[3] == static_cast<uint64_t>(AT_EMPTY_PATH)) {
+@@ -367,6 +368,7 @@ intptr_t SIGSYSFstatatHandler(const stru
+     }
+     return -reinterpret_cast<intptr_t>(fs_denied_errno);
+   }
++#endif
+ 
+   CrashSIGSYS_Handler(args, fs_denied_errno);
+ 
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc b/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc
+--- a/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/linux/seccomp-bpf-helpers/syscall_parameters_restrictions.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -39,7 +39,7 @@
+ #include "sandbox/linux/system_headers/linux_time.h"
+ 
+ #if BUILDFLAG(IS_LINUX) && !defined(__arm__) && !defined(__aarch64__) && \
+-    !defined(PTRACE_GET_THREAD_AREA)
++    !defined(PTRACE_GET_THREAD_AREA) && !defined(__loongarch__)
+ // Also include asm/ptrace-abi.h since ptrace.h in older libc (for instance
+ // the one in Ubuntu 16.04 LTS) is missing PTRACE_GET_THREAD_AREA.
+ // asm/ptrace-abi.h doesn't exist on arm32 and PTRACE_GET_THREAD_AREA isn't
+@@ -476,8 +476,11 @@ ResultExpr RestrictPtrace() {
+   return Switch(request)
+       .Cases({
+ #if !defined(__aarch64__)
+-                 PTRACE_GETREGS, PTRACE_GETFPREGS, PTRACE_GET_THREAD_AREA,
++                 PTRACE_GETREGS, PTRACE_GETFPREGS,
+                  PTRACE_GETREGSET,
++#if !defined(__loongarch__)
++                 PTRACE_GET_THREAD_AREA,
++#endif
+ #endif
+ #if defined(__arm__)
+                  PTRACE_GETVFPREGS,
+@@ -521,7 +524,7 @@ SANDBOX_EXPORT bpf_dsl::ResultExpr Restr
+       break;
+ #endif
+ #if defined(__i386__) || defined(__x86_64__) || defined(__arm__) || \
+-    defined(__mips__) || defined(__aarch64__)
++    defined(__mips__) || defined(__aarch64__) || defined(__loongarch__)
+     case __NR_sendto:  // Could specify destination.
+       argIndex = 3;
+       break;
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc b/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc
+--- a/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/linux/seccomp-bpf-helpers/syscall_sets.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -103,7 +103,7 @@ bool SyscallSets::IsUmask(int sysno) {
+ // Both EPERM and ENOENT are valid errno unless otherwise noted in comment.
+ bool SyscallSets::IsFileSystem(int sysno) {
+   switch (sysno) {
+-#if !defined(__aarch64__)
++#if !defined(__aarch64__) && !defined(__loongarch__)
+     case __NR_access:  // EPERM not a valid errno.
+     case __NR_chmod:
+     case __NR_chown:
+@@ -161,7 +161,9 @@ bool SyscallSets::IsFileSystem(int sysno
+ #endif
+     case __NR_openat:
+     case __NR_readlinkat:
++#if !defined(__loongarch__)
+     case __NR_renameat:
++#endif
+     case __NR_renameat2:
+ #if defined(__i386__) || defined(__arm__) || \
+     (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS))
+@@ -211,7 +213,11 @@ bool SyscallSets::IsTruncate(int sysno)
+ 
+ bool SyscallSets::IsAllowedFileSystemAccessViaFd(int sysno) {
+   switch (sysno) {
++#if !defined(__loongarch__)
+     case __NR_fstat:
++#else
++    case __NR_statx:
++#endif
+     case __NR_ftruncate:
+ #if defined(__i386__) || defined(__arm__) || \
+     (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS))
+@@ -241,7 +247,7 @@ bool SyscallSets::IsAllowedFileSystemAcc
+     case __NR_oldfstat:
+ #endif
+ #if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
+-    defined(__aarch64__)
++    defined(__aarch64__) || defined(__loongarch__)
+     case __NR_sync_file_range:  // EPERM not a valid errno.
+ #elif defined(__arm__)
+     case __NR_arm_sync_file_range:  // EPERM not a valid errno.
+@@ -260,7 +266,7 @@ bool SyscallSets::IsDeniedFileSystemAcce
+ #if defined(__i386__) || defined(__arm__)
+     case __NR_fchown32:
+ #endif
+-#if !defined(__aarch64__)
++#if !defined(__aarch64__) && !defined(__loongarch__)
+     case __NR_getdents:    // EPERM not a valid errno.
+ #endif
+     case __NR_getdents64:  // EPERM not a valid errno.
+@@ -339,7 +345,7 @@ bool SyscallSets::IsProcessPrivilegeChan
+ bool SyscallSets::IsProcessGroupOrSession(int sysno) {
+   switch (sysno) {
+     case __NR_setpgid:
+-#if !defined(__aarch64__)
++#if !defined(__aarch64__) && !defined(__loongarch__)
+     case __NR_getpgrp:
+ #endif
+     case __NR_setsid:
+@@ -373,7 +379,7 @@ bool SyscallSets::IsAllowedSignalHandlin
+     case __NR_rt_sigqueueinfo:
+     case __NR_rt_sigsuspend:
+     case __NR_rt_tgsigqueueinfo:
+-#if !defined(__aarch64__)
++#if !defined(__aarch64__) && !defined(__loongarch__)
+     case __NR_signalfd:
+ #endif
+     case __NR_signalfd4:
+@@ -397,12 +403,12 @@ bool SyscallSets::IsAllowedOperationOnFd
+   switch (sysno) {
+     case __NR_close:
+     case __NR_dup:
+-#if !defined(__aarch64__)
++#if !defined(__aarch64__) && !defined(__loongarch__)
+     case __NR_dup2:
+ #endif
+     case __NR_dup3:
+ #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
+-    defined(__aarch64__)
++    defined(__aarch64__) || defined(__loongarch__)
+     case __NR_shutdown:
+ #endif
+       return true;
+@@ -441,7 +447,7 @@ bool SyscallSets::IsAllowedProcessStartO
+       return true;
+     case __NR_clone:  // Should be parameter-restricted.
+     case __NR_setns:  // Privileged.
+-#if !defined(__aarch64__)
++#if !defined(__aarch64__) && !defined(__loongarch__)
+     case __NR_fork:
+ #endif
+ #if defined(__i386__) || defined(__x86_64__)
+@@ -452,7 +458,7 @@ bool SyscallSets::IsAllowedProcessStartO
+ #endif
+     case __NR_set_tid_address:
+     case __NR_unshare:
+-#if !defined(__mips__) && !defined(__aarch64__)
++#if !defined(__mips__) && !defined(__aarch64__) && !defined(__loongarch__)
+     case __NR_vfork:
+ #endif
+     default:
+@@ -477,7 +483,7 @@ bool SyscallSets::IsAllowedFutex(int sys
+ 
+ bool SyscallSets::IsAllowedEpoll(int sysno) {
+   switch (sysno) {
+-#if !defined(__aarch64__)
++#if !defined(__aarch64__) && !defined(__loongarch__)
+     case __NR_epoll_create:
+     case __NR_epoll_wait:
+ #endif
+@@ -499,7 +505,7 @@ bool SyscallSets::IsAllowedEpoll(int sys
+ bool SyscallSets::IsDeniedGetOrModifySocket(int sysno) {
+   switch (sysno) {
+ #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
+-    defined(__aarch64__)
++    defined(__aarch64__) || defined(__loongarch__)
+     case __NR_accept:
+     case __NR_accept4:
+     case __NR_bind:
+@@ -548,13 +554,15 @@ bool SyscallSets::IsAllowedAddressSpaceA
+     case __NR_mlock:
+     case __NR_munlock:
+     case __NR_munmap:
++#if !defined(__loongarch__)
+     case __NR_mseal:
++#endif
+       return true;
+     case __NR_madvise:
+     case __NR_mincore:
+     case __NR_mlockall:
+ #if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
+-    defined(__aarch64__)
++    defined(__aarch64__) || defined(__loongarch__)
+     case __NR_mmap:
+ #endif
+ #if defined(__i386__) || defined(__arm__) || \
+@@ -587,7 +595,7 @@ bool SyscallSets::IsAllowedGeneralIo(int
+     (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS))
+     case __NR__llseek:
+ #endif
+-#if !defined(__aarch64__)
++#if !defined(__aarch64__) && !defined(__loongarch__)
+     case __NR_poll:
+ #endif
+     case __NR_ppoll:
+@@ -608,7 +616,7 @@ bool SyscallSets::IsAllowedGeneralIo(int
+     case __NR_recv:
+ #endif
+ #if defined(__x86_64__) || defined(__arm__) || defined(__mips__) || \
+-    defined(__aarch64__)
++    defined(__aarch64__) || defined(__loongarch__)
+     case __NR_recvfrom:  // Could specify source.
+     case __NR_recvmsg:   // Could specify source.
+ #endif
+@@ -639,7 +647,7 @@ bool SyscallSets::IsAllowedGeneralIo(int
+     case __NR_send:
+ #endif
+ #if defined(__i386__) || defined(__x86_64__) || defined(__arm__) || \
+-    defined(__mips__) || defined(__aarch64__)
++    defined(__mips__) || defined(__aarch64__) || defined(__loongarch__)
+     case __NR_sendmsg:  // Could specify destination.
+     case __NR_sendto:   // Could specify destination.
+ #endif
+@@ -656,7 +664,7 @@ bool SyscallSets::IsSockSendOneMsg(int s
+     case __NR_send:
+ #endif
+ #if defined(__i386__) || defined(__x86_64__) || defined(__arm__) || \
+-    defined(__mips__) || defined(__aarch64__)
++    defined(__mips__) || defined(__aarch64__) || defined(__loongarch__)
+     case __NR_sendmsg:  // Could specify destination.
+     case __NR_sendto:   // Could specify destination.
+ #endif
+@@ -690,7 +698,7 @@ bool SyscallSets::IsSeccomp(int sysno) {
+ bool SyscallSets::IsAllowedBasicScheduler(int sysno) {
+   switch (sysno) {
+     case __NR_sched_yield:
+-#if !defined(__aarch64__)
++#if !defined(__aarch64__) && !defined(__loongarch__)
+     case __NR_pause:
+ #endif
+     case __NR_nanosleep:
+@@ -774,7 +782,7 @@ bool SyscallSets::IsNuma(int sysno) {
+     case __NR_getcpu:
+     case __NR_mbind:
+ #if defined(__i386__) || defined(__x86_64__) || defined(__mips__) || \
+-    defined(__aarch64__)
++    defined(__aarch64__) || defined(__loongarch__)
+     case __NR_migrate_pages:
+ #endif
+     case __NR_move_pages:
+@@ -822,7 +830,9 @@ bool SyscallSets::IsGlobalProcessEnviron
+     case __NR_getrusage:
+     case __NR_personality:  // Can change its personality as well.
+     case __NR_prlimit64:    // Like setrlimit / getrlimit.
++#if !defined(__loongarch__)
+     case __NR_setrlimit:
++#endif
+     case __NR_times:
+       return true;
+     default:
+@@ -844,7 +854,7 @@ bool SyscallSets::IsDebug(int sysno) {
+ 
+ bool SyscallSets::IsGlobalSystemStatus(int sysno) {
+   switch (sysno) {
+-#if !defined(__aarch64__)
++#if !defined(__aarch64__) && !defined(__loongarch__)
+     case __NR__sysctl:
+     case __NR_sysfs:
+ #endif
+@@ -862,7 +872,7 @@ bool SyscallSets::IsGlobalSystemStatus(i
+ 
+ bool SyscallSets::IsEventFd(int sysno) {
+   switch (sysno) {
+-#if !defined(__aarch64__)
++#if !defined(__aarch64__) && !defined(__loongarch__)
+     case __NR_eventfd:
+ #endif
+     case __NR_eventfd2:
+@@ -914,7 +924,7 @@ bool SyscallSets::IsKeyManagement(int sy
+ }
+ 
+ #if defined(__x86_64__) || defined(__arm__) || defined(__aarch64__) || \
+-    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS))
++    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS)) || defined(__loongarch__)
+ bool SyscallSets::IsSystemVSemaphores(int sysno) {
+   switch (sysno) {
+     case __NR_semctl:
+@@ -934,7 +944,7 @@ bool SyscallSets::IsSystemVSemaphores(in
+ 
+ #if defined(__i386__) || defined(__x86_64__) || defined(__arm__) || \
+     defined(__aarch64__) ||                                         \
+-    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS))
++    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS)) || defined(__loongarch__)
+ // These give a lot of ambient authority and bypass the setuid sandbox.
+ bool SyscallSets::IsSystemVSharedMemory(int sysno) {
+   switch (sysno) {
+@@ -950,7 +960,7 @@ bool SyscallSets::IsSystemVSharedMemory(
+ #endif
+ 
+ #if defined(__x86_64__) || defined(__arm__) || defined(__aarch64__) || \
+-    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS))
++    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS)) || defined(__loongarch__)
+ bool SyscallSets::IsSystemVMessageQueue(int sysno) {
+   switch (sysno) {
+     case __NR_msgctl:
+@@ -981,7 +991,7 @@ bool SyscallSets::IsSystemVIpc(int sysno
+ 
+ bool SyscallSets::IsAnySystemV(int sysno) {
+ #if defined(__x86_64__) || defined(__arm__) || defined(__aarch64__) || \
+-    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS))
++    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS)) || defined(__loongarch__)
+   return IsSystemVMessageQueue(sysno) || IsSystemVSemaphores(sysno) ||
+          IsSystemVSharedMemory(sysno);
+ #elif defined(__i386__) || \
+@@ -1018,7 +1028,7 @@ bool SyscallSets::IsAdvancedScheduler(in
+ bool SyscallSets::IsInotify(int sysno) {
+   switch (sysno) {
+     case __NR_inotify_add_watch:
+-#if !defined(__aarch64__)
++#if !defined(__aarch64__) && !defined(__loongarch__)
+     case __NR_inotify_init:
+ #endif
+     case __NR_inotify_init1:
+@@ -1153,7 +1163,7 @@ bool SyscallSets::IsMisc(int sysno) {
+ #if defined(__x86_64__)
+     case __NR_tuxcall:
+ #endif
+-#if !defined(__aarch64__)
++#if !defined(__aarch64__) && !defined(__loongarch__)
+     case __NR_vserver:
+ #endif
+       return true;
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h b/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h
+--- a/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/linux/seccomp-bpf-helpers/syscall_sets.h	2000-01-01 00:00:00.000000000 +0800
+@@ -80,18 +80,18 @@ class SANDBOX_EXPORT SyscallSets {
+   static bool IsAsyncIo(int sysno);
+   static bool IsKeyManagement(int sysno);
+ #if defined(__x86_64__) || defined(__arm__) || defined(__aarch64__) || \
+-    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS))
++    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS)) || defined(__loongarch__)
+   static bool IsSystemVSemaphores(int sysno);
+ #endif
+ #if defined(__i386__) || defined(__x86_64__) || defined(__arm__) || \
+     defined(__aarch64__) ||                                         \
+-    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS))
++    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS)) || defined(__loongarch__)
+   // These give a lot of ambient authority and bypass the setuid sandbox.
+   static bool IsSystemVSharedMemory(int sysno);
+ #endif
+ 
+ #if defined(__x86_64__) || defined(__arm__) || defined(__aarch64__) || \
+-    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS))
++    (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_64_BITS)) || defined(__loongarch__)
+   static bool IsSystemVMessageQueue(int sysno);
+ #endif
+ 
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/seccomp-bpf/syscall.cc b/sandbox/linux/seccomp-bpf/syscall.cc
+--- a/sandbox/linux/seccomp-bpf/syscall.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/linux/seccomp-bpf/syscall.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -19,7 +19,7 @@ namespace sandbox {
+ namespace {
+ 
+ #if defined(ARCH_CPU_X86_FAMILY) || defined(ARCH_CPU_ARM_FAMILY) || \
+-    defined(ARCH_CPU_MIPS_FAMILY)
++    defined(ARCH_CPU_MIPS_FAMILY) || defined(ARCH_CPU_LOONGARCH_FAMILY)
+ // Number that's not currently used by any Linux kernel ABIs.
+ const int kInvalidSyscallNumber = 0x351d3;
+ #else
+@@ -309,6 +309,27 @@ asm(// We need to be able to tell the ke
+     "2:ret\n"
+     ".cfi_endproc\n"
+     ".size SyscallAsm, .-SyscallAsm\n"
++#elif defined(__loongarch__)
++    ".text\n"
++    ".align 2\n"
++    ".type SyscallAsm, %function\n"
++    "SyscallAsm:\n"
++    ".cfi_startproc\n"
++    "bge $a0, $zero, 1f\n"
++    "la.pcrel $a0, 2f\n"
++    "b 2f\n"
++    "1:ld.d $a5, $a6, 40\n"
++    "ld.d $a4, $a6, 32\n"
++    "ld.d $a3, $a6, 24\n"
++    "ld.d $a2, $a6, 16\n"
++    "ld.d $a1, $a6, 8\n"
++    "move $a7, $a0\n"
++    "ld.d $a0, $a6, 0\n"
++    // Enter the kernel
++    "syscall 0\n"
++    "2:ret\n"
++    ".cfi_endproc\n"
++    ".size SyscallAsm, .-SyscallAsm\n"
+ #endif
+     );  // asm
+ 
+@@ -426,6 +447,18 @@ intptr_t Syscall::Call(int nr,
+     ret = inout;
+   }
+ 
++#elif defined(__loongarch__)
++  intptr_t ret;
++  {
++    register intptr_t inout __asm__("$r4") = nr;
++    register const intptr_t* data __asm__("$r10") = args;
++    asm volatile("bl SyscallAsm\n"
++                 : "=r"(inout)
++                 : "0"(inout), "r"(data)
++                 : "memory", "$r5", "$r6", "$r7", "$r8", "$r9", "$r11", "$r1");
++    ret = inout;
++  }
++
+ #else
+ #error "Unimplemented architecture"
+ #endif
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/services/credentials.cc b/sandbox/linux/services/credentials.cc
+--- a/sandbox/linux/services/credentials.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/linux/services/credentials.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -90,7 +90,7 @@ bool ChrootToSafeEmptyDir() {
+   alignas(16) char stack_buf[PTHREAD_STACK_MIN_CONST];
+ 
+ #if defined(ARCH_CPU_X86_FAMILY) || defined(ARCH_CPU_ARM_FAMILY) || \
+-    defined(ARCH_CPU_MIPS_FAMILY)
++    defined(ARCH_CPU_MIPS_FAMILY) || defined(ARCH_CPU_LOONGARCH_FAMILY)
+   // The stack grows downward.
+   void* stack = stack_buf + sizeof(stack_buf);
+ #else
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/services/syscall_wrappers.cc b/sandbox/linux/services/syscall_wrappers.cc
+--- a/sandbox/linux/services/syscall_wrappers.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/linux/services/syscall_wrappers.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -10,6 +10,7 @@
+ #include "sandbox/linux/services/syscall_wrappers.h"
+ 
+ #include <fcntl.h>
++#include <linux/stat.h>
+ #include <pthread.h>
+ #include <sched.h>
+ #include <setjmp.h>
+@@ -63,7 +64,7 @@ long sys_clone(unsigned long flags,
+   if (ctid) MSAN_UNPOISON(ctid, sizeof(*ctid));
+   // See kernel/fork.c in Linux. There is different ordering of sys_clone
+   // parameters depending on CONFIG_CLONE_BACKWARDS* configuration options.
+-#if defined(ARCH_CPU_X86_64)
++#if defined(ARCH_CPU_X86_64) || defined(ARCH_CPU_LOONGARCH_FAMILY)
+   return syscall(__NR_clone, flags, child_stack, ptid, ctid, tls);
+ #elif defined(ARCH_CPU_X86) || defined(ARCH_CPU_ARM_FAMILY) || \
+     defined(ARCH_CPU_MIPS_FAMILY)
+@@ -168,9 +169,53 @@ int sys_sigaction(int signum,
+   return sigaction(signum, act, oldact);
+ }
+ 
++// follow glibc __cp_stat64_statx
++void statx_to_stat(struct kernel_stat* to, struct kernel_statx* from) {
++  memset(to, 0, sizeof(struct kernel_stat));
++  to->st_dev = ((from->stx_dev_minor & 0xff) | (from->stx_dev_major << 8) |
++                ((from->stx_dev_minor & ~0xff) << 12));
++  to->st_rdev = ((from->stx_rdev_minor & 0xff) | (from->stx_rdev_major << 8) |
++                 ((from->stx_rdev_minor & ~0xff) << 12));
++  to->st_ino = from->stx_ino;
++  to->st_mode = from->stx_mode;
++  to->st_nlink = from->stx_nlink;
++  to->st_uid = from->stx_uid;
++  to->st_gid = from->stx_gid;
++  to->st_atime_ = from->stx_atime.tv_sec;
++  to->st_atime_nsec_ = from->stx_atime.tv_nsec;
++  to->st_mtime_ = from->stx_mtime.tv_sec;
++  to->st_mtime_nsec_ = from->stx_mtime.tv_nsec;
++  to->st_ctime_ = from->stx_ctime.tv_sec;
++  to->st_ctime_nsec_ = from->stx_ctime.tv_nsec;
++  to->st_size = from->stx_size;
++  to->st_blocks = from->stx_blocks;
++  to->st_blksize = from->stx_blksize;
++}
++
++int sys_statx(int fd,
++              const char* path,
++              int flags,
++              unsigned int mask,
++              struct kernel_statx* statx_buf) {
++#if defined(__NR_statx)
++  int res = syscall(__NR_statx, fd, path, flags, mask, statx_buf);
++  if (res == 0)
++    MSAN_UNPOISON(statx_buf, sizeof(*statx_buf));
++  return res;
++#else  // defined(__NR_statx)
++  RAW_CHECK(false);
++  return -ENOSYS;
++#endif
++}
++
+ int sys_stat(const char* path, struct kernel_stat* stat_buf) {
+   int res;
+-#if !defined(__NR_stat)
++#if defined(__NR_statx)
++  kernel_statx statx_buf;
++  res = syscall(__NR_statx, AT_FDCWD, path, AT_NO_AUTOMOUNT, STATX_BASIC_STATS, &statx_buf);
++  if (res == 0)
++    statx_to_stat(stat_buf, &statx_buf);
++#elif !defined(__NR_stat)
+   res = syscall(__NR_newfstatat, AT_FDCWD, path, stat_buf, 0);
+ #else
+   res = syscall(__NR_stat, path, stat_buf);
+@@ -182,7 +227,12 @@ int sys_stat(const char* path, struct ke
+ 
+ int sys_lstat(const char* path, struct kernel_stat* stat_buf) {
+   int res;
+-#if !defined(__NR_lstat)
++#if defined(__NR_statx)
++  kernel_statx statx_buf;
++  res = syscall(__NR_statx, AT_FDCWD, path, AT_NO_AUTOMOUNT | AT_SYMLINK_NOFOLLOW, STATX_BASIC_STATS, &statx_buf);
++  if (res == 0)
++    statx_to_stat(stat_buf, &statx_buf);
++#elif !defined(__NR_lstat)
+   res = syscall(__NR_newfstatat, AT_FDCWD, path, stat_buf, AT_SYMLINK_NOFOLLOW);
+ #else
+   res = syscall(__NR_lstat, path, stat_buf);
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/services/syscall_wrappers.h b/sandbox/linux/services/syscall_wrappers.h
+--- a/sandbox/linux/services/syscall_wrappers.h	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/linux/services/syscall_wrappers.h	2000-01-01 00:00:00.000000000 +0800
+@@ -19,6 +19,7 @@ struct cap_hdr;
+ struct cap_data;
+ struct kernel_stat;
+ struct kernel_stat64;
++struct kernel_statx;
+ struct landlock_ruleset_attr;
+ 
+ namespace sandbox {
+@@ -92,6 +93,7 @@ SANDBOX_EXPORT int sys_sigaction(int sig
+ // architectures, with the same capabilities as stat() and lstat().
+ SANDBOX_EXPORT int sys_stat(const char* path, struct kernel_stat* stat_buf);
+ SANDBOX_EXPORT int sys_lstat(const char* path, struct kernel_stat* stat_buf);
++SANDBOX_EXPORT int sys_statx(int fd, const char* path, int flags, unsigned int mask, struct kernel_statx* statx_buf);
+ 
+ // Takes care of unpoisoning |stat_buf| for MSAN. Check-fails if fstatat64() is
+ // not a supported syscall on the current platform.
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/syscall_broker/broker_client.cc b/sandbox/linux/syscall_broker/broker_client.cc
+--- a/sandbox/linux/syscall_broker/broker_client.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/linux/syscall_broker/broker_client.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -198,6 +198,21 @@ int BrokerClient::Stat64(const char* pat
+                            sizeof(*sb));
+ }
+ 
++int BrokerClient::Statx(const char* pathname,
++                         bool follow_links,
++                         struct kernel_statx* sb) const {
++  if (!pathname || !sb)
++    return -EFAULT;
++
++  if (fast_check_in_client_ &&
++      !CommandStatIsSafe(policy_->allowed_command_set,
++                         *policy_->file_permissions, pathname)) {
++    return -policy_->file_permissions->denied_errno();
++  }
++  return StatFamilySyscall(COMMAND_STATX, pathname, follow_links, sb,
++                           sizeof(*sb));
++}
++
+ int BrokerClient::Unlink(const char* path) const {
+   if (!path)
+     return -EFAULT;
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/syscall_broker/broker_client.h b/sandbox/linux/syscall_broker/broker_client.h
+--- a/sandbox/linux/syscall_broker/broker_client.h	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/linux/syscall_broker/broker_client.h	2000-01-01 00:00:00.000000000 +0800
+@@ -67,6 +67,9 @@ class SANDBOX_EXPORT BrokerClient : publ
+   int Stat64(const char* pathname,
+              bool follow_links,
+              struct kernel_stat64* sb) const override;
++  int Statx(const char* pathname,
++             bool follow_links,
++             struct kernel_statx* sb) const override;
+   int Unlink(const char* unlink) const override;
+   int InotifyAddWatch(int fd,
+                       const char* pathname,
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/syscall_broker/broker_command.h b/sandbox/linux/syscall_broker/broker_command.h
+--- a/sandbox/linux/syscall_broker/broker_command.h	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/linux/syscall_broker/broker_command.h	2000-01-01 00:00:00.000000000 +0800
+@@ -42,6 +42,7 @@ enum BrokerCommand {
+   COMMAND_RMDIR,
+   COMMAND_STAT,
+   COMMAND_STAT64,
++  COMMAND_STATX,
+   COMMAND_UNLINK,
+   COMMAND_INOTIFY_ADD_WATCH,
+ 
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/syscall_broker/broker_file_permission.h b/sandbox/linux/syscall_broker/broker_file_permission.h
+--- a/sandbox/linux/syscall_broker/broker_file_permission.h	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/linux/syscall_broker/broker_file_permission.h	2000-01-01 00:00:00.000000000 +0800
+@@ -5,6 +5,7 @@
+ #ifndef SANDBOX_LINUX_SYSCALL_BROKER_BROKER_FILE_PERMISSION_H_
+ #define SANDBOX_LINUX_SYSCALL_BROKER_BROKER_FILE_PERMISSION_H_
+ 
++#include <cstdint>
+ #include <bitset>
+ #include <cstdint>
+ #include <string>
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/syscall_broker/broker_host.cc b/sandbox/linux/syscall_broker/broker_host.cc
+--- a/sandbox/linux/syscall_broker/broker_host.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/linux/syscall_broker/broker_host.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -302,6 +302,21 @@ void BrokerHost::StatFileForIPC(BrokerCo
+     RAW_CHECK(reply->AddIntToMessage(0));
+     RAW_CHECK(
+         reply->AddDataToMessage(reinterpret_cast<char*>(&sb), sizeof(sb)));
++#elif defined(__loongarch__)
++    // handle COMMAND_STATX
++    DCHECK(command_type == COMMAND_STATX);
++    struct kernel_statx sb;
++
++    int sts = sandbox::sys_statx(AT_FDCWD, file_to_access,
++                                     follow_links ? 0 : AT_SYMLINK_NOFOLLOW,
++				     STATX_BASIC_STATS, &sb);
++    if (sts < 0) {
++      RAW_CHECK(reply->AddIntToMessage(-errno));
++      return;
++    }
++    RAW_CHECK(reply->AddIntToMessage(0));
++    RAW_CHECK(
++        reply->AddDataToMessage(reinterpret_cast<char*>(&sb), sizeof(sb)));
+ #else  // defined(__NR_fstatat64)
+     // We should not reach here on 64-bit systems, as the *stat*64() are only
+     // necessary on 32-bit.
+@@ -441,7 +456,8 @@ bool BrokerHost::HandleRemoteCommand(Bro
+       break;
+     }
+     case COMMAND_STAT:
+-    case COMMAND_STAT64: {
++    case COMMAND_STAT64:
++    case COMMAND_STATX: {
+       const char* requested_filename;
+       if (!message->ReadString(&requested_filename)) {
+         return false;
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/syscall_broker/broker_process.cc b/sandbox/linux/syscall_broker/broker_process.cc
+--- a/sandbox/linux/syscall_broker/broker_process.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/linux/syscall_broker/broker_process.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -120,44 +120,46 @@ bool BrokerProcess::IsSyscallBrokerable(
+   // and are default disabled in Android. So, we should refuse to broker them
+   // to be consistent with the platform's restrictions.
+   switch (sysno) {
+-#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID)
++#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID) && !defined(__loongarch__)
+     case __NR_access:
+ #endif
+     case __NR_faccessat:
+     case __NR_faccessat2:
+       return !fast_check || policy_->allowed_command_set.test(COMMAND_ACCESS);
+ 
+-#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID)
++#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID) && !defined(__loongarch__)
+     case __NR_mkdir:
+ #endif
+     case __NR_mkdirat:
+       return !fast_check || policy_->allowed_command_set.test(COMMAND_MKDIR);
+ 
+-#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID)
++#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID) && !defined(__loongarch__)
+     case __NR_open:
+ #endif
+     case __NR_openat:
+       return !fast_check || policy_->allowed_command_set.test(COMMAND_OPEN);
+ 
+-#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID)
++#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID) && !defined(__loongarch__)
+     case __NR_readlink:
+ #endif
+     case __NR_readlinkat:
+       return !fast_check || policy_->allowed_command_set.test(COMMAND_READLINK);
+ 
+-#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID)
++#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID) && !defined(__loongarch__)
+     case __NR_rename:
+ #endif
++#if !defined(__loongarch__)
+     case __NR_renameat:
++#endif
+     case __NR_renameat2:
+       return !fast_check || policy_->allowed_command_set.test(COMMAND_RENAME);
+ 
+-#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID)
++#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID) && !defined(__loongarch__)
+     case __NR_rmdir:
+       return !fast_check || policy_->allowed_command_set.test(COMMAND_RMDIR);
+ #endif
+ 
+-#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID)
++#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID) && !defined(__loongarch__)
+     case __NR_stat:
+     case __NR_lstat:
+ #endif
+@@ -167,6 +169,9 @@ bool BrokerProcess::IsSyscallBrokerable(
+ #if defined(__NR_fstatat64)
+     case __NR_fstatat64:
+ #endif
++#if defined(__NR_statx)
++    case __NR_statx:
++#endif
+ #if defined(__x86_64__) || defined(__aarch64__)
+     case __NR_newfstatat:
+ #endif
+@@ -182,7 +187,7 @@ bool BrokerProcess::IsSyscallBrokerable(
+       return !fast_check || policy_->allowed_command_set.test(COMMAND_STAT);
+ #endif
+ 
+-#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID)
++#if !defined(__aarch64__) && !BUILDFLAG(IS_ANDROID) && !defined(__loongarch__)
+     case __NR_unlink:
+       return !fast_check || policy_->allowed_command_set.test(COMMAND_UNLINK);
+ #endif
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/syscall_broker/syscall_dispatcher.cc b/sandbox/linux/syscall_broker/syscall_dispatcher.cc
+--- a/sandbox/linux/syscall_broker/syscall_dispatcher.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/linux/syscall_broker/syscall_dispatcher.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -27,6 +27,8 @@ int SyscallDispatcher::DefaultStatForTes
+   return Stat64(pathname, follow_links, sb);
+ #elif defined(__NR_newfstatat)
+   return Stat(pathname, follow_links, sb);
++#elif defined(__NR_statx)
++  return Statx(pathname, follow_links, sb);
+ #endif
+ }
+ 
+@@ -170,6 +172,19 @@ int SyscallDispatcher::DispatchSyscall(c
+       return Stat64(reinterpret_cast<const char*>(args.args[0]), true,
+                     reinterpret_cast<struct kernel_stat64*>(args.args[1]));
+ #endif
++#if defined(__NR_statx)
++    case __NR_statx:
++      // we have ensured that the statx does not have AT_EMPTY_PATH in HandleViaBroker()
++      // so this is stat/lstat instead of fstat
++      // see PerformStatat
++      if (static_cast<int>(args.args[0]) != AT_FDCWD) {
++        return -EPERM;
++      }
++
++      return Statx(reinterpret_cast<const char*>(args.args[1]),
++		   !(static_cast<int>(args.args[2]) & AT_SYMLINK_NOFOLLOW),
++                   reinterpret_cast<struct kernel_statx*>(args.args[4]));
++#endif
+ #if defined(__NR_lstat)
+     case __NR_lstat:
+       // See https://crbug.com/847096
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/syscall_broker/syscall_dispatcher.h b/sandbox/linux/syscall_broker/syscall_dispatcher.h
+--- a/sandbox/linux/syscall_broker/syscall_dispatcher.h	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/linux/syscall_broker/syscall_dispatcher.h	2000-01-01 00:00:00.000000000 +0800
+@@ -49,6 +49,9 @@ class SANDBOX_EXPORT SyscallDispatcher {
+   virtual int Stat64(const char* pathname,
+                      bool follow_links,
+                      struct kernel_stat64* sb) const = 0;
++  virtual int Statx(const char* pathname,
++                     bool follow_links,
++                     struct kernel_statx* sb) const = 0;
+ 
+   // Emulates unlink()/unlinkat().
+   virtual int Unlink(const char* unlink) const = 0;
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/system_headers/linux_seccomp.h b/sandbox/linux/system_headers/linux_seccomp.h
+--- a/sandbox/linux/system_headers/linux_seccomp.h	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/linux/system_headers/linux_seccomp.h	2000-01-01 00:00:00.000000000 +0800
+@@ -39,6 +39,10 @@
+ #define EM_AARCH64 183
+ #endif
+ 
++#ifndef EM_LOONGARCH64
++#define EM_LOONGARCH64 258
++#endif
++
+ #ifndef __AUDIT_ARCH_64BIT
+ #define __AUDIT_ARCH_64BIT 0x80000000
+ #endif
+@@ -71,6 +75,10 @@
+ #define AUDIT_ARCH_AARCH64 (EM_AARCH64 | __AUDIT_ARCH_64BIT | __AUDIT_ARCH_LE)
+ #endif
+ 
++#ifndef AUDIT_ARCH_LOONGARCH64
++#define AUDIT_ARCH_LOONGARCH64 (EM_LOONGARCH64 | __AUDIT_ARCH_64BIT | __AUDIT_ARCH_LE)
++#endif
++
+ // For prctl.h
+ #ifndef PR_SET_SECCOMP
+ #define PR_SET_SECCOMP               22
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/system_headers/linux_signal.h b/sandbox/linux/system_headers/linux_signal.h
+--- a/sandbox/linux/system_headers/linux_signal.h	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/linux/system_headers/linux_signal.h	2000-01-01 00:00:00.000000000 +0800
+@@ -13,7 +13,7 @@
+ // (not undefined, but defined different values and in different memory
+ // layouts). So, fill the gap here.
+ #if defined(__i386__) || defined(__x86_64__) || defined(__arm__) || \
+-    defined(__aarch64__)
++    defined(__aarch64__) || defined(__loongarch__)
+ 
+ #define LINUX_SIGHUP 1
+ #define LINUX_SIGINT 2
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/system_headers/linux_stat.h b/sandbox/linux/system_headers/linux_stat.h
+--- a/sandbox/linux/system_headers/linux_stat.h	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/linux/system_headers/linux_stat.h	2000-01-01 00:00:00.000000000 +0800
+@@ -150,7 +150,7 @@ struct kernel_stat {
+   int st_blocks;
+   int st_pad4[14];
+ };
+-#elif defined(__aarch64__)
++#elif defined(__aarch64__) || defined(__loongarch__)
+ struct kernel_stat {
+   unsigned long st_dev;
+   unsigned long st_ino;
+@@ -175,6 +175,40 @@ struct kernel_stat {
+ };
+ #endif
+ 
++// from linux include/uapi/linux/stat.h
++struct kernel_statx_timestamp {
++  long tv_sec;
++  unsigned int tv_nsec;
++  int __reserved;
++};
++
++struct kernel_statx {
++  unsigned int stx_mask;
++  unsigned int stx_blksize;
++  unsigned long stx_attributes;
++  unsigned int stx_nlink;
++  unsigned int stx_uid;
++  unsigned int stx_gid;
++  unsigned short stx_mode;
++  unsigned short __spare0[1];
++  unsigned long stx_ino;
++  unsigned long stx_size;
++  unsigned long stx_blocks;
++  unsigned long stx_attributes_mask;
++  struct kernel_statx_timestamp stx_atime;
++  struct kernel_statx_timestamp stx_btime;
++  struct kernel_statx_timestamp stx_ctime;
++  struct kernel_statx_timestamp stx_mtime;
++  unsigned int stx_rdev_major;
++  unsigned int stx_rdev_minor;
++  unsigned int stx_dev_major;
++  unsigned int stx_dev_minor;
++  unsigned long stx_mnt_id;
++  unsigned int stx_dio_mem_align;
++  unsigned int stx_dio_offset_align;
++  unsigned long __spare3[12];
++};
++
+ #if !defined(AT_EMPTY_PATH)
+ #define AT_EMPTY_PATH 0x1000
+ #endif
+@@ -207,8 +241,14 @@ using default_stat_struct = struct kerne
+ #define __NR_fstatat_default __NR_newfstatat
+ #define __NR_fstat_default __NR_fstat
+ 
++#elif defined(__NR_statx)
++
++namespace sandbox {
++using default_stat_struct = struct kernel_statx;
++}  // namespace sandbox
++
+ #else
+-#error "one of fstatat64 and newfstatat must be defined"
++#error "one of fstatat64, newfstatat and statx must be defined"
+ #endif
+ 
+ #endif  // SANDBOX_LINUX_SYSTEM_HEADERS_LINUX_STAT_H_
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/system_headers/linux_syscalls.h b/sandbox/linux/system_headers/linux_syscalls.h
+--- a/sandbox/linux/system_headers/linux_syscalls.h	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/linux/system_headers/linux_syscalls.h	2000-01-01 00:00:00.000000000 +0800
+@@ -35,5 +35,9 @@
+ #include "sandbox/linux/system_headers/arm64_linux_syscalls.h"
+ #endif
+ 
++#if defined(__loongarch__)
++#include "sandbox/linux/system_headers/loong64_linux_syscalls.h"
++#endif
++
+ #endif  // SANDBOX_LINUX_SYSTEM_HEADERS_LINUX_SYSCALLS_H_
+ 
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/system_headers/loong64_linux_syscalls.h b/sandbox/linux/system_headers/loong64_linux_syscalls.h
+--- a/sandbox/linux/system_headers/loong64_linux_syscalls.h	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/linux/system_headers/loong64_linux_syscalls.h	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,1194 @@
++// Copyright 2023 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef SANDBOX_LINUX_SYSTEM_HEADERS_LOONG64_LINUX_SYSCALLS_H_
++#define SANDBOX_LINUX_SYSTEM_HEADERS_LOONG64_LINUX_SYSCALLS_H_
++
++#include <asm-generic/unistd.h>
++
++#if !defined(__NR_io_setup)
++#define __NR_io_setup 0
++#endif
++
++#if !defined(__NR_io_destroy)
++#define __NR_io_destroy 1
++#endif
++
++#if !defined(__NR_io_submit)
++#define __NR_io_submit 2
++#endif
++
++#if !defined(__NR_io_cancel)
++#define __NR_io_cancel 3
++#endif
++
++#if !defined(__NR_io_getevents)
++#define __NR_io_getevents 4
++#endif
++
++#if !defined(__NR_setxattr)
++#define __NR_setxattr 5
++#endif
++
++#if !defined(__NR_lsetxattr)
++#define __NR_lsetxattr 6
++#endif
++
++#if !defined(__NR_fsetxattr)
++#define __NR_fsetxattr 7
++#endif
++
++#if !defined(__NR_getxattr)
++#define __NR_getxattr 8
++#endif
++
++#if !defined(__NR_lgetxattr)
++#define __NR_lgetxattr 9
++#endif
++
++#if !defined(__NR_fgetxattr)
++#define __NR_fgetxattr 10
++#endif
++
++#if !defined(__NR_listxattr)
++#define __NR_listxattr 11
++#endif
++
++#if !defined(__NR_llistxattr)
++#define __NR_llistxattr 12
++#endif
++
++#if !defined(__NR_flistxattr)
++#define __NR_flistxattr 13
++#endif
++
++#if !defined(__NR_removexattr)
++#define __NR_removexattr 14
++#endif
++
++#if !defined(__NR_lremovexattr)
++#define __NR_lremovexattr 15
++#endif
++
++#if !defined(__NR_fremovexattr)
++#define __NR_fremovexattr 16
++#endif
++
++#if !defined(__NR_getcwd)
++#define __NR_getcwd 17
++#endif
++
++#if !defined(__NR_lookup_dcookie)
++#define __NR_lookup_dcookie 18
++#endif
++
++#if !defined(__NR_eventfd2)
++#define __NR_eventfd2 19
++#endif
++
++#if !defined(__NR_epoll_create1)
++#define __NR_epoll_create1 20
++#endif
++
++#if !defined(__NR_epoll_ctl)
++#define __NR_epoll_ctl 21
++#endif
++
++#if !defined(__NR_epoll_pwait)
++#define __NR_epoll_pwait 22
++#endif
++
++#if !defined(__NR_dup)
++#define __NR_dup 23
++#endif
++
++#if !defined(__NR_dup3)
++#define __NR_dup3 24
++#endif
++
++#if !defined(__NR_fcntl)
++#define __NR_fcntl 25
++#endif
++
++#if !defined(__NR_inotify_init1)
++#define __NR_inotify_init1 26
++#endif
++
++#if !defined(__NR_inotify_add_watch)
++#define __NR_inotify_add_watch 27
++#endif
++
++#if !defined(__NR_inotify_rm_watch)
++#define __NR_inotify_rm_watch 28
++#endif
++
++#if !defined(__NR_ioctl)
++#define __NR_ioctl 29
++#endif
++
++#if !defined(__NR_ioprio_set)
++#define __NR_ioprio_set 30
++#endif
++
++#if !defined(__NR_ioprio_get)
++#define __NR_ioprio_get 31
++#endif
++
++#if !defined(__NR_flock)
++#define __NR_flock 32
++#endif
++
++#if !defined(__NR_mknodat)
++#define __NR_mknodat 33
++#endif
++
++#if !defined(__NR_mkdirat)
++#define __NR_mkdirat 34
++#endif
++
++#if !defined(__NR_unlinkat)
++#define __NR_unlinkat 35
++#endif
++
++#if !defined(__NR_symlinkat)
++#define __NR_symlinkat 36
++#endif
++
++#if !defined(__NR_linkat)
++#define __NR_linkat 37
++#endif
++
++#if !defined(__NR_umount2)
++#define __NR_umount2 39
++#endif
++
++#if !defined(__NR_mount)
++#define __NR_mount 40
++#endif
++
++#if !defined(__NR_pivot_root)
++#define __NR_pivot_root 41
++#endif
++
++#if !defined(__NR_nfsservctl)
++#define __NR_nfsservctl 42
++#endif
++
++#if !defined(__NR_statfs)
++#define __NR_statfs 43
++#endif
++
++#if !defined(__NR_fstatfs)
++#define __NR_fstatfs 44
++#endif
++
++#if !defined(__NR_truncate)
++#define __NR_truncate 45
++#endif
++
++#if !defined(__NR_ftruncate)
++#define __NR_ftruncate 46
++#endif
++
++#if !defined(__NR_fallocate)
++#define __NR_fallocate 47
++#endif
++
++#if !defined(__NR_faccessat)
++#define __NR_faccessat 48
++#endif
++
++#if !defined(__NR_chdir)
++#define __NR_chdir 49
++#endif
++
++#if !defined(__NR_fchdir)
++#define __NR_fchdir 50
++#endif
++
++#if !defined(__NR_chroot)
++#define __NR_chroot 51
++#endif
++
++#if !defined(__NR_fchmod)
++#define __NR_fchmod 52
++#endif
++
++#if !defined(__NR_fchmodat)
++#define __NR_fchmodat 53
++#endif
++
++#if !defined(__NR_fchownat)
++#define __NR_fchownat 54
++#endif
++
++#if !defined(__NR_fchown)
++#define __NR_fchown 55
++#endif
++
++#if !defined(__NR_openat)
++#define __NR_openat 56
++#endif
++
++#if !defined(__NR_close)
++#define __NR_close 57
++#endif
++
++#if !defined(__NR_vhangup)
++#define __NR_vhangup 58
++#endif
++
++#if !defined(__NR_pipe2)
++#define __NR_pipe2 59
++#endif
++
++#if !defined(__NR_quotactl)
++#define __NR_quotactl 60
++#endif
++
++#if !defined(__NR_getdents64)
++#define __NR_getdents64 61
++#endif
++
++#if !defined(__NR_lseek)
++#define __NR_lseek 62
++#endif
++
++#if !defined(__NR_read)
++#define __NR_read 63
++#endif
++
++#if !defined(__NR_write)
++#define __NR_write 64
++#endif
++
++#if !defined(__NR_readv)
++#define __NR_readv 65
++#endif
++
++#if !defined(__NR_writev)
++#define __NR_writev 66
++#endif
++
++#if !defined(__NR_pread64)
++#define __NR_pread64 67
++#endif
++
++#if !defined(__NR_pwrite64)
++#define __NR_pwrite64 68
++#endif
++
++#if !defined(__NR_preadv)
++#define __NR_preadv 69
++#endif
++
++#if !defined(__NR_pwritev)
++#define __NR_pwritev 70
++#endif
++
++#if !defined(__NR_sendfile)
++#define __NR_sendfile 71
++#endif
++
++#if !defined(__NR_pselect6)
++#define __NR_pselect6 72
++#endif
++
++#if !defined(__NR_ppoll)
++#define __NR_ppoll 73
++#endif
++
++#if !defined(__NR_signalfd4)
++#define __NR_signalfd4 74
++#endif
++
++#if !defined(__NR_vmsplice)
++#define __NR_vmsplice 75
++#endif
++
++#if !defined(__NR_splice)
++#define __NR_splice 76
++#endif
++
++#if !defined(__NR_tee)
++#define __NR_tee 77
++#endif
++
++#if !defined(__NR_readlinkat)
++#define __NR_readlinkat 78
++#endif
++
++#if !defined(__NR_sync)
++#define __NR_sync 81
++#endif
++
++#if !defined(__NR_fsync)
++#define __NR_fsync 82
++#endif
++
++#if !defined(__NR_fdatasync)
++#define __NR_fdatasync 83
++#endif
++
++#if !defined(__NR_sync_file_range)
++#define __NR_sync_file_range 84
++#endif
++
++#if !defined(__NR_timerfd_create)
++#define __NR_timerfd_create 85
++#endif
++
++#if !defined(__NR_timerfd_settime)
++#define __NR_timerfd_settime 86
++#endif
++
++#if !defined(__NR_timerfd_gettime)
++#define __NR_timerfd_gettime 87
++#endif
++
++#if !defined(__NR_utimensat)
++#define __NR_utimensat 88
++#endif
++
++#if !defined(__NR_acct)
++#define __NR_acct 89
++#endif
++
++#if !defined(__NR_capget)
++#define __NR_capget 90
++#endif
++
++#if !defined(__NR_capset)
++#define __NR_capset 91
++#endif
++
++#if !defined(__NR_personality)
++#define __NR_personality 92
++#endif
++
++#if !defined(__NR_exit)
++#define __NR_exit 93
++#endif
++
++#if !defined(__NR_exit_group)
++#define __NR_exit_group 94
++#endif
++
++#if !defined(__NR_waitid)
++#define __NR_waitid 95
++#endif
++
++#if !defined(__NR_set_tid_address)
++#define __NR_set_tid_address 96
++#endif
++
++#if !defined(__NR_unshare)
++#define __NR_unshare 97
++#endif
++
++#if !defined(__NR_futex)
++#define __NR_futex 98
++#endif
++
++#if !defined(__NR_set_robust_list)
++#define __NR_set_robust_list 99
++#endif
++
++#if !defined(__NR_get_robust_list)
++#define __NR_get_robust_list 100
++#endif
++
++#if !defined(__NR_nanosleep)
++#define __NR_nanosleep 101
++#endif
++
++#if !defined(__NR_getitimer)
++#define __NR_getitimer 102
++#endif
++
++#if !defined(__NR_setitimer)
++#define __NR_setitimer 103
++#endif
++
++#if !defined(__NR_kexec_load)
++#define __NR_kexec_load 104
++#endif
++
++#if !defined(__NR_init_module)
++#define __NR_init_module 105
++#endif
++
++#if !defined(__NR_delete_module)
++#define __NR_delete_module 106
++#endif
++
++#if !defined(__NR_timer_create)
++#define __NR_timer_create 107
++#endif
++
++#if !defined(__NR_timer_gettime)
++#define __NR_timer_gettime 108
++#endif
++
++#if !defined(__NR_timer_getoverrun)
++#define __NR_timer_getoverrun 109
++#endif
++
++#if !defined(__NR_timer_settime)
++#define __NR_timer_settime 110
++#endif
++
++#if !defined(__NR_timer_delete)
++#define __NR_timer_delete 111
++#endif
++
++#if !defined(__NR_clock_settime)
++#define __NR_clock_settime 112
++#endif
++
++#if !defined(__NR_clock_gettime)
++#define __NR_clock_gettime 113
++#endif
++
++#if !defined(__NR_clock_getres)
++#define __NR_clock_getres 114
++#endif
++
++#if !defined(__NR_clock_nanosleep)
++#define __NR_clock_nanosleep 115
++#endif
++
++#if !defined(__NR_syslog)
++#define __NR_syslog 116
++#endif
++
++#if !defined(__NR_ptrace)
++#define __NR_ptrace 117
++#endif
++
++#if !defined(__NR_sched_setparam)
++#define __NR_sched_setparam 118
++#endif
++
++#if !defined(__NR_sched_setscheduler)
++#define __NR_sched_setscheduler 119
++#endif
++
++#if !defined(__NR_sched_getscheduler)
++#define __NR_sched_getscheduler 120
++#endif
++
++#if !defined(__NR_sched_getparam)
++#define __NR_sched_getparam 121
++#endif
++
++#if !defined(__NR_sched_setaffinity)
++#define __NR_sched_setaffinity 122
++#endif
++
++#if !defined(__NR_sched_getaffinity)
++#define __NR_sched_getaffinity 123
++#endif
++
++#if !defined(__NR_sched_yield)
++#define __NR_sched_yield 124
++#endif
++
++#if !defined(__NR_sched_get_priority_max)
++#define __NR_sched_get_priority_max 125
++#endif
++
++#if !defined(__NR_sched_get_priority_min)
++#define __NR_sched_get_priority_min 126
++#endif
++
++#if !defined(__NR_sched_rr_get_interval)
++#define __NR_sched_rr_get_interval 127
++#endif
++
++#if !defined(__NR_restart_syscall)
++#define __NR_restart_syscall 128
++#endif
++
++#if !defined(__NR_kill)
++#define __NR_kill 129
++#endif
++
++#if !defined(__NR_tkill)
++#define __NR_tkill 130
++#endif
++
++#if !defined(__NR_tgkill)
++#define __NR_tgkill 131
++#endif
++
++#if !defined(__NR_sigaltstack)
++#define __NR_sigaltstack 132
++#endif
++
++#if !defined(__NR_rt_sigsuspend)
++#define __NR_rt_sigsuspend 133
++#endif
++
++#if !defined(__NR_rt_sigaction)
++#define __NR_rt_sigaction 134
++#endif
++
++#if !defined(__NR_rt_sigprocmask)
++#define __NR_rt_sigprocmask 135
++#endif
++
++#if !defined(__NR_rt_sigpending)
++#define __NR_rt_sigpending 136
++#endif
++
++#if !defined(__NR_rt_sigtimedwait)
++#define __NR_rt_sigtimedwait 137
++#endif
++
++#if !defined(__NR_rt_sigqueueinfo)
++#define __NR_rt_sigqueueinfo 138
++#endif
++
++#if !defined(__NR_rt_sigreturn)
++#define __NR_rt_sigreturn 139
++#endif
++
++#if !defined(__NR_setpriority)
++#define __NR_setpriority 140
++#endif
++
++#if !defined(__NR_getpriority)
++#define __NR_getpriority 141
++#endif
++
++#if !defined(__NR_reboot)
++#define __NR_reboot 142
++#endif
++
++#if !defined(__NR_setregid)
++#define __NR_setregid 143
++#endif
++
++#if !defined(__NR_setgid)
++#define __NR_setgid 144
++#endif
++
++#if !defined(__NR_setreuid)
++#define __NR_setreuid 145
++#endif
++
++#if !defined(__NR_setuid)
++#define __NR_setuid 146
++#endif
++
++#if !defined(__NR_setresuid)
++#define __NR_setresuid 147
++#endif
++
++#if !defined(__NR_getresuid)
++#define __NR_getresuid 148
++#endif
++
++#if !defined(__NR_setresgid)
++#define __NR_setresgid 149
++#endif
++
++#if !defined(__NR_getresgid)
++#define __NR_getresgid 150
++#endif
++
++#if !defined(__NR_setfsuid)
++#define __NR_setfsuid 151
++#endif
++
++#if !defined(__NR_setfsgid)
++#define __NR_setfsgid 152
++#endif
++
++#if !defined(__NR_times)
++#define __NR_times 153
++#endif
++
++#if !defined(__NR_setpgid)
++#define __NR_setpgid 154
++#endif
++
++#if !defined(__NR_getpgid)
++#define __NR_getpgid 155
++#endif
++
++#if !defined(__NR_getsid)
++#define __NR_getsid 156
++#endif
++
++#if !defined(__NR_setsid)
++#define __NR_setsid 157
++#endif
++
++#if !defined(__NR_getgroups)
++#define __NR_getgroups 158
++#endif
++
++#if !defined(__NR_setgroups)
++#define __NR_setgroups 159
++#endif
++
++#if !defined(__NR_uname)
++#define __NR_uname 160
++#endif
++
++#if !defined(__NR_sethostname)
++#define __NR_sethostname 161
++#endif
++
++#if !defined(__NR_setdomainname)
++#define __NR_setdomainname 162
++#endif
++
++#if !defined(__NR_getrusage)
++#define __NR_getrusage 165
++#endif
++
++#if !defined(__NR_umask)
++#define __NR_umask 166
++#endif
++
++#if !defined(__NR_prctl)
++#define __NR_prctl 167
++#endif
++
++#if !defined(__NR_getcpu)
++#define __NR_getcpu 168
++#endif
++
++#if !defined(__NR_gettimeofday)
++#define __NR_gettimeofday 169
++#endif
++
++#if !defined(__NR_settimeofday)
++#define __NR_settimeofday 170
++#endif
++
++#if !defined(__NR_adjtimex)
++#define __NR_adjtimex 171
++#endif
++
++#if !defined(__NR_getpid)
++#define __NR_getpid 172
++#endif
++
++#if !defined(__NR_getppid)
++#define __NR_getppid 173
++#endif
++
++#if !defined(__NR_getuid)
++#define __NR_getuid 174
++#endif
++
++#if !defined(__NR_geteuid)
++#define __NR_geteuid 175
++#endif
++
++#if !defined(__NR_getgid)
++#define __NR_getgid 176
++#endif
++
++#if !defined(__NR_getegid)
++#define __NR_getegid 177
++#endif
++
++#if !defined(__NR_gettid)
++#define __NR_gettid 178
++#endif
++
++#if !defined(__NR_sysinfo)
++#define __NR_sysinfo 179
++#endif
++
++#if !defined(__NR_mq_open)
++#define __NR_mq_open 180
++#endif
++
++#if !defined(__NR_mq_unlink)
++#define __NR_mq_unlink 181
++#endif
++
++#if !defined(__NR_mq_timedsend)
++#define __NR_mq_timedsend 182
++#endif
++
++#if !defined(__NR_mq_timedreceive)
++#define __NR_mq_timedreceive 183
++#endif
++
++#if !defined(__NR_mq_notify)
++#define __NR_mq_notify 184
++#endif
++
++#if !defined(__NR_mq_getsetattr)
++#define __NR_mq_getsetattr 185
++#endif
++
++#if !defined(__NR_msgget)
++#define __NR_msgget 186
++#endif
++
++#if !defined(__NR_msgctl)
++#define __NR_msgctl 187
++#endif
++
++#if !defined(__NR_msgrcv)
++#define __NR_msgrcv 188
++#endif
++
++#if !defined(__NR_msgsnd)
++#define __NR_msgsnd 189
++#endif
++
++#if !defined(__NR_semget)
++#define __NR_semget 190
++#endif
++
++#if !defined(__NR_semctl)
++#define __NR_semctl 191
++#endif
++
++#if !defined(__NR_semtimedop)
++#define __NR_semtimedop 192
++#endif
++
++#if !defined(__NR_semop)
++#define __NR_semop 193
++#endif
++
++#if !defined(__NR_shmget)
++#define __NR_shmget 194
++#endif
++
++#if !defined(__NR_shmctl)
++#define __NR_shmctl 195
++#endif
++
++#if !defined(__NR_shmat)
++#define __NR_shmat 196
++#endif
++
++#if !defined(__NR_shmdt)
++#define __NR_shmdt 197
++#endif
++
++#if !defined(__NR_socket)
++#define __NR_socket 198
++#endif
++
++#if !defined(__NR_socketpair)
++#define __NR_socketpair 199
++#endif
++
++#if !defined(__NR_bind)
++#define __NR_bind 200
++#endif
++
++#if !defined(__NR_listen)
++#define __NR_listen 201
++#endif
++
++#if !defined(__NR_accept)
++#define __NR_accept 202
++#endif
++
++#if !defined(__NR_connect)
++#define __NR_connect 203
++#endif
++
++#if !defined(__NR_getsockname)
++#define __NR_getsockname 204
++#endif
++
++#if !defined(__NR_getpeername)
++#define __NR_getpeername 205
++#endif
++
++#if !defined(__NR_sendto)
++#define __NR_sendto 206
++#endif
++
++#if !defined(__NR_recvfrom)
++#define __NR_recvfrom 207
++#endif
++
++#if !defined(__NR_setsockopt)
++#define __NR_setsockopt 208
++#endif
++
++#if !defined(__NR_getsockopt)
++#define __NR_getsockopt 209
++#endif
++
++#if !defined(__NR_shutdown)
++#define __NR_shutdown 210
++#endif
++
++#if !defined(__NR_sendmsg)
++#define __NR_sendmsg 211
++#endif
++
++#if !defined(__NR_recvmsg)
++#define __NR_recvmsg 212
++#endif
++
++#if !defined(__NR_readahead)
++#define __NR_readahead 213
++#endif
++
++#if !defined(__NR_brk)
++#define __NR_brk 214
++#endif
++
++#if !defined(__NR_munmap)
++#define __NR_munmap 215
++#endif
++
++#if !defined(__NR_mremap)
++#define __NR_mremap 216
++#endif
++
++#if !defined(__NR_add_key)
++#define __NR_add_key 217
++#endif
++
++#if !defined(__NR_request_key)
++#define __NR_request_key 218
++#endif
++
++#if !defined(__NR_keyctl)
++#define __NR_keyctl 219
++#endif
++
++#if !defined(__NR_clone)
++#define __NR_clone 220
++#endif
++
++#if !defined(__NR_execve)
++#define __NR_execve 221
++#endif
++
++#if !defined(__NR_mmap)
++#define __NR_mmap 222
++#endif
++
++#if !defined(__NR_fadvise64)
++#define __NR_fadvise64 223
++#endif
++
++#if !defined(__NR_swapon)
++#define __NR_swapon 224
++#endif
++
++#if !defined(__NR_swapoff)
++#define __NR_swapoff 225
++#endif
++
++#if !defined(__NR_mprotect)
++#define __NR_mprotect 226
++#endif
++
++#if !defined(__NR_msync)
++#define __NR_msync 227
++#endif
++
++#if !defined(__NR_mlock)
++#define __NR_mlock 228
++#endif
++
++#if !defined(__NR_munlock)
++#define __NR_munlock 229
++#endif
++
++#if !defined(__NR_mlockall)
++#define __NR_mlockall 230
++#endif
++
++#if !defined(__NR_munlockall)
++#define __NR_munlockall 231
++#endif
++
++#if !defined(__NR_mincore)
++#define __NR_mincore 232
++#endif
++
++#if !defined(__NR_madvise)
++#define __NR_madvise 233
++#endif
++
++#if !defined(__NR_remap_file_pages)
++#define __NR_remap_file_pages 234
++#endif
++
++#if !defined(__NR_mbind)
++#define __NR_mbind 235
++#endif
++
++#if !defined(__NR_get_mempolicy)
++#define __NR_get_mempolicy 236
++#endif
++
++#if !defined(__NR_set_mempolicy)
++#define __NR_set_mempolicy 237
++#endif
++
++#if !defined(__NR_migrate_pages)
++#define __NR_migrate_pages 238
++#endif
++
++#if !defined(__NR_move_pages)
++#define __NR_move_pages 239
++#endif
++
++#if !defined(__NR_rt_tgsigqueueinfo)
++#define __NR_rt_tgsigqueueinfo 240
++#endif
++
++#if !defined(__NR_perf_event_open)
++#define __NR_perf_event_open 241
++#endif
++
++#if !defined(__NR_accept4)
++#define __NR_accept4 242
++#endif
++
++#if !defined(__NR_recvmmsg)
++#define __NR_recvmmsg 243
++#endif
++
++#if !defined(__NR_wait4)
++#define __NR_wait4 260
++#endif
++
++#if !defined(__NR_prlimit64)
++#define __NR_prlimit64 261
++#endif
++
++#if !defined(__NR_fanotify_init)
++#define __NR_fanotify_init 262
++#endif
++
++#if !defined(__NR_fanotify_mark)
++#define __NR_fanotify_mark 263
++#endif
++
++#if !defined(__NR_name_to_handle_at)
++#define __NR_name_to_handle_at 264
++#endif
++
++#if !defined(__NR_open_by_handle_at)
++#define __NR_open_by_handle_at 265
++#endif
++
++#if !defined(__NR_clock_adjtime)
++#define __NR_clock_adjtime 266
++#endif
++
++#if !defined(__NR_syncfs)
++#define __NR_syncfs 267
++#endif
++
++#if !defined(__NR_setns)
++#define __NR_setns 268
++#endif
++
++#if !defined(__NR_sendmmsg)
++#define __NR_sendmmsg 269
++#endif
++
++#if !defined(__NR_process_vm_readv)
++#define __NR_process_vm_readv 270
++#endif
++
++#if !defined(__NR_process_vm_writev)
++#define __NR_process_vm_writev 271
++#endif
++
++#if !defined(__NR_kcmp)
++#define __NR_kcmp 272
++#endif
++
++#if !defined(__NR_finit_module)
++#define __NR_finit_module 273
++#endif
++
++#if !defined(__NR_sched_setattr)
++#define __NR_sched_setattr 274
++#endif
++
++#if !defined(__NR_sched_getattr)
++#define __NR_sched_getattr 275
++#endif
++
++#if !defined(__NR_renameat2)
++#define __NR_renameat2 276
++#endif
++
++#if !defined(__NR_seccomp)
++#define __NR_seccomp 277
++#endif
++
++#if !defined(__NR_getrandom)
++#define __NR_getrandom 278
++#endif
++
++#if !defined(__NR_memfd_create)
++#define __NR_memfd_create 279
++#endif
++
++#if !defined(__NR_bpf)
++#define __NR_bpf 280
++#endif
++
++#if !defined(__NR_execveat)
++#define __NR_execveat 281
++#endif
++
++#if !defined(__NR_userfaultfd)
++#define __NR_userfaultfd 282
++#endif
++
++#if !defined(__NR_membarrier)
++#define __NR_membarrier 283
++#endif
++
++#if !defined(__NR_mlock2)
++#define __NR_mlock2 284
++#endif
++
++#if !defined(__NR_copy_file_range)
++#define __NR_copy_file_range 285
++#endif
++
++#if !defined(__NR_preadv2)
++#define __NR_preadv2 286
++#endif
++
++#if !defined(__NR_pwritev2)
++#define __NR_pwritev2 287
++#endif
++
++#if !defined(__NR_pkey_mprotect)
++#define __NR_pkey_mprotect 288
++#endif
++
++#if !defined(__NR_pkey_alloc)
++#define __NR_pkey_alloc 289
++#endif
++
++#if !defined(__NR_pkey_free)
++#define __NR_pkey_free 290
++#endif
++
++#if !defined(__NR_statx)
++#define __NR_statx 291
++#endif
++
++#if !defined(__NR_io_pgetevents)
++#define __NR_io_pgetevents 292
++#endif
++
++#if !defined(__NR_rseq)
++#define __NR_rseq 293
++#endif
++
++#if !defined(__NR_kexec_file_load)
++#define __NR_kexec_file_load 294
++#endif
++
++#if !defined(__NR_pidfd_send_signal)
++#define __NR_pidfd_send_signal 424
++#endif
++
++#if !defined(__NR_io_uring_setup)
++#define __NR_io_uring_setup 425
++#endif
++
++#if !defined(__NR_io_uring_enter)
++#define __NR_io_uring_enter 426
++#endif
++
++#if !defined(__NR_io_uring_register)
++#define __NR_io_uring_register 427
++#endif
++
++#if !defined(__NR_open_tree)
++#define __NR_open_tree 428
++#endif
++
++#if !defined(__NR_move_mount)
++#define __NR_move_mount 429
++#endif
++
++#if !defined(__NR_fsopen)
++#define __NR_fsopen 430
++#endif
++
++#if !defined(__NR_fsconfig)
++#define __NR_fsconfig 431
++#endif
++
++#if !defined(__NR_fsmount)
++#define __NR_fsmount 432
++#endif
++
++#if !defined(__NR_fspick)
++#define __NR_fspick 433
++#endif
++
++#if !defined(__NR_pidfd_open)
++#define __NR_pidfd_open 434
++#endif
++
++#if !defined(__NR_clone3)
++#define __NR_clone3 435
++#endif
++
++#if !defined(__NR_close_range)
++#define __NR_close_range 436
++#endif
++
++#if !defined(__NR_openat2)
++#define __NR_openat2 437
++#endif
++
++#if !defined(__NR_pidfd_getfd)
++#define __NR_pidfd_getfd 438
++#endif
++
++#if !defined(__NR_faccessat2)
++#define __NR_faccessat2 439
++#endif
++
++#if !defined(__NR_process_madvise)
++#define __NR_process_madvise 440
++#endif
++
++#if !defined(__NR_epoll_pwait2)
++#define __NR_epoll_pwait2 441
++#endif
++
++#if !defined(__NR_mount_setattr)
++#define __NR_mount_setattr 442
++#endif
++
++#if !defined(__NR_landlock_create_ruleset)
++#define __NR_landlock_create_ruleset 444
++#endif
++
++#if !defined(__NR_landlock_add_rule)
++#define __NR_landlock_add_rule 445
++#endif
++
++#if !defined(__NR_landlock_restrict_self)
++#define __NR_landlock_restrict_self 446
++#endif
++
++#endif  // SANDBOX_LINUX_SYSTEM_HEADERS_LOONG64_LINUX_SYSCALLS_H_
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/policy/linux/bpf_audio_policy_linux.cc b/sandbox/policy/linux/bpf_audio_policy_linux.cc
+--- a/sandbox/policy/linux/bpf_audio_policy_linux.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/policy/linux/bpf_audio_policy_linux.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -85,6 +85,7 @@ ResultExpr AudioProcessPolicy::EvaluateS
+       return Switch(op & ~(FUTEX_PRIVATE_FLAG | FUTEX_CLOCK_REALTIME))
+           .Cases({FUTEX_CMP_REQUEUE,
+                   FUTEX_LOCK_PI,
++                  FUTEX_LOCK_PI2,
+                   FUTEX_UNLOCK_PI,
+                   FUTEX_WAIT,
+                   FUTEX_WAIT_BITSET,
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/policy/linux/bpf_broker_policy_linux.cc b/sandbox/policy/linux/bpf_broker_policy_linux.cc
+--- a/sandbox/policy/linux/bpf_broker_policy_linux.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/policy/linux/bpf_broker_policy_linux.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -87,6 +87,12 @@ ResultExpr BrokerProcessPolicy::Evaluate
+         return Allow();
+       break;
+ #endif
++#if defined(__NR_statx)
++    case __NR_statx:
++      if (allowed_command_set_.test(syscall_broker::COMMAND_STAT))
++        return Allow();
++      break;
++#endif
+ #if defined(__NR_lstat)
+     case __NR_lstat:
+       if (allowed_command_set_.test(syscall_broker::COMMAND_STAT))
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/policy/linux/bpf_cros_amd_gpu_policy_linux.cc b/sandbox/policy/linux/bpf_cros_amd_gpu_policy_linux.cc
+--- a/sandbox/policy/linux/bpf_cros_amd_gpu_policy_linux.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/policy/linux/bpf_cros_amd_gpu_policy_linux.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -38,7 +38,7 @@ ResultExpr CrosAmdGpuProcessPolicy::Eval
+     case __NR_sched_setscheduler:
+     case __NR_sysinfo:
+     case __NR_uname:
+-#if !defined(__aarch64__)
++#if !defined(__aarch64__) && !defined(__loongarch__)
+     case __NR_readlink:
+     case __NR_stat:
+ #endif
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/policy/linux/bpf_gpu_policy_linux.cc b/sandbox/policy/linux/bpf_gpu_policy_linux.cc
+--- a/sandbox/policy/linux/bpf_gpu_policy_linux.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/policy/linux/bpf_gpu_policy_linux.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -72,7 +72,7 @@ ResultExpr GpuProcessPolicy::EvaluateSys
+     (defined(ARCH_CPU_MIPS_FAMILY) && defined(ARCH_CPU_32_BITS))
+     case __NR_ftruncate64:
+ #endif
+-#if !defined(__aarch64__)
++#if !defined(__aarch64__) && !defined(__loongarch__)
+     case __NR_getdents:
+ #endif
+     case __NR_getdents64:
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/policy/linux/bpf_network_policy_linux.cc b/sandbox/policy/linux/bpf_network_policy_linux.cc
+--- a/sandbox/policy/linux/bpf_network_policy_linux.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/policy/linux/bpf_network_policy_linux.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -260,7 +260,7 @@ ResultExpr NetworkProcessPolicy::Evaluat
+     case __NR_fdatasync:
+     case __NR_fsync:
+     case __NR_mremap:
+-#if !defined(__aarch64__)
++#if !defined(__aarch64__) && !defined(__loongarch__)
+     case __NR_getdents:
+ #endif
+     case __NR_getdents64:
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/policy/linux/bpf_screen_ai_policy_linux.cc b/sandbox/policy/linux/bpf_screen_ai_policy_linux.cc
+--- a/sandbox/policy/linux/bpf_screen_ai_policy_linux.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/policy/linux/bpf_screen_ai_policy_linux.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -47,7 +47,7 @@ ResultExpr ScreenAIProcessPolicy::Evalua
+       const Arg<int> op(1);
+       return Switch(op & FUTEX_CMD_MASK)
+           .Cases(
+-              {FUTEX_CMP_REQUEUE, FUTEX_LOCK_PI, FUTEX_UNLOCK_PI, FUTEX_WAIT,
++              {FUTEX_CMP_REQUEUE, FUTEX_LOCK_PI, FUTEX_LOCK_PI2, FUTEX_UNLOCK_PI, FUTEX_WAIT,
+                FUTEX_WAIT_BITSET, FUTEX_WAKE},
+               Allow())
+           // Sending ENOSYS tells the Futex backend to use another approach if
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/policy/linux/sandbox_linux.cc b/sandbox/policy/linux/sandbox_linux.cc
+--- a/sandbox/policy/linux/sandbox_linux.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/sandbox/policy/linux/sandbox_linux.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -579,6 +579,7 @@ bpf_dsl::ResultExpr SandboxLinux::Handle
+   const bpf_dsl::ResultExpr handle_via_broker =
+       bpf_dsl::Trap(syscall_broker::BrokerClient::SIGSYS_Handler,
+                     broker_process_->GetBrokerClientSignalBased());
++#if !defined(__loongarch__)
+   if (sysno == __NR_fstatat_default) {
+     // This may be an fstatat(fd, "", stat_buf, AT_EMPTY_PATH), which should be
+     // rewritten as fstat(fd, stat_buf). This should be consistent with how the
+@@ -589,6 +590,18 @@ bpf_dsl::ResultExpr SandboxLinux::Handle
+     return bpf_dsl::If((flags & AT_EMPTY_PATH) == AT_EMPTY_PATH,
+                        RewriteFstatatSIGSYS(BPFBasePolicy::GetFSDeniedErrno()))
+         .Else(handle_via_broker);
++#else
++  if (sysno == __NR_statx) {
++    // This may be a statx(fd, "", AT_EMPTY_PATH, mask, statx_buf), and we allow it.
++    // Otherwise, we expect a statx(AT_FDCWD, path, flags, mask, statx_buf).
++    // However, it is possible to pass a non-empty path even when AT_EMPTY_PATH
++    // is set. But there are currently no easy way to validate the argument in
++    // seccomp bpf.
++    const bpf_dsl::Arg<int> flags(2);
++    return bpf_dsl::If((flags & AT_EMPTY_PATH) == AT_EMPTY_PATH,
++                       bpf_dsl::Allow())
++        .Else(handle_via_broker);
++#endif
+   } else {
+     return handle_via_broker;
+   }
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/blink/renderer/platform/graphics/cpu/loongarch64/webgl_image_conversion_lsx.h b/third_party/blink/renderer/platform/graphics/cpu/loongarch64/webgl_image_conversion_lsx.h
+--- a/third_party/blink/renderer/platform/graphics/cpu/loongarch64/webgl_image_conversion_lsx.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/blink/renderer/platform/graphics/cpu/loongarch64/webgl_image_conversion_lsx.h	2000-01-01 00:00:00.000000000 +0800
+@@ -91,19 +91,19 @@ ALWAYS_INLINE void PackOneRowOfRGBA8Litt
+   v4f32 mask_falpha = __lsx_vffint_s_w(mask_lalpha);
+   v16u8 ra_index = {0,19, 4,23, 8,27, 12,31};
+   for (unsigned i = 0; i < pixels_per_row_trunc; i += 4) {
+-    v16u8 bgra = *((__m128i*)(source));
++    __m128i bgra = *((__m128i*)(source));
+     //if A !=0, A=0; else A=0xFF
+-    v4f32 alpha_factor = __lsx_vseq_b(bgra, mask_zero);
++    __m128i alpha_factor = __lsx_vseq_b(bgra, mask_zero);
+     //if A!=0, A=A; else A=0xFF
+     alpha_factor = __lsx_vor_v(bgra, alpha_factor);
+     alpha_factor = __lsx_vsrli_w(alpha_factor, 24);
+-    alpha_factor = __lsx_vffint_s_w(alpha_factor);
+-    alpha_factor = __lsx_vfdiv_s(mask_falpha, alpha_factor);
++    alpha_factor = (__m128i) __lsx_vffint_s_w(alpha_factor);
++    alpha_factor = (__m128i) __lsx_vfdiv_s((__m128) mask_falpha, (__m128) alpha_factor);
+ 
+-    v16u8 component_r = __lsx_vand_v(bgra, mask_lalpha);
+-    component_r = __lsx_vffint_s_w(component_r);
+-    component_r = __lsx_vfmul_s(component_r, alpha_factor);
+-    component_r = __lsx_vftintrz_w_s(component_r);
++    __m128i component_r = __lsx_vand_v(bgra, mask_lalpha);
++    component_r = (__m128i) __lsx_vffint_s_w(component_r);
++    component_r = (__m128i) __lsx_vfmul_s((__m128) component_r, (__m128) alpha_factor);
++    component_r = __lsx_vftintrz_w_s((__m128) component_r);
+ 
+     v2u64 ra = __lsx_vshuf_b(bgra, component_r, ra_index);
+     __lsx_vstelm_d(ra, destination, 0, 0);
+@@ -138,19 +138,19 @@ ALWAYS_INLINE void PackOneRowOfRGBA8Litt
+   v4u32 mask_lalpha = __lsx_vreplgr2vr_w(0x0ff);
+   v4f32 mask_falpha = __lsx_vffint_s_w(mask_lalpha);
+   for (unsigned i = 0; i < pixels_per_row_trunc; i += 4) {
+-    v16u8 bgra = *((__m128i*)(source));
++    __m128i bgra = *((__m128i*)(source));
+     //if A !=0, A=0; else A=0xFF
+-    v4f32 alpha_factor = __lsx_vseq_b(bgra, mask_zero);
++    __m128i alpha_factor = __lsx_vseq_b(bgra, mask_zero);
+     //if A!=0, A=A; else A=0xFF
+     alpha_factor = __lsx_vor_v(bgra, alpha_factor);
+     alpha_factor = __lsx_vsrli_w(alpha_factor, 24);
+-    alpha_factor = __lsx_vffint_s_w(alpha_factor);
+-    alpha_factor = __lsx_vfdiv_s(mask_falpha, alpha_factor);
++    alpha_factor = (__m128i) __lsx_vffint_s_w(alpha_factor);
++    alpha_factor = (__m128i) __lsx_vfdiv_s((__m128) mask_falpha, (__m128) alpha_factor);
+ 
+-    v16u8 component_r = __lsx_vand_v(bgra, mask_lalpha);
+-    component_r = __lsx_vffint_s_w(component_r);
+-    component_r = __lsx_vfmul_s(component_r, alpha_factor);
+-    component_r = __lsx_vftintrz_w_s(component_r);
++    __m128i component_r = __lsx_vand_v(bgra, mask_lalpha);
++    component_r = (__m128i) __lsx_vffint_s_w(component_r);
++    component_r = (__m128i) __lsx_vfmul_s((__m128) component_r, (__m128) alpha_factor);
++    component_r = __lsx_vftintrz_w_s((__m128) component_r);
+ 
+     component_r = __lsx_vpickev_b(component_r, component_r);
+     component_r = __lsx_vpickev_b(component_r, component_r);
+@@ -172,41 +172,41 @@ ALWAYS_INLINE void PackOneRowOfRGBA8Litt
+   v4f32 mask_falpha = __lsx_vffint_s_w(mask_lalpha);
+   v16u8 rgba_index = {0,1,2,19, 4,5,6,23, 8,9,10,27, 12,13,14,31};
+   for (unsigned i = 0; i < pixels_per_row_trunc; i += 4) {
+-    v16u8 bgra = *((__m128i*)(source));
++    __m128i bgra = *((__m128i*)(source));
+     //if A !=0, A=0; else A=0xFF
+-    v4f32 alpha_factor = __lsx_vseq_b(bgra, mask_zero);
++    __m128i alpha_factor = __lsx_vseq_b(bgra, mask_zero);
+     //if A!=0, A=A; else A=0xFF
+     alpha_factor = __lsx_vor_v(bgra, alpha_factor);
+     alpha_factor = __lsx_vsrli_w(alpha_factor, 24);
+-    alpha_factor = __lsx_vffint_s_w(alpha_factor);
+-    alpha_factor = __lsx_vfdiv_s(mask_falpha, alpha_factor);
++    alpha_factor = (__m128i) __lsx_vffint_s_w(alpha_factor);
++    alpha_factor = (__m128i) __lsx_vfdiv_s((__m128) mask_falpha, (__m128) alpha_factor);
+ 
+     v16u8 bgra_01 = __lsx_vilvl_b(mask_zero, bgra);
+     v16u8 bgra_23 = __lsx_vilvh_b(mask_zero, bgra);
+-    v16u8 bgra_0 = __lsx_vilvl_b(mask_zero, bgra_01);
+-    v16u8 bgra_1 = __lsx_vilvh_b(mask_zero, bgra_01);
+-    v16u8 bgra_2 = __lsx_vilvl_b(mask_zero, bgra_23);
+-    v16u8 bgra_3 = __lsx_vilvh_b(mask_zero, bgra_23);
+-
+-    bgra_0 = __lsx_vffint_s_w(bgra_0);
+-    bgra_1 = __lsx_vffint_s_w(bgra_1);
+-    bgra_2 = __lsx_vffint_s_w(bgra_2);
+-    bgra_3 = __lsx_vffint_s_w(bgra_3);
+-
+-    v4f32 alpha_factor_0 = __lsx_vreplvei_w(alpha_factor, 0);
+-    v4f32 alpha_factor_1 = __lsx_vreplvei_w(alpha_factor, 1);
+-    v4f32 alpha_factor_2 = __lsx_vreplvei_w(alpha_factor, 2);
+-    v4f32 alpha_factor_3 = __lsx_vreplvei_w(alpha_factor, 3);
+-
+-    bgra_0 = __lsx_vfmul_s(alpha_factor_0, bgra_0);
+-    bgra_1 = __lsx_vfmul_s(alpha_factor_1, bgra_1);
+-    bgra_2 = __lsx_vfmul_s(alpha_factor_2, bgra_2);
+-    bgra_3 = __lsx_vfmul_s(alpha_factor_3, bgra_3);
+-
+-    bgra_0 = __lsx_vftintrz_w_s(bgra_0);
+-    bgra_1 = __lsx_vftintrz_w_s(bgra_1);
+-    bgra_2 = __lsx_vftintrz_w_s(bgra_2);
+-    bgra_3 = __lsx_vftintrz_w_s(bgra_3);
++    __m128i bgra_0 = __lsx_vilvl_b(mask_zero, bgra_01);
++    __m128i bgra_1 = __lsx_vilvh_b(mask_zero, bgra_01);
++    __m128i bgra_2 = __lsx_vilvl_b(mask_zero, bgra_23);
++    __m128i bgra_3 = __lsx_vilvh_b(mask_zero, bgra_23);
++
++    bgra_0 = (__m128i) __lsx_vffint_s_w(bgra_0);
++    bgra_1 = (__m128i) __lsx_vffint_s_w(bgra_1);
++    bgra_2 = (__m128i) __lsx_vffint_s_w(bgra_2);
++    bgra_3 = (__m128i) __lsx_vffint_s_w(bgra_3);
++
++    __m128i alpha_factor_0 = __lsx_vreplvei_w(alpha_factor, 0);
++    __m128i alpha_factor_1 = __lsx_vreplvei_w(alpha_factor, 1);
++    __m128i alpha_factor_2 = __lsx_vreplvei_w(alpha_factor, 2);
++    __m128i alpha_factor_3 = __lsx_vreplvei_w(alpha_factor, 3);
++
++    bgra_0 = (__m128i) __lsx_vfmul_s((__m128) alpha_factor_0, (__m128) bgra_0);
++    bgra_1 = (__m128i) __lsx_vfmul_s((__m128) alpha_factor_1, (__m128) bgra_1);
++    bgra_2 = (__m128i) __lsx_vfmul_s((__m128) alpha_factor_2, (__m128) bgra_2);
++    bgra_3 = (__m128i) __lsx_vfmul_s((__m128) alpha_factor_3, (__m128) bgra_3);
++
++    bgra_0 = __lsx_vftintrz_w_s((__m128) bgra_0);
++    bgra_1 = __lsx_vftintrz_w_s((__m128) bgra_1);
++    bgra_2 = __lsx_vftintrz_w_s((__m128) bgra_2);
++    bgra_3 = __lsx_vftintrz_w_s((__m128) bgra_3);
+ 
+     bgra_01 = __lsx_vpickev_b(bgra_1, bgra_0);
+     bgra_23 = __lsx_vpickev_b(bgra_3, bgra_2);
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/boringssl/src/include/openssl/target.h b/third_party/boringssl/src/include/openssl/target.h
+--- a/third_party/boringssl/src/include/openssl/target.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/boringssl/src/include/openssl/target.h	2000-01-01 00:00:00.000000000 +0800
+@@ -54,6 +54,8 @@
+ #define OPENSSL_32_BIT
+ #elif defined(__myriad2__)
+ #define OPENSSL_32_BIT
++#elif defined(__loongarch__) && __SIZEOF_POINTER__ == 8
++#define OPENSSL_64_BIT
+ #else
+ // The list above enumerates the platforms that BoringSSL supports. For these
+ // platforms we keep a reasonable bar of not breaking them: automated test
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/crashpad/crashpad/minidump/minidump_context.h b/third_party/crashpad/crashpad/minidump/minidump_context.h
+--- a/third_party/crashpad/crashpad/minidump/minidump_context.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/crashpad/crashpad/minidump/minidump_context.h	2000-01-01 00:00:00.000000000 +0800
+@@ -686,6 +686,56 @@ struct MinidumpContextRISCV64 {
+   uint32_t fcsr;
+ };
+ 
++//! \brief LOONG64-specifc flags for MinidumpContextLOONG64::context_flags.
++//! Based on minidump_cpu_loong64.h from breakpad
++enum MinidumpContextLOONG64Flags : uint32_t {
++  //! \brief Identifies the context structure as LOONG64.
++  kMinidumpContextLOONG64 = 0x00800000,
++
++  //! \brief Indicates the validity of integer registers.
++  //!
++  //! Registers `0`-`31`, `csr_era` are valid.
++  kMinidumpContextLOONG64Integer = kMinidumpContextLOONG64 | 0x00000002,
++
++  //! \brief Indicates the validity of floating point registers.
++  //!
++  //! Floating point registers `0`-`31`, `fcsr` and `fcc` are valid
++  kMinidumpContextLOONG64FloatingPoint = kMinidumpContextLOONG64 | 0x00000004,
++
++  //! \brief Indicates the validity of all registers.
++  kMinidumpContextLOONG64All = kMinidumpContextLOONG64Integer |
++                              kMinidumpContextLOONG64FloatingPoint,
++};
++
++//! \brief A LOONG64 CPU context (register state) carried in a minidump file.
++struct MinidumpContextLOONG64 {
++  uint64_t context_flags;
++
++  //! \brief General purpose registers.
++  uint64_t regs[32];
++
++  //! \brief csr_era registers.
++  uint64_t csr_era;
++
++  //! \brief FPU registers.
++  union {
++    struct {
++      float _fp_fregs;
++      uint32_t _fp_pad;
++    } fregs[32];
++    double dregs[32];
++  } fpregs;
++
++  //! \brief Floating-point status and control register.
++  uint64_t fcc;
++
++  //! \brief Floating-point control and status register.
++  uint32_t fcsr;
++
++  //! \brief padding
++  uint32_t _pad;
++};
++
+ }  // namespace crashpad
+ 
+ #endif  // CRASHPAD_MINIDUMP_MINIDUMP_CONTEXT_H_
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/crashpad/crashpad/minidump/minidump_context_writer.cc b/third_party/crashpad/crashpad/minidump/minidump_context_writer.cc
+--- a/third_party/crashpad/crashpad/minidump/minidump_context_writer.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/crashpad/crashpad/minidump/minidump_context_writer.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -110,6 +110,13 @@ MinidumpContextWriter::CreateFromSnapsho
+       break;
+     }
+ 
++    case kCPUArchitectureLOONG64: {
++      context = std::make_unique<MinidumpContextLOONG64Writer>();
++      reinterpret_cast<MinidumpContextLOONG64Writer*>(context.get())
++          ->InitializeFromSnapshot(context_snapshot->loong64);
++      break;
++    }
++
+     default: {
+       LOG(ERROR) << "unknown context architecture "
+                  << context_snapshot->architecture;
+@@ -605,5 +612,44 @@ size_t MinidumpContextRISCV64Writer::Con
+   DCHECK_GE(state(), kStateFrozen);
+   return sizeof(context_);
+ }
++
++MinidumpContextLOONG64Writer::MinidumpContextLOONG64Writer()
++    : MinidumpContextWriter(), context_() {
++  context_.context_flags = kMinidumpContextLOONG64;
++}
++
++MinidumpContextLOONG64Writer::~MinidumpContextLOONG64Writer() = default;
++
++void MinidumpContextLOONG64Writer::InitializeFromSnapshot(
++    const CPUContextLOONG64* context_snapshot) {
++  DCHECK_EQ(state(), kStateMutable);
++  DCHECK_EQ(context_.context_flags, kMinidumpContextLOONG64);
++
++  context_.context_flags = kMinidumpContextLOONG64All;
++
++  static_assert(sizeof(context_.regs) == sizeof(context_snapshot->regs),
++                "GPRs size mismatch");
++  memcpy(context_.regs, context_snapshot->regs, sizeof(context_.regs));
++  context_.csr_era = context_snapshot->csr_era;
++
++  static_assert(sizeof(context_.fpregs) == sizeof(context_snapshot->fpregs),
++                "FPRs size mismatch");
++  memcpy(context_.fpregs.dregs,
++         context_snapshot->fpregs.dregs,
++         sizeof(context_.fpregs.dregs));
++  context_.fcsr = context_snapshot->fcsr;
++  context_.fcc = context_snapshot->fcc;
++}
++
++bool MinidumpContextLOONG64Writer::WriteObject(
++    FileWriterInterface* file_writer) {
++  DCHECK_EQ(state(), kStateWritable);
++  return file_writer->Write(&context_, sizeof(context_));
++}
++
++size_t MinidumpContextLOONG64Writer::ContextSize() const {
++  DCHECK_GE(state(), kStateFrozen);
++  return sizeof(context_);
++}
+ 
+ }  // namespace crashpad
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/crashpad/crashpad/minidump/minidump_context_writer.h b/third_party/crashpad/crashpad/minidump/minidump_context_writer.h
+--- a/third_party/crashpad/crashpad/minidump/minidump_context_writer.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/crashpad/crashpad/minidump/minidump_context_writer.h	2000-01-01 00:00:00.000000000 +0800
+@@ -413,6 +413,44 @@ class MinidumpContextRISCV64Writer final
+   MinidumpContextRISCV64 context_;
+ };
+ 
++//! \brief The writer for a MinidumpContextLOONG64 structure in a minidump file.
++class MinidumpContextLOONG64Writer final : public MinidumpContextWriter {
++ public:
++  MinidumpContextLOONG64Writer();
++  ~MinidumpContextLOONG64Writer() override;
++
++  //! \brief Initializes the MinidumpContextLOONGARCH based on \a context_snapshot.
++  //!
++  //! \param[in] context_snapshot The context snapshot to use as source data.
++  //!
++  //! \note Valid in #kStateMutable. No mutation of context() may be done before
++  //!     calling this method, and it is not normally necessary to alter
++  //!     context() after calling this method.
++  void InitializeFromSnapshot(const CPUContextLOONG64* context_snapshot);
++
++  //! \brief Returns a pointer to the context structure that this object will
++  //!     write.
++  //!
++  //! \attention This returns a non-`const` pointer to this object’s private
++  //!     data so that a caller can populate the context structure directly.
++  //!     This is done because providing setter interfaces to each field in the
++  //!     context structure would be unwieldy and cumbersome. Care must be taken
++  //!     to populate the context structure correctly. The context structure
++  //!     must only be modified while this object is in the #kStateMutable
++  //!     state.
++  MinidumpContextLOONG64* context() { return &context_; }
++
++ protected:
++  // MinidumpWritable:
++  bool WriteObject(FileWriterInterface* file_writer) override;
++
++  // MinidumpContextWriter:
++  size_t ContextSize() const override;
++
++ private:
++  MinidumpContextLOONG64 context_;
++};
++
+ }  // namespace crashpad
+ 
+ #endif  // CRASHPAD_MINIDUMP_MINIDUMP_CONTEXT_WRITER_H_
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/crashpad/crashpad/minidump/minidump_extensions.h b/third_party/crashpad/crashpad/minidump/minidump_extensions.h
+--- a/third_party/crashpad/crashpad/minidump/minidump_extensions.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/crashpad/crashpad/minidump/minidump_extensions.h	2000-01-01 00:00:00.000000000 +0800
+@@ -213,6 +213,9 @@ enum MinidumpCPUArchitecture : uint16_t
+   //! \brief Used by Breakpad for 64-bit RISC-V.
+   kMinidumpCPUArchitectureRISCV64Breakpad = 0x8006,
+ 
++  //! \brief Used by Breakpad for 64-bit LoongArch.
++  kMinidumpCPUArchitectureLOONG64Breakpad = 0x8007,
++
+   //! \brief Unknown CPU architecture.
+   kMinidumpCPUArchitectureUnknown = PROCESSOR_ARCHITECTURE_UNKNOWN,
+ };
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc b/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc
+--- a/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/crashpad/crashpad/minidump/minidump_misc_info_writer.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -177,6 +177,8 @@ std::string MinidumpMiscInfoDebugBuildSt
+   static constexpr char kCPU[] = "mips64";
+ #elif defined(ARCH_CPU_RISCV64)
+   static constexpr char kCPU[] = "riscv64";
++#elif defined(ARCH_CPU_LOONGARCH64)
++  static constexpr char kCPU[] = "loong64";
+ #else
+ #error define kCPU for this CPU
+ #endif
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/crashpad/crashpad/minidump/minidump_system_info_writer.cc b/third_party/crashpad/crashpad/minidump/minidump_system_info_writer.cc
+--- a/third_party/crashpad/crashpad/minidump/minidump_system_info_writer.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/crashpad/crashpad/minidump/minidump_system_info_writer.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -135,6 +135,9 @@ void MinidumpSystemInfoWriter::Initializ
+     case kCPUArchitectureRISCV64:
+       cpu_architecture = kMinidumpCPUArchitectureRISCV64Breakpad;
+       break;
++    case kCPUArchitectureLOONG64:
++      cpu_architecture = kMinidumpCPUArchitectureLOONG64Breakpad;
++      break;
+     default:
+       NOTREACHED();
+   }
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/crashpad/crashpad/snapshot/capture_memory.cc b/third_party/crashpad/crashpad/snapshot/capture_memory.cc
+--- a/third_party/crashpad/crashpad/snapshot/capture_memory.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/crashpad/crashpad/snapshot/capture_memory.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -123,6 +123,11 @@ void CaptureMemory::PointedToByContext(c
+   for (size_t i = 0; i < std::size(context.riscv64->regs); ++i) {
+     MaybeCaptureMemoryAround(delegate, context.riscv64->regs[i]);
+   }
++#elif defined(ARCH_CPU_LOONGARCH64)
++  MaybeCaptureMemoryAround(delegate, context.loong64->csr_era);
++  for (size_t i = 0; i < std::size(context.loong64->regs); ++i) {
++    MaybeCaptureMemoryAround(delegate, context.loong64->regs[i]);
++  }
+ #else
+ #error Port.
+ #endif
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/crashpad/crashpad/snapshot/cpu_architecture.h b/third_party/crashpad/crashpad/snapshot/cpu_architecture.h
+--- a/third_party/crashpad/crashpad/snapshot/cpu_architecture.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/crashpad/crashpad/snapshot/cpu_architecture.h	2000-01-01 00:00:00.000000000 +0800
+@@ -47,6 +47,9 @@ enum CPUArchitecture {
+ 
+   //! \brief 64-bit RISC-V.
+   kCPUArchitectureRISCV64,
++
++  //! \brief 64-bit LOONGARCH.
++  kCPUArchitectureLOONG64,
+ };
+ 
+ }  // namespace crashpad
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/crashpad/crashpad/snapshot/cpu_context.cc b/third_party/crashpad/crashpad/snapshot/cpu_context.cc
+--- a/third_party/crashpad/crashpad/snapshot/cpu_context.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/crashpad/crashpad/snapshot/cpu_context.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -173,6 +173,8 @@ uint64_t CPUContext::InstructionPointer(
+       return arm64->pc;
+     case kCPUArchitectureRISCV64:
+       return riscv64->pc;
++    case kCPUArchitectureLOONG64:
++      return loong64->csr_era;
+     default:
+       NOTREACHED();
+   }
+@@ -190,6 +192,8 @@ uint64_t CPUContext::StackPointer() cons
+       return arm64->sp;
+     case kCPUArchitectureRISCV64:
+       return riscv64->regs[1];
++    case kCPUArchitectureLOONG64:
++      return loong64->regs[3];
+     default:
+       NOTREACHED();
+   }
+@@ -227,6 +231,7 @@ bool CPUContext::Is64Bit() const {
+     case kCPUArchitectureARM64:
+     case kCPUArchitectureMIPS64EL:
+     case kCPUArchitectureRISCV64:
++    case kCPUArchitectureLOONG64:
+       return true;
+     case kCPUArchitectureX86:
+     case kCPUArchitectureARM:
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/crashpad/crashpad/snapshot/cpu_context.h b/third_party/crashpad/crashpad/snapshot/cpu_context.h
+--- a/third_party/crashpad/crashpad/snapshot/cpu_context.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/crashpad/crashpad/snapshot/cpu_context.h	2000-01-01 00:00:00.000000000 +0800
+@@ -371,6 +371,22 @@ struct CPUContextRISCV64 {
+   uint32_t fcsr;
+ };
+ 
++//! \brief A context structure carrying LOONG64 CPU state.
++struct CPUContextLOONG64 {
++  uint64_t regs[32];
++  uint64_t csr_era;
++
++  union {
++    double dregs[32];
++    struct {
++      float _fp_fregs;
++      uint32_t _fp_pad;
++    } fregs[32];
++  } fpregs;
++  uint64_t fcc;
++  uint32_t fcsr;
++};
++
+ //! \brief A context structure capable of carrying the context of any supported
+ //!     CPU architecture.
+ struct CPUContext {
+@@ -412,6 +428,7 @@ struct CPUContext {
+     CPUContextMIPS* mipsel;
+     CPUContextMIPS64* mips64;
+     CPUContextRISCV64* riscv64;
++    CPUContextLOONG64* loong64;
+   };
+ };
+ 
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.cc b/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.cc
+--- a/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -281,6 +281,40 @@ void InitializeCPUContextRISCV64(const T
+   context->fcsr = float_context.fcsr;
+ }
+ 
++#elif defined(ARCH_CPU_LOONGARCH64)
++
++void InitializeCPUContextLOONG64_NoFloatingPoint(
++    const ThreadContext::t64_t& thread_context,
++    CPUContextLOONG64* context) {
++  static_assert(sizeof(context->regs) == sizeof(thread_context.regs),
++                "gpr context size mismtach");
++  memcpy(context->regs, thread_context.regs, sizeof(context->regs));
++  context->csr_era = thread_context.csr_era;
++
++  memset(&context->fpregs, 0, sizeof(context->fpregs));
++  context->fcc = 0;
++  context->fcsr = 0;
++}
++
++void InitializeCPUContextLOONG64_OnlyFPU(
++    const FloatContext::f64_t& float_context,
++    CPUContextLOONG64* context) {
++  static_assert(sizeof(context->fpregs) == sizeof(float_context.fpregs),
++                "fpu context size mismatch");
++  memcpy(&context->fpregs, &float_context.fpregs, sizeof(context->fpregs));
++  context->fcc = float_context.fcc;
++  context->fcsr = float_context.fcsr;
++}
++
++void InitializeCPUContextLOONG64(
++    const ThreadContext::t64_t& thread_context,
++    const FloatContext::f64_t& float_context,
++    CPUContextLOONG64* context) {
++  InitializeCPUContextLOONG64_NoFloatingPoint(thread_context, context);
++
++  InitializeCPUContextLOONG64_OnlyFPU(float_context, context);
++}
++
+ #endif  // ARCH_CPU_X86_FAMILY
+ 
+ }  // namespace internal
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.h b/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.h
+--- a/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/crashpad/crashpad/snapshot/linux/cpu_context_linux.h	2000-01-01 00:00:00.000000000 +0800
+@@ -188,6 +188,45 @@ void InitializeCPUContextRISCV64(const T
+ 
+ #endif  // ARCH_CPU_RISCV64 || DOXYGEN
+ 
++#if defined(ARCH_CPU_LOONGARCH64) || DOXYGEN
++
++//! \brief Initializes GPR state in a CPUContextLOONG64 from a native context
++//!     structure on Linux.
++//!
++//! Floating point state is initialized to zero.
++//!
++//! \param[in] thread_context The native thread context.
++//! \param[out] context The CPUContextLOONG64 structure to initialize.
++void InitializeCPUContextLOONG64_NoFloatingPoint(
++    const ThreadContext::t64_t& thread_context,
++    CPUContextLOONG64* context);
++//! \brief Initializes FPU state in a CPUContextLOONG64 from a native fpu
++//!     signal context structure on Linux.
++//!
++//! General purpose registers are not initialized.
++//!
++//! \param[in] float_context The native fpu context.
++//! \param[out] context The CPUContextLOONG64 structure to initialize.
++void InitializeCPUContextLOONG64_OnlyFPU(
++    const FloatContext::f64_t& float_context,
++    CPUContextLOONG64* context);
++//! \brief Initializes a CPUContextLOONG64 structure from native context
++//!     structures on Linux.
++//!
++//! This function has template specializations for LOONG64 architecture
++//! contexts, using ContextTraits32 or ContextTraits64 as template parameter,
++//! respectively.
++//!
++//! \param[in] thread_context The native thread context.
++//! \param[in] float_context The native float context.
++//! \param[out] context The CPUContextLOONG64 structure to initialize.
++void InitializeCPUContextLOONG64(
++    const ThreadContext::t64_t& thread_context,
++    const FloatContext::f64_t& float_context,
++    CPUContextLOONG64* context);
++
++#endif  // ARCH_CPU_LOONGARCH64 || DOXYGEN
++
+ }  // namespace internal
+ }  // namespace crashpad
+ 
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.cc b/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.cc
+--- a/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -15,6 +15,7 @@
+ #include "snapshot/linux/exception_snapshot_linux.h"
+ 
+ #include <signal.h>
++#include <cstring>
+ 
+ #include "base/logging.h"
+ #include "snapshot/linux/capture_memory_delegate_linux.h"
+@@ -367,6 +368,78 @@ bool ExceptionSnapshotLinux::ReadContext
+   return internal::ReadContext(reader, context_address, context_.riscv64);
+ }
+ 
++#elif defined(ARCH_CPU_LOONGARCH64)
++
++static bool ReadContext(ProcessReaderLinux* reader,
++                        LinuxVMAddress context_address,
++                        typename ContextTraits64::CPUContext* dest_context) {
++  const ProcessMemory* memory = reader->Memory();
++  LinuxVMAddress mcontext_address = context_address +
++                                 offsetof(UContext<ContextTraits64>, mcontext);
++  ThreadContext::t64_t thread_context;
++  ContextTraits64::MContext mcontext;
++  if (!memory->Read(mcontext_address, sizeof(mcontext), &mcontext)) {
++    LOG(ERROR) << "Couldn't read gregs";
++    return false;
++  }
++  static_assert(sizeof(thread_context.regs) == sizeof(mcontext.gregs),
++                "gpr context size mismtach");
++  memcpy(thread_context.regs, mcontext.gregs, sizeof(mcontext.gregs));
++  thread_context.csr_era = mcontext.pc;
++  thread_context.orig_a0 = 0;
++  thread_context.csr_badv = 0;
++  InitializeCPUContextLOONG64_NoFloatingPoint(thread_context, dest_context);
++
++  LinuxVMAddress reserved_address =
++        context_address + offsetof(UContext<ContextTraits64>, mcontext.extcontext);
++  if ((reserved_address & 15) != 0) {
++    LOG(ERROR) << "invalid alignment 0x" << std::hex << reserved_address;
++    return false;
++   }
++  constexpr VMSize kMaxContextSpace = 4096;
++  ProcessMemoryRange range;
++  if (!range.Initialize(memory, true, reserved_address, kMaxContextSpace)) {
++    return false;
++  }
++  do {
++    struct sctx_info head;
++    if (!range.Read(reserved_address, sizeof(head), &head)) {
++      LOG(ERROR) << "missing context terminator";
++      return false;
++    }
++    reserved_address += sizeof(head);
++    switch (head.magic) {
++      case FPU_CTX_MAGIC:
++        if (head.size != sizeof(struct fpu_context) + sizeof(head)) {
++          LOG(ERROR) << "unexpected fpu context size " << head.size;
++          return false;
++        }
++        FloatContext::f64_t fpucontext;
++        if (!range.Read(reserved_address, sizeof(fpucontext), &fpucontext)) {
++          LOG(ERROR) << "Couldn't read fpu " << head.size;
++          return false;
++        }
++        InitializeCPUContextLOONG64_OnlyFPU(fpucontext, dest_context);
++        return true;
++      case 0:
++        return true;
++      default:
++        LOG(ERROR) << "invalid magic number 0x" << std::hex << head.magic;
++        return false;
++    }
++  } while (true);
++}
++
++template <>
++bool ExceptionSnapshotLinux::ReadContext<ContextTraits64>(
++    ProcessReaderLinux* reader,
++    LinuxVMAddress context_address) {
++  context_.architecture = kCPUArchitectureLOONG64;
++  context_.loong64 = &context_union_.loong64;
++
++  return internal::ReadContext(reader, context_address, context_.loong64);
++}
++
+ #endif  // ARCH_CPU_X86_FAMILY
+ 
+ bool ExceptionSnapshotLinux::Initialize(
+@@ -397,7 +470,7 @@ bool ExceptionSnapshotLinux::Initialize(
+       return false;
+     }
+   } else {
+-#if !defined(ARCH_CPU_RISCV64)
++#if !defined(ARCH_CPU_RISCV64) && !defined(ARCH_CPU_LOONGARCH64)
+     if (!ReadContext<ContextTraits32>(process_reader, context_address) ||
+         !ReadSiginfo<Traits32>(process_reader, siginfo_address)) {
+       return false;
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.h b/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.h
+--- a/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/crashpad/crashpad/snapshot/linux/exception_snapshot_linux.h	2000-01-01 00:00:00.000000000 +0800
+@@ -94,6 +94,8 @@ class ExceptionSnapshotLinux final : pub
+     CPUContextMIPS64 mips64;
+ #elif defined(ARCH_CPU_RISCV64)
+     CPUContextRISCV64 riscv64;
++#elif defined(ARCH_CPU_LOONGARCH64)
++    CPUContextLOONG64 loong64;
+ #endif
+   } context_union_;
+   CPUContext context_;
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/crashpad/crashpad/snapshot/linux/process_reader_linux.cc b/third_party/crashpad/crashpad/snapshot/linux/process_reader_linux.cc
+--- a/third_party/crashpad/crashpad/snapshot/linux/process_reader_linux.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/crashpad/crashpad/snapshot/linux/process_reader_linux.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -129,6 +129,8 @@ void ProcessReaderLinux::Thread::Initial
+                                     : thread_info.thread_context.t32.regs[29];
+ #elif defined(ARCH_CPU_RISCV64)
+   stack_pointer = thread_info.thread_context.t64.regs[1];
++#elif defined(ARCH_CPU_LOONGARCH64)
++  stack_pointer = thread_info.thread_context.t64.regs[3];
+ #else
+ #error Port.
+ #endif
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/crashpad/crashpad/snapshot/linux/signal_context.h b/third_party/crashpad/crashpad/snapshot/linux/signal_context.h
+--- a/third_party/crashpad/crashpad/snapshot/linux/signal_context.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/crashpad/crashpad/snapshot/linux/signal_context.h	2000-01-01 00:00:00.000000000 +0800
+@@ -456,6 +456,46 @@ static_assert(offsetof(UContext<ContextT
+                   offsetof(ucontext_t, uc_mcontext.__fpregs),
+               "context offset mismatch");
+ 
++#elif defined(ARCH_CPU_LOONGARCH64)
++
++// See asm/sigcontext.h
++struct MContext64 {
++  uint64_t pc;
++  uint64_t gregs[32];
++  uint32_t flags;
++  uint32_t padding;
++  uint64_t extcontext[0] __attribute__((__aligned__(16)));
++};
++
++struct ContextTraits64 : public Traits64 {
++  using MContext = MContext64;
++  using SignalThreadContext = ThreadContext::t64_t;
++  using SignalFloatContext = FloatContext::f64_t;
++  using CPUContext = CPUContextLOONG64;
++};
++
++// See asm/ucontext.h
++template <typename Traits>
++struct UContext {
++  typename Traits::ULong flags;
++  typename Traits::Address link;
++  SignalStack<Traits> stack;
++  Sigset<Traits> sigmask;
++  char alignment_padding_[8];
++  char padding[128 - sizeof(Sigset<Traits>)];
++  MContext64 mcontext;
++};
++
++static_assert(offsetof(UContext<ContextTraits64>, mcontext) ==
++                  offsetof(ucontext_t, uc_mcontext),
++              "context offset mismatch");
++static_assert(offsetof(UContext<ContextTraits64>, mcontext.gregs) ==
++                  offsetof(ucontext_t, uc_mcontext.__gregs),
++              "context offset mismatch");
++static_assert(offsetof(UContext<ContextTraits64>, mcontext.extcontext) ==
++                  offsetof(ucontext_t, uc_mcontext.__extcontext),
++              "context offset mismatch");
++
+ #else
+ #error Port.
+ #endif  // ARCH_CPU_X86_FAMILY
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/crashpad/crashpad/snapshot/linux/system_snapshot_linux.cc b/third_party/crashpad/crashpad/snapshot/linux/system_snapshot_linux.cc
+--- a/third_party/crashpad/crashpad/snapshot/linux/system_snapshot_linux.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/crashpad/crashpad/snapshot/linux/system_snapshot_linux.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -208,6 +208,8 @@ CPUArchitecture SystemSnapshotLinux::Get
+                                     : kCPUArchitectureMIPSEL;
+ #elif defined(ARCH_CPU_RISCV64)
+   return kCPUArchitectureRISCV64;
++#elif defined(ARCH_CPU_LOONGARCH64)
++  return kCPUArchitectureLOONG64;
+ #else
+ #error port to your architecture
+ #endif
+@@ -226,6 +228,9 @@ uint32_t SystemSnapshotLinux::CPURevisio
+ #elif defined(ARCH_CPU_RISCV64)
+   // Not implemented
+   return 0;
++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
++  // Not implemented
++  return 0;
+ #else
+ #error port to your architecture
+ #endif
+@@ -249,6 +254,9 @@ std::string SystemSnapshotLinux::CPUVend
+ #elif defined(ARCH_CPU_RISCV64)
+   // Not implemented
+   return std::string();
++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
++  // Not implemented
++  return std::string();
+ #else
+ #error port to your architecture
+ #endif
+@@ -380,6 +388,9 @@ bool SystemSnapshotLinux::NXEnabled() co
+ #elif defined(ARCH_CPU_RISCV64)
+   // Not implemented
+   return false;
++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
++  // Not implemented
++  return false;
+ #else
+ #error Port.
+ #endif  // ARCH_CPU_X86_FAMILY
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.cc b/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.cc
+--- a/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -196,6 +196,12 @@ bool ThreadSnapshotLinux::Initialize(
+   InitializeCPUContextRISCV64(thread.thread_info.thread_context.t64,
+                               thread.thread_info.float_context.f64,
+                               context_.riscv64);
++#elif defined(ARCH_CPU_LOONGARCH64)
++  context_.architecture = kCPUArchitectureLOONG64;
++  context_.loong64 = &context_union_.loong64;
++  InitializeCPUContextLOONG64(thread.thread_info.thread_context.t64,
++                              thread.thread_info.float_context.f64,
++                              context_.loong64);
+ #else
+ #error Port.
+ #endif
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.h b/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.h
+--- a/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/crashpad/crashpad/snapshot/linux/thread_snapshot_linux.h	2000-01-01 00:00:00.000000000 +0800
+@@ -79,6 +79,8 @@ class ThreadSnapshotLinux final : public
+     CPUContextMIPS64 mips64;
+ #elif defined(ARCH_CPU_RISCV64)
+     CPUContextRISCV64 riscv64;
++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
++    CPUContextLOONG64 loong64;
+ #else
+ #error Port.
+ #endif  // ARCH_CPU_X86_FAMILY
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/crashpad/crashpad/snapshot/minidump/minidump_context_converter.cc b/third_party/crashpad/crashpad/snapshot/minidump/minidump_context_converter.cc
+--- a/third_party/crashpad/crashpad/snapshot/minidump/minidump_context_converter.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/crashpad/crashpad/snapshot/minidump/minidump_context_converter.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -293,6 +293,30 @@ bool MinidumpContextConverter::Initializ
+     memcpy(&context_.riscv64->fpregs, &src->fpregs, sizeof(src->fpregs));
+ 
+     context_.riscv64->fcsr = src->fcsr;
++  } else if (context_.architecture ==
++             CPUArchitecture::kCPUArchitectureLOONG64) {
++    context_memory_.resize(sizeof(CPUContextLOONG64));
++    context_.loong64 =
++        reinterpret_cast<CPUContextLOONG64*>(context_memory_.data());
++    const MinidumpContextLOONG64* src =
++        reinterpret_cast<const MinidumpContextLOONG64*>(minidump_context.data());
++    if (minidump_context.size() < sizeof(MinidumpContextLOONG64)) {
++      return false;
++    }
++
++    if (!(src->context_flags & kMinidumpContextLOONG64)) {
++      return false;
++    }
++
++    for (size_t i = 0; i < std::size(src->regs); i++) {
++      context_.loong64->regs[i] = src->regs[i];
++    }
++
++    context_.loong64->csr_era = src->csr_era;
++    context_.loong64->fcsr = src->fcsr;
++    context_.loong64->fcc = src->fcc;
++
++    memcpy(&context_.loong64->fpregs, &src->fpregs, sizeof(src->fpregs));
+   } else {
+     // Architecture is listed as "unknown".
+     DLOG(ERROR) << "Unknown architecture";
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/crashpad/crashpad/snapshot/minidump/system_snapshot_minidump.cc b/third_party/crashpad/crashpad/snapshot/minidump/system_snapshot_minidump.cc
+--- a/third_party/crashpad/crashpad/snapshot/minidump/system_snapshot_minidump.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/crashpad/crashpad/snapshot/minidump/system_snapshot_minidump.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -70,6 +70,8 @@ CPUArchitecture SystemSnapshotMinidump::
+     // No word on how MIPS64 is signalled
+     case kMinidumpCPUArchitectureRISCV64Breakpad:
+       return kCPUArchitectureRISCV64;
++    case kMinidumpCPUArchitectureLOONG64Breakpad:
++      return kCPUArchitectureLOONG64;
+ 
+     default:
+       return CPUArchitecture::kCPUArchitectureUnknown;
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/crashpad/crashpad/util/linux/ptracer.cc b/third_party/crashpad/crashpad/util/linux/ptracer.cc
+--- a/third_party/crashpad/crashpad/util/linux/ptracer.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/crashpad/crashpad/util/linux/ptracer.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -430,6 +430,37 @@ bool GetThreadArea64(pid_t tid,
+   return true;
+ }
+ 
++#elif defined(ARCH_CPU_LOONGARCH64)
++
++bool GetFloatingPointRegisters64(pid_t tid,
++                                 FloatContext* context,
++                                 bool can_log) {
++  iovec iov;
++  iov.iov_base = context;
++  iov.iov_len = sizeof(*context);
++  if (ptrace(
++          PTRACE_GETREGSET, tid, reinterpret_cast<void*>(NT_PRFPREG), &iov) !=
++      0) {
++    PLOG_IF(ERROR, can_log) << "ptrace";
++    return false;
++  }
++  if (iov.iov_len != sizeof(context->f64)) {
++    LOG_IF(ERROR, can_log) << "Unexpected registers size " << iov.iov_len
++                           << " != " << sizeof(context->f64);
++    return false;
++  }
++  return true;
++}
++
++bool GetThreadArea64(pid_t tid,
++                     const ThreadContext& context,
++                     LinuxVMAddress* address,
++                     bool can_log) {
++  // Thread pointer register
++  *address = context.t64.regs[2];
++  return true;
++}
++
+ #else
+ #error Port.
+ #endif  // ARCH_CPU_X86_FAMILY
+@@ -534,7 +565,7 @@ bool Ptracer::GetThreadInfo(pid_t tid, T
+                            can_log_);
+   }
+ 
+-#if !defined(ARCH_CPU_RISCV64)
++#if !defined(ARCH_CPU_RISCV64) && !defined(ARCH_CPU_LOONGARCH64)
+   return GetGeneralPurposeRegisters32(tid, &info->thread_context, can_log_) &&
+          GetFloatingPointRegisters32(tid, &info->float_context, can_log_) &&
+          GetThreadArea32(tid,
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/crashpad/crashpad/util/linux/thread_info.h b/third_party/crashpad/crashpad/util/linux/thread_info.h
+--- a/third_party/crashpad/crashpad/util/linux/thread_info.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/crashpad/crashpad/util/linux/thread_info.h	2000-01-01 00:00:00.000000000 +0800
+@@ -87,6 +87,8 @@ union ThreadContext {
+     uint32_t padding1_;
+ #elif defined(ARCH_CPU_RISCV64)
+     // 32 bit RISC-V not supported
++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
++    // 32 bit LoongArch not supported
+ #else
+ #error Port.
+ #endif  // ARCH_CPU_X86_FAMILY
+@@ -144,13 +146,20 @@ union ThreadContext {
+     // Reflects user_regs_struct in asm/ptrace.h.
+     uint64_t pc;
+     uint64_t regs[31];
++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
++    // Reflects user_regs_struct in sys/user.h.
++    uint64_t regs[32];
++    uint64_t orig_a0;
++    uint64_t csr_era;
++    uint64_t csr_badv;
++    uint64_t reserved[10];
+ #else
+ #error Port.
+ #endif  // ARCH_CPU_X86_FAMILY
+   } t64;
+ 
+ #if defined(ARCH_CPU_X86_FAMILY) || defined(ARCH_CPU_ARM64) || \
+-    defined(ARCH_CPU_RISCV64)
++    defined(ARCH_CPU_RISCV64) || defined(ARCH_CPU_LOONGARCH_FAMILY)
+   using NativeThreadContext = user_regs_struct;
+ #elif defined(ARCH_CPU_ARMEL)
+   using NativeThreadContext = user_regs;
+@@ -233,6 +242,8 @@ union FloatContext {
+     uint32_t fpu_id;
+ #elif defined(ARCH_CPU_RISCV64)
+     // 32 bit RISC-V not supported
++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
++    // 32 bit LoongArch not supported
+ #else
+ #error Port.
+ #endif  // ARCH_CPU_X86_FAMILY
+@@ -271,6 +282,11 @@ union FloatContext {
+     // Reflects __riscv_d_ext_state in asm/ptrace.h
+     uint64_t fpregs[32];
+     uint64_t fcsr;
++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
++    // Reflects user_fp_struct in sys/user.h
++    uint64_t fpregs[32];
++    uint64_t fcc;
++    uint32_t fcsr;
+ #else
+ #error Port.
+ #endif  // ARCH_CPU_X86_FAMILY
+@@ -302,6 +318,8 @@ union FloatContext {
+ // No appropriate floating point context native type for available MIPS.
+ #elif defined(ARCH_CPU_RISCV64)
+   static_assert(sizeof(f64) == sizeof(__riscv_d_ext_state), "Size mismatch");
++#elif defined(ARCH_CPU_LOONGARCH_FAMILY)
++  static_assert(sizeof(f64) == sizeof(user_fp_struct), "Size mismatch");
+ #else
+ #error Port.
+ #endif  // ARCH_CPU_X86
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/crashpad/crashpad/util/misc/capture_context_linux.S b/third_party/crashpad/crashpad/util/misc/capture_context_linux.S
+--- a/third_party/crashpad/crashpad/util/misc/capture_context_linux.S	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/crashpad/crashpad/util/misc/capture_context_linux.S	2000-01-01 00:00:00.000000000 +0800
+@@ -510,4 +510,49 @@ CAPTURECONTEXT_SYMBOL2:
+ 
+   ret
+ 
++#elif defined(__loongarch_lp64)
++
++#define MCONTEXT_GREG_SIZE 8
++#define MCONTEXT_PC_OFFSET 176
++#define MCONTEXT_GREGS_OFFSET 184
++
++#define STORE_GPR(X) st.d $r##X, $a0, MCONTEXT_GREGS_OFFSET + X * MCONTEXT_GREG_SIZE
++#define STORE_PC st.d $ra, $a0, MCONTEXT_PC_OFFSET
++
++  STORE_PC
++  STORE_GPR(0)
++  STORE_GPR(1)
++  STORE_GPR(2)
++  STORE_GPR(3)
++  STORE_GPR(4)
++  STORE_GPR(5)
++  STORE_GPR(6)
++  STORE_GPR(7)
++  STORE_GPR(8)
++  STORE_GPR(9)
++  STORE_GPR(10)
++  STORE_GPR(11)
++  STORE_GPR(12)
++  STORE_GPR(13)
++  STORE_GPR(14)
++  STORE_GPR(15)
++  STORE_GPR(16)
++  STORE_GPR(17)
++  STORE_GPR(18)
++  STORE_GPR(19)
++  STORE_GPR(20)
++  STORE_GPR(21)
++  STORE_GPR(22)
++  STORE_GPR(23)
++  STORE_GPR(24)
++  STORE_GPR(25)
++  STORE_GPR(26)
++  STORE_GPR(27)
++  STORE_GPR(28)
++  STORE_GPR(29)
++  STORE_GPR(30)
++  STORE_GPR(31)
++
++  jirl $zero, $ra, 0
++
+ #endif  // __i386__
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc b/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc
+--- a/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc	2000-01-01 00:00:00.000000000 +0800
+@@ -239,6 +239,8 @@ std::string UserAgent() {
+ #endif
+ #elif defined (ARCH_CPU_RISCV64)
+     static constexpr char arch[] = "riscv64";
++#elif defined (ARCH_CPU_LOONGARCH64)
++    static constexpr char arch[] = "loong64";
+ #else
+ #error Port
+ #endif
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/dav1d/config/linux/loong64/config.h b/third_party/dav1d/config/linux/loong64/config.h
+--- a/third_party/dav1d/config/linux/loong64/config.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/dav1d/config/linux/loong64/config.h	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,45 @@
++/*
++ * Autogenerated by the Meson build system.
++ * Do not edit, your changes will be lost.
++ */
++
++#pragma once
++
++#define ARCH_AARCH64 0
++
++#define ARCH_ARM 0
++
++#define ARCH_PPC64LE 0
++
++#define ARCH_X86 0
++
++#define ARCH_X86_32 0
++
++#define ARCH_X86_64 0
++
++#define CONFIG_16BPC 1
++
++#define CONFIG_8BPC 1
++
++// #define CONFIG_LOG 1 -- Logging is controlled by Chromium
++
++#define ENDIANNESS_BIG 0
++
++#define HAVE_ASM 0
++
++#define HAVE_C11_GENERIC 1
++
++#define HAVE_CLOCK_GETTIME 1
++
++#define HAVE_DLSYM 1
++
++#define HAVE_POSIX_MEMALIGN 1
++
++// #define HAVE_PTHREAD_GETAFFINITY_NP 1 -- Controlled by Chomium
++
++// #define HAVE_PTHREAD_SETAFFINITY_NP 1 -- Controlled by Chomium
++
++#define HAVE_UNISTD_H 1
++
++#define TRIM_DSP_FUNCTIONS 1
++
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/devtools-frontend/src/scripts/build/rollup.config.mjs b/third_party/devtools-frontend/src/scripts/build/rollup.config.mjs
+--- a/third_party/devtools-frontend/src/scripts/build/rollup.config.mjs	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/devtools-frontend/src/scripts/build/rollup.config.mjs	2000-01-01 00:00:00.000000000 +0800
+@@ -19,7 +19,7 @@ export default commandLineArgs => ({
+     sourcemap: Boolean(commandLineArgs.configSourcemaps),
+   }],
+   plugins: [
+-    terser(),
++    // terser(),
+     {
+       name: 'devtools-plugin',
+       resolveId(source, importer) {
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config.h b/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config.h
+--- a/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config.h	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,772 @@
++/* Automatically generated by configure - do not modify! */
++#ifndef FFMPEG_CONFIG_H
++#define FFMPEG_CONFIG_H
++/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-lsx --disable-lasx --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --disable-linux-perf --x86asmexe=nasm --optflags='\\\\\"-O2\\\\\"' --cc=clang --cxx=clang++ --ld=clang --enable-decoder='aac,h264' --enable-demuxer=aac --enable-parser='aac,h264'" */
++#define FFMPEG_LICENSE "LGPL version 2.1 or later"
++#define CONFIG_THIS_YEAR 2024
++#define FFMPEG_DATADIR "/usr/local/share/ffmpeg"
++#define AVCONV_DATADIR "/usr/local/share/ffmpeg"
++#define CC_IDENT "clang version 17.0.6"
++#define OS_NAME linux
++#define av_restrict restrict
++#define EXTERN_PREFIX ""
++#define EXTERN_ASM 
++#define BUILDSUF ""
++#define SLIBSUF ".so"
++#define SWS_MAX_FILTER_SIZE 256
++#define ARCH_AARCH64 0
++#define ARCH_ALPHA 0
++#define ARCH_ARM 0
++#define ARCH_AVR32 0
++#define ARCH_AVR32_AP 0
++#define ARCH_AVR32_UC 0
++#define ARCH_BFIN 0
++#define ARCH_IA64 0
++#define ARCH_LOONGARCH 1
++#define ARCH_LOONGARCH32 0
++#define ARCH_LOONGARCH64 1
++#define ARCH_M68K 0
++#define ARCH_MIPS 0
++#define ARCH_MIPS64 0
++#define ARCH_PARISC 0
++#define ARCH_PPC 0
++#define ARCH_PPC64 0
++#define ARCH_RISCV 0
++#define ARCH_S390 0
++#define ARCH_SH4 0
++#define ARCH_SPARC 0
++#define ARCH_SPARC64 0
++#define ARCH_TILEGX 0
++#define ARCH_TILEPRO 0
++#define ARCH_X86 0
++#define ARCH_X86_32 0
++#define ARCH_X86_64 0
++#define HAVE_ARMV5TE 0
++#define HAVE_ARMV6 0
++#define HAVE_ARMV6T2 0
++#define HAVE_ARMV8 0
++#define HAVE_DOTPROD 0
++#define HAVE_I8MM 0
++#define HAVE_NEON 0
++#define HAVE_VFP 0
++#define HAVE_VFPV3 0
++#define HAVE_SETEND 0
++#define HAVE_ALTIVEC 0
++#define HAVE_DCBZL 0
++#define HAVE_LDBRX 0
++#define HAVE_POWER8 0
++#define HAVE_PPC4XX 0
++#define HAVE_VSX 0
++#define HAVE_RV 0
++#define HAVE_RVV 0
++#define HAVE_AESNI 0
++#define HAVE_AMD3DNOW 0
++#define HAVE_AMD3DNOWEXT 0
++#define HAVE_AVX 0
++#define HAVE_AVX2 0
++#define HAVE_AVX512 0
++#define HAVE_AVX512ICL 0
++#define HAVE_FMA3 0
++#define HAVE_FMA4 0
++#define HAVE_MMX 0
++#define HAVE_MMXEXT 0
++#define HAVE_SSE 0
++#define HAVE_SSE2 0
++#define HAVE_SSE3 0
++#define HAVE_SSE4 0
++#define HAVE_SSE42 0
++#define HAVE_SSSE3 0
++#define HAVE_XOP 0
++#define HAVE_CPUNOP 0
++#define HAVE_I686 0
++#define HAVE_MIPSFPU 0
++#define HAVE_MIPS32R2 0
++#define HAVE_MIPS32R5 0
++#define HAVE_MIPS64R2 0
++#define HAVE_MIPS32R6 0
++#define HAVE_MIPS64R6 0
++#define HAVE_MIPSDSP 0
++#define HAVE_MIPSDSPR2 0
++#define HAVE_MSA 0
++#define HAVE_LOONGSON2 0
++#define HAVE_LOONGSON3 0
++#define HAVE_MMI 0
++#define HAVE_LSX 0
++#define HAVE_LASX 0
++#define HAVE_ARMV5TE_EXTERNAL 0
++#define HAVE_ARMV6_EXTERNAL 0
++#define HAVE_ARMV6T2_EXTERNAL 0
++#define HAVE_ARMV8_EXTERNAL 0
++#define HAVE_DOTPROD_EXTERNAL 0
++#define HAVE_I8MM_EXTERNAL 0
++#define HAVE_NEON_EXTERNAL 0
++#define HAVE_VFP_EXTERNAL 0
++#define HAVE_VFPV3_EXTERNAL 0
++#define HAVE_SETEND_EXTERNAL 0
++#define HAVE_ALTIVEC_EXTERNAL 0
++#define HAVE_DCBZL_EXTERNAL 0
++#define HAVE_LDBRX_EXTERNAL 0
++#define HAVE_POWER8_EXTERNAL 0
++#define HAVE_PPC4XX_EXTERNAL 0
++#define HAVE_VSX_EXTERNAL 0
++#define HAVE_RV_EXTERNAL 0
++#define HAVE_RVV_EXTERNAL 0
++#define HAVE_AESNI_EXTERNAL 0
++#define HAVE_AMD3DNOW_EXTERNAL 0
++#define HAVE_AMD3DNOWEXT_EXTERNAL 0
++#define HAVE_AVX_EXTERNAL 0
++#define HAVE_AVX2_EXTERNAL 0
++#define HAVE_AVX512_EXTERNAL 0
++#define HAVE_AVX512ICL_EXTERNAL 0
++#define HAVE_FMA3_EXTERNAL 0
++#define HAVE_FMA4_EXTERNAL 0
++#define HAVE_MMX_EXTERNAL 0
++#define HAVE_MMXEXT_EXTERNAL 0
++#define HAVE_SSE_EXTERNAL 0
++#define HAVE_SSE2_EXTERNAL 0
++#define HAVE_SSE3_EXTERNAL 0
++#define HAVE_SSE4_EXTERNAL 0
++#define HAVE_SSE42_EXTERNAL 0
++#define HAVE_SSSE3_EXTERNAL 0
++#define HAVE_XOP_EXTERNAL 0
++#define HAVE_CPUNOP_EXTERNAL 0
++#define HAVE_I686_EXTERNAL 0
++#define HAVE_MIPSFPU_EXTERNAL 0
++#define HAVE_MIPS32R2_EXTERNAL 0
++#define HAVE_MIPS32R5_EXTERNAL 0
++#define HAVE_MIPS64R2_EXTERNAL 0
++#define HAVE_MIPS32R6_EXTERNAL 0
++#define HAVE_MIPS64R6_EXTERNAL 0
++#define HAVE_MIPSDSP_EXTERNAL 0
++#define HAVE_MIPSDSPR2_EXTERNAL 0
++#define HAVE_MSA_EXTERNAL 0
++#define HAVE_LOONGSON2_EXTERNAL 0
++#define HAVE_LOONGSON3_EXTERNAL 0
++#define HAVE_MMI_EXTERNAL 0
++#define HAVE_LSX_EXTERNAL 0
++#define HAVE_LASX_EXTERNAL 0
++#define HAVE_ARMV5TE_INLINE 0
++#define HAVE_ARMV6_INLINE 0
++#define HAVE_ARMV6T2_INLINE 0
++#define HAVE_ARMV8_INLINE 0
++#define HAVE_DOTPROD_INLINE 0
++#define HAVE_I8MM_INLINE 0
++#define HAVE_NEON_INLINE 0
++#define HAVE_VFP_INLINE 0
++#define HAVE_VFPV3_INLINE 0
++#define HAVE_SETEND_INLINE 0
++#define HAVE_ALTIVEC_INLINE 0
++#define HAVE_DCBZL_INLINE 0
++#define HAVE_LDBRX_INLINE 0
++#define HAVE_POWER8_INLINE 0
++#define HAVE_PPC4XX_INLINE 0
++#define HAVE_VSX_INLINE 0
++#define HAVE_RV_INLINE 0
++#define HAVE_RVV_INLINE 0
++#define HAVE_AESNI_INLINE 0
++#define HAVE_AMD3DNOW_INLINE 0
++#define HAVE_AMD3DNOWEXT_INLINE 0
++#define HAVE_AVX_INLINE 0
++#define HAVE_AVX2_INLINE 0
++#define HAVE_AVX512_INLINE 0
++#define HAVE_AVX512ICL_INLINE 0
++#define HAVE_FMA3_INLINE 0
++#define HAVE_FMA4_INLINE 0
++#define HAVE_MMX_INLINE 0
++#define HAVE_MMXEXT_INLINE 0
++#define HAVE_SSE_INLINE 0
++#define HAVE_SSE2_INLINE 0
++#define HAVE_SSE3_INLINE 0
++#define HAVE_SSE4_INLINE 0
++#define HAVE_SSE42_INLINE 0
++#define HAVE_SSSE3_INLINE 0
++#define HAVE_XOP_INLINE 0
++#define HAVE_CPUNOP_INLINE 0
++#define HAVE_I686_INLINE 0
++#define HAVE_MIPSFPU_INLINE 0
++#define HAVE_MIPS32R2_INLINE 0
++#define HAVE_MIPS32R5_INLINE 0
++#define HAVE_MIPS64R2_INLINE 0
++#define HAVE_MIPS32R6_INLINE 0
++#define HAVE_MIPS64R6_INLINE 0
++#define HAVE_MIPSDSP_INLINE 0
++#define HAVE_MIPSDSPR2_INLINE 0
++#define HAVE_MSA_INLINE 0
++#define HAVE_LOONGSON2_INLINE 0
++#define HAVE_LOONGSON3_INLINE 0
++#define HAVE_MMI_INLINE 0
++#define HAVE_LSX_INLINE 0
++#define HAVE_LASX_INLINE 0
++#define HAVE_ALIGNED_STACK 0
++#define HAVE_FAST_64BIT 1
++#define HAVE_FAST_CLZ 1
++#define HAVE_FAST_CMOV 0
++#define HAVE_FAST_FLOAT16 0
++#define HAVE_LOCAL_ALIGNED 1
++#define HAVE_SIMD_ALIGN_16 0
++#define HAVE_SIMD_ALIGN_32 1
++#define HAVE_SIMD_ALIGN_64 0
++#define HAVE_ATOMIC_CAS_PTR 0
++#define HAVE_MACHINE_RW_BARRIER 0
++#define HAVE_MEMORYBARRIER 0
++#define HAVE_MM_EMPTY 0
++#define HAVE_RDTSC 0
++#define HAVE_SEM_TIMEDWAIT 1
++#define HAVE_SYNC_VAL_COMPARE_AND_SWAP 1
++#define HAVE_INLINE_ASM 1
++#define HAVE_SYMVER 0
++#define HAVE_X86ASM 0
++#define HAVE_BIGENDIAN 0
++#define HAVE_FAST_UNALIGNED 1
++#define HAVE_ARPA_INET_H 0
++#define HAVE_ASM_TYPES_H 1
++#define HAVE_CDIO_PARANOIA_H 0
++#define HAVE_CDIO_PARANOIA_PARANOIA_H 0
++#define HAVE_CUDA_H 0
++#define HAVE_DISPATCH_DISPATCH_H 0
++#define HAVE_DEV_BKTR_IOCTL_BT848_H 0
++#define HAVE_DEV_BKTR_IOCTL_METEOR_H 0
++#define HAVE_DEV_IC_BT8XX_H 0
++#define HAVE_DEV_VIDEO_BKTR_IOCTL_BT848_H 0
++#define HAVE_DEV_VIDEO_METEOR_IOCTL_METEOR_H 0
++#define HAVE_DIRECT_H 0
++#define HAVE_DIRENT_H 1
++#define HAVE_DXGIDEBUG_H 0
++#define HAVE_DXVA_H 0
++#define HAVE_ES2_GL_H 0
++#define HAVE_GSM_H 0
++#define HAVE_IO_H 0
++#define HAVE_LINUX_DMA_BUF_H 0
++#define HAVE_LINUX_PERF_EVENT_H 1
++#define HAVE_MACHINE_IOCTL_BT848_H 0
++#define HAVE_MACHINE_IOCTL_METEOR_H 0
++#define HAVE_MALLOC_H 1
++#define HAVE_OPENCV2_CORE_CORE_C_H 0
++#define HAVE_OPENGL_GL3_H 0
++#define HAVE_POLL_H 1
++#define HAVE_PTHREAD_NP_H 0
++#define HAVE_SYS_PARAM_H 1
++#define HAVE_SYS_RESOURCE_H 1
++#define HAVE_SYS_SELECT_H 1
++#define HAVE_SYS_SOUNDCARD_H 1
++#define HAVE_SYS_TIME_H 1
++#define HAVE_SYS_UN_H 1
++#define HAVE_SYS_VIDEOIO_H 0
++#define HAVE_TERMIOS_H 1
++#define HAVE_UDPLITE_H 0
++#define HAVE_UNISTD_H 1
++#define HAVE_VALGRIND_VALGRIND_H 0
++#define HAVE_WINDOWS_H 0
++#define HAVE_WINSOCK2_H 0
++#define HAVE_INTRINSICS_NEON 0
++#define HAVE_ATANF 1
++#define HAVE_ATAN2F 1
++#define HAVE_CBRT 1
++#define HAVE_CBRTF 1
++#define HAVE_COPYSIGN 1
++#define HAVE_COSF 1
++#define HAVE_ERF 1
++#define HAVE_EXP2 1
++#define HAVE_EXP2F 1
++#define HAVE_EXPF 1
++#define HAVE_HYPOT 1
++#define HAVE_ISFINITE 1
++#define HAVE_ISINF 1
++#define HAVE_ISNAN 1
++#define HAVE_LDEXPF 1
++#define HAVE_LLRINT 1
++#define HAVE_LLRINTF 1
++#define HAVE_LOG2 1
++#define HAVE_LOG2F 1
++#define HAVE_LOG10F 1
++#define HAVE_LRINT 1
++#define HAVE_LRINTF 1
++#define HAVE_POWF 1
++#define HAVE_RINT 1
++#define HAVE_ROUND 1
++#define HAVE_ROUNDF 1
++#define HAVE_SINF 1
++#define HAVE_TRUNC 1
++#define HAVE_TRUNCF 1
++#define HAVE_DOS_PATHS 0
++#define HAVE_LIBC_MSVCRT 0
++#define HAVE_MMAL_PARAMETER_VIDEO_MAX_NUM_CALLBACKS 0
++#define HAVE_SECTION_DATA_REL_RO 1
++#define HAVE_THREADS 1
++#define HAVE_UWP 0
++#define HAVE_WINRT 0
++#define HAVE_ACCESS 1
++#define HAVE_ALIGNED_MALLOC 0
++#define HAVE_ARC4RANDOM_BUF 0
++#define HAVE_CLOCK_GETTIME 1
++#define HAVE_CLOSESOCKET 0
++#define HAVE_COMMANDLINETOARGVW 0
++#define HAVE_FCNTL 1
++#define HAVE_GETADDRINFO 0
++#define HAVE_GETAUXVAL 1
++#define HAVE_GETENV 1
++#define HAVE_GETHRTIME 0
++#define HAVE_GETOPT 1
++#define HAVE_GETMODULEHANDLE 0
++#define HAVE_GETPROCESSAFFINITYMASK 0
++#define HAVE_GETPROCESSMEMORYINFO 0
++#define HAVE_GETPROCESSTIMES 0
++#define HAVE_GETRUSAGE 1
++#define HAVE_GETSTDHANDLE 0
++#define HAVE_GETSYSTEMTIMEASFILETIME 0
++#define HAVE_GETTIMEOFDAY 1
++#define HAVE_GLOB 1
++#define HAVE_GLXGETPROCADDRESS 0
++#define HAVE_GMTIME_R 1
++#define HAVE_INET_ATON 0
++#define HAVE_ISATTY 1
++#define HAVE_KBHIT 0
++#define HAVE_LOCALTIME_R 1
++#define HAVE_LSTAT 1
++#define HAVE_LZO1X_999_COMPRESS 0
++#define HAVE_MACH_ABSOLUTE_TIME 0
++#define HAVE_MAPVIEWOFFILE 0
++#define HAVE_MEMALIGN 1
++#define HAVE_MKSTEMP 1
++#define HAVE_MMAP 1
++#define HAVE_MPROTECT 1
++#define HAVE_NANOSLEEP 1
++#define HAVE_PEEKNAMEDPIPE 0
++#define HAVE_POSIX_MEMALIGN 1
++#define HAVE_PRCTL 1
++#define HAVE_PTHREAD_CANCEL 1
++#define HAVE_PTHREAD_SET_NAME_NP 0
++#define HAVE_PTHREAD_SETNAME_NP 0
++#define HAVE_SCHED_GETAFFINITY 1
++#define HAVE_SECITEMIMPORT 0
++#define HAVE_SETCONSOLETEXTATTRIBUTE 0
++#define HAVE_SETCONSOLECTRLHANDLER 0
++#define HAVE_SETDLLDIRECTORY 0
++#define HAVE_SETMODE 0
++#define HAVE_SETRLIMIT 1
++#define HAVE_SLEEP 0
++#define HAVE_STRERROR_R 1
++#define HAVE_SYSCONF 1
++#define HAVE_SYSCTL 0
++#define HAVE_SYSCTLBYNAME 0
++#define HAVE_USLEEP 1
++#define HAVE_UTGETOSTYPEFROMSTRING 0
++#define HAVE_VIRTUALALLOC 0
++#define HAVE_WGLGETPROCADDRESS 0
++#define HAVE_BCRYPT 0
++#define HAVE_VAAPI_DRM 0
++#define HAVE_VAAPI_X11 0
++#define HAVE_VAAPI_WIN32 0
++#define HAVE_VDPAU_X11 0
++#define HAVE_PTHREADS 1
++#define HAVE_OS2THREADS 0
++#define HAVE_W32THREADS 0
++#define HAVE_AS_ARCH_DIRECTIVE 0
++#define HAVE_AS_ARCHEXT_DOTPROD_DIRECTIVE 0
++#define HAVE_AS_ARCHEXT_I8MM_DIRECTIVE 0
++#define HAVE_AS_DN_DIRECTIVE 0
++#define HAVE_AS_FPU_DIRECTIVE 0
++#define HAVE_AS_FUNC 0
++#define HAVE_AS_OBJECT_ARCH 0
++#define HAVE_ASM_MOD_Q 0
++#define HAVE_BLOCKS_EXTENSION 0
++#define HAVE_EBP_AVAILABLE 0
++#define HAVE_EBX_AVAILABLE 0
++#define HAVE_GNU_AS 0
++#define HAVE_GNU_WINDRES 0
++#define HAVE_IBM_ASM 0
++#define HAVE_INLINE_ASM_DIRECT_SYMBOL_REFS 0
++#define HAVE_INLINE_ASM_LABELS 1
++#define HAVE_INLINE_ASM_NONLOCAL_LABELS 1
++#define HAVE_PRAGMA_DEPRECATED 1
++#define HAVE_RSYNC_CONTIMEOUT 1
++#define HAVE_SYMVER_ASM_LABEL 1
++#define HAVE_SYMVER_GNU_ASM 1
++#define HAVE_VFP_ARGS 0
++#define HAVE_XFORM_ASM 0
++#define HAVE_XMM_CLOBBERS 0
++#define HAVE_DPI_AWARENESS_CONTEXT 0
++#define HAVE_IDXGIOUTPUT5 0
++#define HAVE_KCMVIDEOCODECTYPE_HEVC 0
++#define HAVE_KCMVIDEOCODECTYPE_HEVCWITHALPHA 0
++#define HAVE_KCMVIDEOCODECTYPE_VP9 0
++#define HAVE_KCVPIXELFORMATTYPE_420YPCBCR10BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR8BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR10BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR16BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR8BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR10BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR16BIPLANARVIDEORANGE 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_2084_PQ 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2100_HLG 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_LINEAR 0
++#define HAVE_KCVIMAGEBUFFERYCBCRMATRIX_ITU_R_2020 0
++#define HAVE_KCVIMAGEBUFFERCOLORPRIMARIES_ITU_R_2020 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2020 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_428_1 0
++#define HAVE_SOCKLEN_T 0
++#define HAVE_STRUCT_ADDRINFO 0
++#define HAVE_STRUCT_GROUP_SOURCE_REQ 0
++#define HAVE_STRUCT_IP_MREQ_SOURCE 0
++#define HAVE_STRUCT_IPV6_MREQ 0
++#define HAVE_STRUCT_MSGHDR_MSG_FLAGS 0
++#define HAVE_STRUCT_POLLFD 0
++#define HAVE_STRUCT_RUSAGE_RU_MAXRSS 1
++#define HAVE_STRUCT_SCTP_EVENT_SUBSCRIBE 0
++#define HAVE_STRUCT_SOCKADDR_IN6 0
++#define HAVE_STRUCT_SOCKADDR_SA_LEN 0
++#define HAVE_STRUCT_SOCKADDR_STORAGE 0
++#define HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC 1
++#define HAVE_STRUCT_V4L2_FRMIVALENUM_DISCRETE 0
++#define HAVE_GZIP 1
++#define HAVE_LIBDRM_GETFB2 0
++#define HAVE_MAKEINFO 1
++#define HAVE_MAKEINFO_HTML 1
++#define HAVE_OPENCL_D3D11 0
++#define HAVE_OPENCL_DRM_ARM 0
++#define HAVE_OPENCL_DRM_BEIGNET 0
++#define HAVE_OPENCL_DXVA2 0
++#define HAVE_OPENCL_VAAPI_BEIGNET 0
++#define HAVE_OPENCL_VAAPI_INTEL_MEDIA 0
++#define HAVE_PERL 1
++#define HAVE_POD2MAN 1
++#define HAVE_TEXI2HTML 0
++#define HAVE_XMLLINT 1
++#define HAVE_ZLIB_GZIP 0
++#define HAVE_OPENVINO2 0
++#define CONFIG_DOC 0
++#define CONFIG_HTMLPAGES 0
++#define CONFIG_MANPAGES 0
++#define CONFIG_PODPAGES 0
++#define CONFIG_TXTPAGES 0
++#define CONFIG_AVIO_HTTP_SERVE_FILES_EXAMPLE 1
++#define CONFIG_AVIO_LIST_DIR_EXAMPLE 1
++#define CONFIG_AVIO_READ_CALLBACK_EXAMPLE 1
++#define CONFIG_DECODE_AUDIO_EXAMPLE 1
++#define CONFIG_DECODE_FILTER_AUDIO_EXAMPLE 0
++#define CONFIG_DECODE_FILTER_VIDEO_EXAMPLE 0
++#define CONFIG_DECODE_VIDEO_EXAMPLE 1
++#define CONFIG_DEMUX_DECODE_EXAMPLE 1
++#define CONFIG_ENCODE_AUDIO_EXAMPLE 1
++#define CONFIG_ENCODE_VIDEO_EXAMPLE 1
++#define CONFIG_EXTRACT_MVS_EXAMPLE 1
++#define CONFIG_FILTER_AUDIO_EXAMPLE 0
++#define CONFIG_HW_DECODE_EXAMPLE 1
++#define CONFIG_MUX_EXAMPLE 0
++#define CONFIG_QSV_DECODE_EXAMPLE 0
++#define CONFIG_REMUX_EXAMPLE 1
++#define CONFIG_RESAMPLE_AUDIO_EXAMPLE 0
++#define CONFIG_SCALE_VIDEO_EXAMPLE 0
++#define CONFIG_SHOW_METADATA_EXAMPLE 1
++#define CONFIG_TRANSCODE_AAC_EXAMPLE 0
++#define CONFIG_TRANSCODE_EXAMPLE 0
++#define CONFIG_VAAPI_ENCODE_EXAMPLE 0
++#define CONFIG_VAAPI_TRANSCODE_EXAMPLE 0
++#define CONFIG_QSV_TRANSCODE_EXAMPLE 0
++#define CONFIG_AVISYNTH 0
++#define CONFIG_FREI0R 0
++#define CONFIG_LIBCDIO 0
++#define CONFIG_LIBDAVS2 0
++#define CONFIG_LIBRUBBERBAND 0
++#define CONFIG_LIBVIDSTAB 0
++#define CONFIG_LIBX264 0
++#define CONFIG_LIBX265 0
++#define CONFIG_LIBXAVS 0
++#define CONFIG_LIBXAVS2 0
++#define CONFIG_LIBXVID 0
++#define CONFIG_DECKLINK 0
++#define CONFIG_LIBFDK_AAC 0
++#define CONFIG_LIBTLS 0
++#define CONFIG_GMP 0
++#define CONFIG_LIBARIBB24 0
++#define CONFIG_LIBLENSFUN 0
++#define CONFIG_LIBOPENCORE_AMRNB 0
++#define CONFIG_LIBOPENCORE_AMRWB 0
++#define CONFIG_LIBVO_AMRWBENC 0
++#define CONFIG_MBEDTLS 0
++#define CONFIG_RKMPP 0
++#define CONFIG_LIBSMBCLIENT 0
++#define CONFIG_CHROMAPRINT 0
++#define CONFIG_GCRYPT 0
++#define CONFIG_GNUTLS 0
++#define CONFIG_JNI 0
++#define CONFIG_LADSPA 0
++#define CONFIG_LCMS2 0
++#define CONFIG_LIBAOM 0
++#define CONFIG_LIBARIBCAPTION 0
++#define CONFIG_LIBASS 0
++#define CONFIG_LIBBLURAY 0
++#define CONFIG_LIBBS2B 0
++#define CONFIG_LIBCACA 0
++#define CONFIG_LIBCELT 0
++#define CONFIG_LIBCODEC2 0
++#define CONFIG_LIBDAV1D 0
++#define CONFIG_LIBDC1394 0
++#define CONFIG_LIBFLITE 0
++#define CONFIG_LIBFONTCONFIG 0
++#define CONFIG_LIBFREETYPE 0
++#define CONFIG_LIBFRIBIDI 0
++#define CONFIG_LIBHARFBUZZ 0
++#define CONFIG_LIBGLSLANG 0
++#define CONFIG_LIBGME 0
++#define CONFIG_LIBGSM 0
++#define CONFIG_LIBIEC61883 0
++#define CONFIG_LIBILBC 0
++#define CONFIG_LIBJACK 0
++#define CONFIG_LIBJXL 0
++#define CONFIG_LIBKLVANC 0
++#define CONFIG_LIBKVAZAAR 0
++#define CONFIG_LIBMODPLUG 0
++#define CONFIG_LIBMP3LAME 0
++#define CONFIG_LIBMYSOFA 0
++#define CONFIG_LIBOPENCV 0
++#define CONFIG_LIBOPENH264 0
++#define CONFIG_LIBOPENJPEG 0
++#define CONFIG_LIBOPENMPT 0
++#define CONFIG_LIBOPENVINO 0
++#define CONFIG_LIBOPUS 1
++#define CONFIG_LIBPLACEBO 0
++#define CONFIG_LIBPULSE 0
++#define CONFIG_LIBQRENCODE 0
++#define CONFIG_LIBQUIRC 0
++#define CONFIG_LIBRABBITMQ 0
++#define CONFIG_LIBRAV1E 0
++#define CONFIG_LIBRIST 0
++#define CONFIG_LIBRSVG 0
++#define CONFIG_LIBRTMP 0
++#define CONFIG_LIBSHADERC 0
++#define CONFIG_LIBSHINE 0
++#define CONFIG_LIBSMBCLIENT 0
++#define CONFIG_LIBSNAPPY 0
++#define CONFIG_LIBSOXR 0
++#define CONFIG_LIBSPEEX 0
++#define CONFIG_LIBSRT 0
++#define CONFIG_LIBSSH 0
++#define CONFIG_LIBSVTAV1 0
++#define CONFIG_LIBTENSORFLOW 0
++#define CONFIG_LIBTESSERACT 0
++#define CONFIG_LIBTHEORA 0
++#define CONFIG_LIBTWOLAME 0
++#define CONFIG_LIBUAVS3D 0
++#define CONFIG_LIBV4L2 0
++#define CONFIG_LIBVMAF 0
++#define CONFIG_LIBVORBIS 0
++#define CONFIG_LIBVPX 0
++#define CONFIG_LIBWEBP 0
++#define CONFIG_LIBXEVD 0
++#define CONFIG_LIBXEVE 0
++#define CONFIG_LIBXML2 0
++#define CONFIG_LIBZIMG 0
++#define CONFIG_LIBZMQ 0
++#define CONFIG_LIBZVBI 0
++#define CONFIG_LV2 0
++#define CONFIG_MEDIACODEC 0
++#define CONFIG_OPENAL 0
++#define CONFIG_OPENGL 0
++#define CONFIG_OPENSSL 0
++#define CONFIG_POCKETSPHINX 0
++#define CONFIG_VAPOURSYNTH 0
++#define CONFIG_ALSA 0
++#define CONFIG_APPKIT 0
++#define CONFIG_AVFOUNDATION 0
++#define CONFIG_BZLIB 0
++#define CONFIG_COREIMAGE 0
++#define CONFIG_ICONV 0
++#define CONFIG_LIBXCB 0
++#define CONFIG_LIBXCB_SHM 0
++#define CONFIG_LIBXCB_SHAPE 0
++#define CONFIG_LIBXCB_XFIXES 0
++#define CONFIG_LZMA 0
++#define CONFIG_MEDIAFOUNDATION 0
++#define CONFIG_METAL 0
++#define CONFIG_SCHANNEL 0
++#define CONFIG_SDL2 0
++#define CONFIG_SECURETRANSPORT 0
++#define CONFIG_SNDIO 0
++#define CONFIG_XLIB 0
++#define CONFIG_ZLIB 0
++#define CONFIG_CUDA_NVCC 0
++#define CONFIG_CUDA_SDK 0
++#define CONFIG_LIBNPP 0
++#define CONFIG_LIBMFX 0
++#define CONFIG_LIBVPL 0
++#define CONFIG_MMAL 0
++#define CONFIG_OMX 0
++#define CONFIG_OPENCL 0
++#define CONFIG_AMF 0
++#define CONFIG_AUDIOTOOLBOX 0
++#define CONFIG_CRYSTALHD 0
++#define CONFIG_CUDA 0
++#define CONFIG_CUDA_LLVM 0
++#define CONFIG_CUVID 0
++#define CONFIG_D3D11VA 0
++#define CONFIG_D3D12VA 0
++#define CONFIG_DXVA2 0
++#define CONFIG_FFNVCODEC 0
++#define CONFIG_LIBDRM 0
++#define CONFIG_NVDEC 0
++#define CONFIG_NVENC 0
++#define CONFIG_VAAPI 0
++#define CONFIG_VDPAU 0
++#define CONFIG_VIDEOTOOLBOX 0
++#define CONFIG_VULKAN 0
++#define CONFIG_V4L2_M2M 0
++#define CONFIG_FTRAPV 0
++#define CONFIG_GRAY 0
++#define CONFIG_HARDCODED_TABLES 0
++#define CONFIG_OMX_RPI 0
++#define CONFIG_RUNTIME_CPUDETECT 1
++#define CONFIG_SAFE_BITSTREAM_READER 1
++#define CONFIG_SHARED 0
++#define CONFIG_SMALL 0
++#define CONFIG_STATIC 1
++#define CONFIG_SWSCALE_ALPHA 1
++#define CONFIG_GPL 0
++#define CONFIG_NONFREE 0
++#define CONFIG_VERSION3 0
++#define CONFIG_AVDEVICE 0
++#define CONFIG_AVFILTER 0
++#define CONFIG_SWSCALE 0
++#define CONFIG_POSTPROC 0
++#define CONFIG_AVFORMAT 1
++#define CONFIG_AVCODEC 1
++#define CONFIG_SWRESAMPLE 0
++#define CONFIG_AVUTIL 1
++#define CONFIG_FFPLAY 0
++#define CONFIG_FFPROBE 0
++#define CONFIG_FFMPEG 0
++#define CONFIG_DWT 0
++#define CONFIG_ERROR_RESILIENCE 0
++#define CONFIG_FAAN 0
++#define CONFIG_FAST_UNALIGNED 1
++#define CONFIG_LSP 0
++#define CONFIG_PIXELUTILS 0
++#define CONFIG_NETWORK 0
++#define CONFIG_AUTODETECT 0
++#define CONFIG_FONTCONFIG 0
++#define CONFIG_LARGE_TESTS 1
++#define CONFIG_LINUX_PERF 0
++#define CONFIG_MACOS_KPERF 0
++#define CONFIG_MEMORY_POISONING 0
++#define CONFIG_NEON_CLOBBER_TEST 0
++#define CONFIG_OSSFUZZ 0
++#define CONFIG_PIC 1
++#define CONFIG_PTX_COMPRESSION 0
++#define CONFIG_THUMB 0
++#define CONFIG_VALGRIND_BACKTRACE 0
++#define CONFIG_XMM_CLOBBER_TEST 0
++#define CONFIG_BSFS 0
++#define CONFIG_DECODERS 1
++#define CONFIG_ENCODERS 0
++#define CONFIG_HWACCELS 0
++#define CONFIG_PARSERS 1
++#define CONFIG_INDEVS 0
++#define CONFIG_OUTDEVS 0
++#define CONFIG_FILTERS 0
++#define CONFIG_DEMUXERS 1
++#define CONFIG_MUXERS 0
++#define CONFIG_PROTOCOLS 0
++#define CONFIG_AANDCTTABLES 0
++#define CONFIG_AC3DSP 0
++#define CONFIG_ADTS_HEADER 1
++#define CONFIG_ATSC_A53 1
++#define CONFIG_AUDIO_FRAME_QUEUE 0
++#define CONFIG_AUDIODSP 0
++#define CONFIG_BLOCKDSP 0
++#define CONFIG_BSWAPDSP 0
++#define CONFIG_CABAC 1
++#define CONFIG_CBS 0
++#define CONFIG_CBS_AV1 0
++#define CONFIG_CBS_H264 0
++#define CONFIG_CBS_H265 0
++#define CONFIG_CBS_H266 0
++#define CONFIG_CBS_JPEG 0
++#define CONFIG_CBS_MPEG2 0
++#define CONFIG_CBS_VP8 0
++#define CONFIG_CBS_VP9 0
++#define CONFIG_DEFLATE_WRAPPER 0
++#define CONFIG_DIRAC_PARSE 1
++#define CONFIG_DNN 0
++#define CONFIG_DOVI_RPU 0
++#define CONFIG_DVPROFILE 0
++#define CONFIG_EVCPARSE 0
++#define CONFIG_EXIF 0
++#define CONFIG_FAANDCT 0
++#define CONFIG_FAANIDCT 0
++#define CONFIG_FDCTDSP 0
++#define CONFIG_FMTCONVERT 0
++#define CONFIG_FRAME_THREAD_ENCODER 0
++#define CONFIG_G722DSP 0
++#define CONFIG_GOLOMB 1
++#define CONFIG_GPLV3 0
++#define CONFIG_H263DSP 0
++#define CONFIG_H264CHROMA 1
++#define CONFIG_H264DSP 1
++#define CONFIG_H264PARSE 1
++#define CONFIG_H264PRED 1
++#define CONFIG_H264QPEL 1
++#define CONFIG_H264_SEI 1
++#define CONFIG_HEVCPARSE 0
++#define CONFIG_HEVC_SEI 0
++#define CONFIG_HPELDSP 0
++#define CONFIG_HUFFMAN 0
++#define CONFIG_HUFFYUVDSP 0
++#define CONFIG_HUFFYUVENCDSP 0
++#define CONFIG_IAMFDEC 0
++#define CONFIG_IAMFENC 0
++#define CONFIG_IDCTDSP 0
++#define CONFIG_IIRFILTER 0
++#define CONFIG_INFLATE_WRAPPER 0
++#define CONFIG_INTRAX8 0
++#define CONFIG_ISO_MEDIA 1
++#define CONFIG_IVIDSP 0
++#define CONFIG_JPEGTABLES 0
++#define CONFIG_LGPLV3 0
++#define CONFIG_LIBX262 0
++#define CONFIG_LLAUDDSP 0
++#define CONFIG_LLVIDDSP 0
++#define CONFIG_LLVIDENCDSP 0
++#define CONFIG_LPC 0
++#define CONFIG_LZF 0
++#define CONFIG_ME_CMP 0
++#define CONFIG_MPEG_ER 0
++#define CONFIG_MPEGAUDIO 1
++#define CONFIG_MPEGAUDIODSP 1
++#define CONFIG_MPEGAUDIOHEADER 1
++#define CONFIG_MPEG4AUDIO 1
++#define CONFIG_MPEGVIDEO 0
++#define CONFIG_MPEGVIDEODEC 0
++#define CONFIG_MPEGVIDEOENC 0
++#define CONFIG_MSMPEG4DEC 0
++#define CONFIG_MSMPEG4ENC 0
++#define CONFIG_MSS34DSP 0
++#define CONFIG_PIXBLOCKDSP 0
++#define CONFIG_QPELDSP 0
++#define CONFIG_QSV 0
++#define CONFIG_QSVDEC 0
++#define CONFIG_QSVENC 0
++#define CONFIG_QSVVPP 0
++#define CONFIG_RANGECODER 0
++#define CONFIG_RIFFDEC 1
++#define CONFIG_RIFFENC 0
++#define CONFIG_RTPDEC 0
++#define CONFIG_RTPENC_CHAIN 0
++#define CONFIG_RV34DSP 0
++#define CONFIG_SCENE_SAD 0
++#define CONFIG_SINEWIN 1
++#define CONFIG_SNAPPY 0
++#define CONFIG_SRTP 0
++#define CONFIG_STARTCODE 1
++#define CONFIG_TEXTUREDSP 0
++#define CONFIG_TEXTUREDSPENC 0
++#define CONFIG_TPELDSP 0
++#define CONFIG_VAAPI_1 0
++#define CONFIG_VAAPI_ENCODE 0
++#define CONFIG_VC1DSP 0
++#define CONFIG_VIDEODSP 1
++#define CONFIG_VP3DSP 0
++#define CONFIG_VP56DSP 0
++#define CONFIG_VP8DSP 0
++#define CONFIG_WMA_FREQS 0
++#define CONFIG_WMV2DSP 0
++#endif /* FFMPEG_CONFIG_H */
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config_components.h b/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config_components.h
+--- a/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config_components.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/config_components.h	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,2218 @@
++/* Automatically generated by configure - do not modify! */
++#ifndef FFMPEG_CONFIG_COMPONENTS_H
++#define FFMPEG_CONFIG_COMPONENTS_H
++#define CONFIG_AAC_ADTSTOASC_BSF 0
++#define CONFIG_AV1_FRAME_MERGE_BSF 0
++#define CONFIG_AV1_FRAME_SPLIT_BSF 0
++#define CONFIG_AV1_METADATA_BSF 0
++#define CONFIG_CHOMP_BSF 0
++#define CONFIG_DUMP_EXTRADATA_BSF 0
++#define CONFIG_DCA_CORE_BSF 0
++#define CONFIG_DTS2PTS_BSF 0
++#define CONFIG_DV_ERROR_MARKER_BSF 0
++#define CONFIG_EAC3_CORE_BSF 0
++#define CONFIG_EXTRACT_EXTRADATA_BSF 0
++#define CONFIG_FILTER_UNITS_BSF 0
++#define CONFIG_H264_METADATA_BSF 0
++#define CONFIG_H264_MP4TOANNEXB_BSF 0
++#define CONFIG_H264_REDUNDANT_PPS_BSF 0
++#define CONFIG_HAPQA_EXTRACT_BSF 0
++#define CONFIG_HEVC_METADATA_BSF 0
++#define CONFIG_HEVC_MP4TOANNEXB_BSF 0
++#define CONFIG_IMX_DUMP_HEADER_BSF 0
++#define CONFIG_MEDIA100_TO_MJPEGB_BSF 0
++#define CONFIG_MJPEG2JPEG_BSF 0
++#define CONFIG_MJPEGA_DUMP_HEADER_BSF 0
++#define CONFIG_MP3_HEADER_DECOMPRESS_BSF 0
++#define CONFIG_MPEG2_METADATA_BSF 0
++#define CONFIG_MPEG4_UNPACK_BFRAMES_BSF 0
++#define CONFIG_MOV2TEXTSUB_BSF 0
++#define CONFIG_NOISE_BSF 0
++#define CONFIG_NULL_BSF 0
++#define CONFIG_OPUS_METADATA_BSF 0
++#define CONFIG_PCM_RECHUNK_BSF 0
++#define CONFIG_PGS_FRAME_MERGE_BSF 0
++#define CONFIG_PRORES_METADATA_BSF 0
++#define CONFIG_REMOVE_EXTRADATA_BSF 0
++#define CONFIG_SETTS_BSF 0
++#define CONFIG_SHOWINFO_BSF 0
++#define CONFIG_TEXT2MOVSUB_BSF 0
++#define CONFIG_TRACE_HEADERS_BSF 0
++#define CONFIG_TRUEHD_CORE_BSF 0
++#define CONFIG_VP9_METADATA_BSF 0
++#define CONFIG_VP9_RAW_REORDER_BSF 0
++#define CONFIG_VP9_SUPERFRAME_BSF 0
++#define CONFIG_VP9_SUPERFRAME_SPLIT_BSF 0
++#define CONFIG_VVC_METADATA_BSF 0
++#define CONFIG_VVC_MP4TOANNEXB_BSF 0
++#define CONFIG_EVC_FRAME_MERGE_BSF 0
++#define CONFIG_AASC_DECODER 0
++#define CONFIG_AIC_DECODER 0
++#define CONFIG_ALIAS_PIX_DECODER 0
++#define CONFIG_AGM_DECODER 0
++#define CONFIG_AMV_DECODER 0
++#define CONFIG_ANM_DECODER 0
++#define CONFIG_ANSI_DECODER 0
++#define CONFIG_APNG_DECODER 0
++#define CONFIG_ARBC_DECODER 0
++#define CONFIG_ARGO_DECODER 0
++#define CONFIG_ASV1_DECODER 0
++#define CONFIG_ASV2_DECODER 0
++#define CONFIG_AURA_DECODER 0
++#define CONFIG_AURA2_DECODER 0
++#define CONFIG_AVRP_DECODER 0
++#define CONFIG_AVRN_DECODER 0
++#define CONFIG_AVS_DECODER 0
++#define CONFIG_AVUI_DECODER 0
++#define CONFIG_AYUV_DECODER 0
++#define CONFIG_BETHSOFTVID_DECODER 0
++#define CONFIG_BFI_DECODER 0
++#define CONFIG_BINK_DECODER 0
++#define CONFIG_BITPACKED_DECODER 0
++#define CONFIG_BMP_DECODER 0
++#define CONFIG_BMV_VIDEO_DECODER 0
++#define CONFIG_BRENDER_PIX_DECODER 0
++#define CONFIG_C93_DECODER 0
++#define CONFIG_CAVS_DECODER 0
++#define CONFIG_CDGRAPHICS_DECODER 0
++#define CONFIG_CDTOONS_DECODER 0
++#define CONFIG_CDXL_DECODER 0
++#define CONFIG_CFHD_DECODER 0
++#define CONFIG_CINEPAK_DECODER 0
++#define CONFIG_CLEARVIDEO_DECODER 0
++#define CONFIG_CLJR_DECODER 0
++#define CONFIG_CLLC_DECODER 0
++#define CONFIG_COMFORTNOISE_DECODER 0
++#define CONFIG_CPIA_DECODER 0
++#define CONFIG_CRI_DECODER 0
++#define CONFIG_CSCD_DECODER 0
++#define CONFIG_CYUV_DECODER 0
++#define CONFIG_DDS_DECODER 0
++#define CONFIG_DFA_DECODER 0
++#define CONFIG_DIRAC_DECODER 0
++#define CONFIG_DNXHD_DECODER 0
++#define CONFIG_DPX_DECODER 0
++#define CONFIG_DSICINVIDEO_DECODER 0
++#define CONFIG_DVAUDIO_DECODER 0
++#define CONFIG_DVVIDEO_DECODER 0
++#define CONFIG_DXA_DECODER 0
++#define CONFIG_DXTORY_DECODER 0
++#define CONFIG_DXV_DECODER 0
++#define CONFIG_EACMV_DECODER 0
++#define CONFIG_EAMAD_DECODER 0
++#define CONFIG_EATGQ_DECODER 0
++#define CONFIG_EATGV_DECODER 0
++#define CONFIG_EATQI_DECODER 0
++#define CONFIG_EIGHTBPS_DECODER 0
++#define CONFIG_EIGHTSVX_EXP_DECODER 0
++#define CONFIG_EIGHTSVX_FIB_DECODER 0
++#define CONFIG_ESCAPE124_DECODER 0
++#define CONFIG_ESCAPE130_DECODER 0
++#define CONFIG_EXR_DECODER 0
++#define CONFIG_FFV1_DECODER 0
++#define CONFIG_FFVHUFF_DECODER 0
++#define CONFIG_FIC_DECODER 0
++#define CONFIG_FITS_DECODER 0
++#define CONFIG_FLASHSV_DECODER 0
++#define CONFIG_FLASHSV2_DECODER 0
++#define CONFIG_FLIC_DECODER 0
++#define CONFIG_FLV_DECODER 0
++#define CONFIG_FMVC_DECODER 0
++#define CONFIG_FOURXM_DECODER 0
++#define CONFIG_FRAPS_DECODER 0
++#define CONFIG_FRWU_DECODER 0
++#define CONFIG_G2M_DECODER 0
++#define CONFIG_GDV_DECODER 0
++#define CONFIG_GEM_DECODER 0
++#define CONFIG_GIF_DECODER 0
++#define CONFIG_H261_DECODER 0
++#define CONFIG_H263_DECODER 0
++#define CONFIG_H263I_DECODER 0
++#define CONFIG_H263P_DECODER 0
++#define CONFIG_H263_V4L2M2M_DECODER 0
++#define CONFIG_H264_DECODER 1
++#define CONFIG_H264_CRYSTALHD_DECODER 0
++#define CONFIG_H264_V4L2M2M_DECODER 0
++#define CONFIG_H264_MEDIACODEC_DECODER 0
++#define CONFIG_H264_MMAL_DECODER 0
++#define CONFIG_H264_QSV_DECODER 0
++#define CONFIG_H264_RKMPP_DECODER 0
++#define CONFIG_HAP_DECODER 0
++#define CONFIG_HEVC_DECODER 0
++#define CONFIG_HEVC_QSV_DECODER 0
++#define CONFIG_HEVC_RKMPP_DECODER 0
++#define CONFIG_HEVC_V4L2M2M_DECODER 0
++#define CONFIG_HNM4_VIDEO_DECODER 0
++#define CONFIG_HQ_HQA_DECODER 0
++#define CONFIG_HQX_DECODER 0
++#define CONFIG_HUFFYUV_DECODER 0
++#define CONFIG_HYMT_DECODER 0
++#define CONFIG_IDCIN_DECODER 0
++#define CONFIG_IFF_ILBM_DECODER 0
++#define CONFIG_IMM4_DECODER 0
++#define CONFIG_IMM5_DECODER 0
++#define CONFIG_INDEO2_DECODER 0
++#define CONFIG_INDEO3_DECODER 0
++#define CONFIG_INDEO4_DECODER 0
++#define CONFIG_INDEO5_DECODER 0
++#define CONFIG_INTERPLAY_VIDEO_DECODER 0
++#define CONFIG_IPU_DECODER 0
++#define CONFIG_JPEG2000_DECODER 0
++#define CONFIG_JPEGLS_DECODER 0
++#define CONFIG_JV_DECODER 0
++#define CONFIG_KGV1_DECODER 0
++#define CONFIG_KMVC_DECODER 0
++#define CONFIG_LAGARITH_DECODER 0
++#define CONFIG_LEAD_DECODER 0
++#define CONFIG_LOCO_DECODER 0
++#define CONFIG_LSCR_DECODER 0
++#define CONFIG_M101_DECODER 0
++#define CONFIG_MAGICYUV_DECODER 0
++#define CONFIG_MDEC_DECODER 0
++#define CONFIG_MEDIA100_DECODER 0
++#define CONFIG_MIMIC_DECODER 0
++#define CONFIG_MJPEG_DECODER 0
++#define CONFIG_MJPEGB_DECODER 0
++#define CONFIG_MMVIDEO_DECODER 0
++#define CONFIG_MOBICLIP_DECODER 0
++#define CONFIG_MOTIONPIXELS_DECODER 0
++#define CONFIG_MPEG1VIDEO_DECODER 0
++#define CONFIG_MPEG2VIDEO_DECODER 0
++#define CONFIG_MPEG4_DECODER 0
++#define CONFIG_MPEG4_CRYSTALHD_DECODER 0
++#define CONFIG_MPEG4_V4L2M2M_DECODER 0
++#define CONFIG_MPEG4_MMAL_DECODER 0
++#define CONFIG_MPEGVIDEO_DECODER 0
++#define CONFIG_MPEG1_V4L2M2M_DECODER 0
++#define CONFIG_MPEG2_MMAL_DECODER 0
++#define CONFIG_MPEG2_CRYSTALHD_DECODER 0
++#define CONFIG_MPEG2_V4L2M2M_DECODER 0
++#define CONFIG_MPEG2_QSV_DECODER 0
++#define CONFIG_MPEG2_MEDIACODEC_DECODER 0
++#define CONFIG_MSA1_DECODER 0
++#define CONFIG_MSCC_DECODER 0
++#define CONFIG_MSMPEG4V1_DECODER 0
++#define CONFIG_MSMPEG4V2_DECODER 0
++#define CONFIG_MSMPEG4V3_DECODER 0
++#define CONFIG_MSMPEG4_CRYSTALHD_DECODER 0
++#define CONFIG_MSP2_DECODER 0
++#define CONFIG_MSRLE_DECODER 0
++#define CONFIG_MSS1_DECODER 0
++#define CONFIG_MSS2_DECODER 0
++#define CONFIG_MSVIDEO1_DECODER 0
++#define CONFIG_MSZH_DECODER 0
++#define CONFIG_MTS2_DECODER 0
++#define CONFIG_MV30_DECODER 0
++#define CONFIG_MVC1_DECODER 0
++#define CONFIG_MVC2_DECODER 0
++#define CONFIG_MVDV_DECODER 0
++#define CONFIG_MVHA_DECODER 0
++#define CONFIG_MWSC_DECODER 0
++#define CONFIG_MXPEG_DECODER 0
++#define CONFIG_NOTCHLC_DECODER 0
++#define CONFIG_NUV_DECODER 0
++#define CONFIG_PAF_VIDEO_DECODER 0
++#define CONFIG_PAM_DECODER 0
++#define CONFIG_PBM_DECODER 0
++#define CONFIG_PCX_DECODER 0
++#define CONFIG_PDV_DECODER 0
++#define CONFIG_PFM_DECODER 0
++#define CONFIG_PGM_DECODER 0
++#define CONFIG_PGMYUV_DECODER 0
++#define CONFIG_PGX_DECODER 0
++#define CONFIG_PHM_DECODER 0
++#define CONFIG_PHOTOCD_DECODER 0
++#define CONFIG_PICTOR_DECODER 0
++#define CONFIG_PIXLET_DECODER 0
++#define CONFIG_PNG_DECODER 0
++#define CONFIG_PPM_DECODER 0
++#define CONFIG_PRORES_DECODER 0
++#define CONFIG_PROSUMER_DECODER 0
++#define CONFIG_PSD_DECODER 0
++#define CONFIG_PTX_DECODER 0
++#define CONFIG_QDRAW_DECODER 0
++#define CONFIG_QOI_DECODER 0
++#define CONFIG_QPEG_DECODER 0
++#define CONFIG_QTRLE_DECODER 0
++#define CONFIG_R10K_DECODER 0
++#define CONFIG_R210_DECODER 0
++#define CONFIG_RASC_DECODER 0
++#define CONFIG_RAWVIDEO_DECODER 0
++#define CONFIG_RKA_DECODER 0
++#define CONFIG_RL2_DECODER 0
++#define CONFIG_ROQ_DECODER 0
++#define CONFIG_RPZA_DECODER 0
++#define CONFIG_RSCC_DECODER 0
++#define CONFIG_RTV1_DECODER 0
++#define CONFIG_RV10_DECODER 0
++#define CONFIG_RV20_DECODER 0
++#define CONFIG_RV30_DECODER 0
++#define CONFIG_RV40_DECODER 0
++#define CONFIG_S302M_DECODER 0
++#define CONFIG_SANM_DECODER 0
++#define CONFIG_SCPR_DECODER 0
++#define CONFIG_SCREENPRESSO_DECODER 0
++#define CONFIG_SGA_DECODER 0
++#define CONFIG_SGI_DECODER 0
++#define CONFIG_SGIRLE_DECODER 0
++#define CONFIG_SHEERVIDEO_DECODER 0
++#define CONFIG_SIMBIOSIS_IMX_DECODER 0
++#define CONFIG_SMACKER_DECODER 0
++#define CONFIG_SMC_DECODER 0
++#define CONFIG_SMVJPEG_DECODER 0
++#define CONFIG_SNOW_DECODER 0
++#define CONFIG_SP5X_DECODER 0
++#define CONFIG_SPEEDHQ_DECODER 0
++#define CONFIG_SPEEX_DECODER 0
++#define CONFIG_SRGC_DECODER 0
++#define CONFIG_SUNRAST_DECODER 0
++#define CONFIG_SVQ1_DECODER 0
++#define CONFIG_SVQ3_DECODER 0
++#define CONFIG_TARGA_DECODER 0
++#define CONFIG_TARGA_Y216_DECODER 0
++#define CONFIG_TDSC_DECODER 0
++#define CONFIG_THEORA_DECODER 0
++#define CONFIG_THP_DECODER 0
++#define CONFIG_TIERTEXSEQVIDEO_DECODER 0
++#define CONFIG_TIFF_DECODER 0
++#define CONFIG_TMV_DECODER 0
++#define CONFIG_TRUEMOTION1_DECODER 0
++#define CONFIG_TRUEMOTION2_DECODER 0
++#define CONFIG_TRUEMOTION2RT_DECODER 0
++#define CONFIG_TSCC_DECODER 0
++#define CONFIG_TSCC2_DECODER 0
++#define CONFIG_TXD_DECODER 0
++#define CONFIG_ULTI_DECODER 0
++#define CONFIG_UTVIDEO_DECODER 0
++#define CONFIG_V210_DECODER 0
++#define CONFIG_V210X_DECODER 0
++#define CONFIG_V308_DECODER 0
++#define CONFIG_V408_DECODER 0
++#define CONFIG_V410_DECODER 0
++#define CONFIG_VB_DECODER 0
++#define CONFIG_VBN_DECODER 0
++#define CONFIG_VBLE_DECODER 0
++#define CONFIG_VC1_DECODER 0
++#define CONFIG_VC1_CRYSTALHD_DECODER 0
++#define CONFIG_VC1IMAGE_DECODER 0
++#define CONFIG_VC1_MMAL_DECODER 0
++#define CONFIG_VC1_QSV_DECODER 0
++#define CONFIG_VC1_V4L2M2M_DECODER 0
++#define CONFIG_VCR1_DECODER 0
++#define CONFIG_VMDVIDEO_DECODER 0
++#define CONFIG_VMIX_DECODER 0
++#define CONFIG_VMNC_DECODER 0
++#define CONFIG_VP3_DECODER 0
++#define CONFIG_VP4_DECODER 0
++#define CONFIG_VP5_DECODER 0
++#define CONFIG_VP6_DECODER 0
++#define CONFIG_VP6A_DECODER 0
++#define CONFIG_VP6F_DECODER 0
++#define CONFIG_VP7_DECODER 0
++#define CONFIG_VP8_DECODER 0
++#define CONFIG_VP8_RKMPP_DECODER 0
++#define CONFIG_VP8_V4L2M2M_DECODER 0
++#define CONFIG_VP9_DECODER 0
++#define CONFIG_VP9_RKMPP_DECODER 0
++#define CONFIG_VP9_V4L2M2M_DECODER 0
++#define CONFIG_VQA_DECODER 0
++#define CONFIG_VQC_DECODER 0
++#define CONFIG_VVC_DECODER 0
++#define CONFIG_WBMP_DECODER 0
++#define CONFIG_WEBP_DECODER 0
++#define CONFIG_WCMV_DECODER 0
++#define CONFIG_WRAPPED_AVFRAME_DECODER 0
++#define CONFIG_WMV1_DECODER 0
++#define CONFIG_WMV2_DECODER 0
++#define CONFIG_WMV3_DECODER 0
++#define CONFIG_WMV3_CRYSTALHD_DECODER 0
++#define CONFIG_WMV3IMAGE_DECODER 0
++#define CONFIG_WNV1_DECODER 0
++#define CONFIG_XAN_WC3_DECODER 0
++#define CONFIG_XAN_WC4_DECODER 0
++#define CONFIG_XBM_DECODER 0
++#define CONFIG_XFACE_DECODER 0
++#define CONFIG_XL_DECODER 0
++#define CONFIG_XPM_DECODER 0
++#define CONFIG_XWD_DECODER 0
++#define CONFIG_Y41P_DECODER 0
++#define CONFIG_YLC_DECODER 0
++#define CONFIG_YOP_DECODER 0
++#define CONFIG_YUV4_DECODER 0
++#define CONFIG_ZERO12V_DECODER 0
++#define CONFIG_ZEROCODEC_DECODER 0
++#define CONFIG_ZLIB_DECODER 0
++#define CONFIG_ZMBV_DECODER 0
++#define CONFIG_AAC_DECODER 1
++#define CONFIG_AAC_FIXED_DECODER 0
++#define CONFIG_AAC_LATM_DECODER 0
++#define CONFIG_AC3_DECODER 0
++#define CONFIG_AC3_FIXED_DECODER 0
++#define CONFIG_ACELP_KELVIN_DECODER 0
++#define CONFIG_ALAC_DECODER 0
++#define CONFIG_ALS_DECODER 0
++#define CONFIG_AMRNB_DECODER 0
++#define CONFIG_AMRWB_DECODER 0
++#define CONFIG_APAC_DECODER 0
++#define CONFIG_APE_DECODER 0
++#define CONFIG_APTX_DECODER 0
++#define CONFIG_APTX_HD_DECODER 0
++#define CONFIG_ATRAC1_DECODER 0
++#define CONFIG_ATRAC3_DECODER 0
++#define CONFIG_ATRAC3AL_DECODER 0
++#define CONFIG_ATRAC3P_DECODER 0
++#define CONFIG_ATRAC3PAL_DECODER 0
++#define CONFIG_ATRAC9_DECODER 0
++#define CONFIG_BINKAUDIO_DCT_DECODER 0
++#define CONFIG_BINKAUDIO_RDFT_DECODER 0
++#define CONFIG_BMV_AUDIO_DECODER 0
++#define CONFIG_BONK_DECODER 0
++#define CONFIG_COOK_DECODER 0
++#define CONFIG_DCA_DECODER 0
++#define CONFIG_DFPWM_DECODER 0
++#define CONFIG_DOLBY_E_DECODER 0
++#define CONFIG_DSD_LSBF_DECODER 0
++#define CONFIG_DSD_MSBF_DECODER 0
++#define CONFIG_DSD_LSBF_PLANAR_DECODER 0
++#define CONFIG_DSD_MSBF_PLANAR_DECODER 0
++#define CONFIG_DSICINAUDIO_DECODER 0
++#define CONFIG_DSS_SP_DECODER 0
++#define CONFIG_DST_DECODER 0
++#define CONFIG_EAC3_DECODER 0
++#define CONFIG_EVRC_DECODER 0
++#define CONFIG_FASTAUDIO_DECODER 0
++#define CONFIG_FFWAVESYNTH_DECODER 0
++#define CONFIG_FLAC_DECODER 1
++#define CONFIG_FTR_DECODER 0
++#define CONFIG_G723_1_DECODER 0
++#define CONFIG_G729_DECODER 0
++#define CONFIG_GSM_DECODER 0
++#define CONFIG_GSM_MS_DECODER 0
++#define CONFIG_HCA_DECODER 0
++#define CONFIG_HCOM_DECODER 0
++#define CONFIG_HDR_DECODER 0
++#define CONFIG_IAC_DECODER 0
++#define CONFIG_ILBC_DECODER 0
++#define CONFIG_IMC_DECODER 0
++#define CONFIG_INTERPLAY_ACM_DECODER 0
++#define CONFIG_MACE3_DECODER 0
++#define CONFIG_MACE6_DECODER 0
++#define CONFIG_METASOUND_DECODER 0
++#define CONFIG_MISC4_DECODER 0
++#define CONFIG_MLP_DECODER 0
++#define CONFIG_MP1_DECODER 0
++#define CONFIG_MP1FLOAT_DECODER 0
++#define CONFIG_MP2_DECODER 0
++#define CONFIG_MP2FLOAT_DECODER 0
++#define CONFIG_MP3FLOAT_DECODER 0
++#define CONFIG_MP3_DECODER 1
++#define CONFIG_MP3ADUFLOAT_DECODER 0
++#define CONFIG_MP3ADU_DECODER 0
++#define CONFIG_MP3ON4FLOAT_DECODER 0
++#define CONFIG_MP3ON4_DECODER 0
++#define CONFIG_MPC7_DECODER 0
++#define CONFIG_MPC8_DECODER 0
++#define CONFIG_MSNSIREN_DECODER 0
++#define CONFIG_NELLYMOSER_DECODER 0
++#define CONFIG_ON2AVC_DECODER 0
++#define CONFIG_OPUS_DECODER 0
++#define CONFIG_OSQ_DECODER 0
++#define CONFIG_PAF_AUDIO_DECODER 0
++#define CONFIG_QCELP_DECODER 0
++#define CONFIG_QDM2_DECODER 0
++#define CONFIG_QDMC_DECODER 0
++#define CONFIG_QOA_DECODER 0
++#define CONFIG_RA_144_DECODER 0
++#define CONFIG_RA_288_DECODER 0
++#define CONFIG_RALF_DECODER 0
++#define CONFIG_SBC_DECODER 0
++#define CONFIG_SHORTEN_DECODER 0
++#define CONFIG_SIPR_DECODER 0
++#define CONFIG_SIREN_DECODER 0
++#define CONFIG_SMACKAUD_DECODER 0
++#define CONFIG_SONIC_DECODER 0
++#define CONFIG_TAK_DECODER 0
++#define CONFIG_TRUEHD_DECODER 0
++#define CONFIG_TRUESPEECH_DECODER 0
++#define CONFIG_TTA_DECODER 0
++#define CONFIG_TWINVQ_DECODER 0
++#define CONFIG_VMDAUDIO_DECODER 0
++#define CONFIG_VORBIS_DECODER 1
++#define CONFIG_WAVARC_DECODER 0
++#define CONFIG_WAVPACK_DECODER 0
++#define CONFIG_WMALOSSLESS_DECODER 0
++#define CONFIG_WMAPRO_DECODER 0
++#define CONFIG_WMAV1_DECODER 0
++#define CONFIG_WMAV2_DECODER 0
++#define CONFIG_WMAVOICE_DECODER 0
++#define CONFIG_WS_SND1_DECODER 0
++#define CONFIG_XMA1_DECODER 0
++#define CONFIG_XMA2_DECODER 0
++#define CONFIG_PCM_ALAW_DECODER 1
++#define CONFIG_PCM_BLURAY_DECODER 0
++#define CONFIG_PCM_DVD_DECODER 0
++#define CONFIG_PCM_F16LE_DECODER 0
++#define CONFIG_PCM_F24LE_DECODER 0
++#define CONFIG_PCM_F32BE_DECODER 0
++#define CONFIG_PCM_F32LE_DECODER 1
++#define CONFIG_PCM_F64BE_DECODER 0
++#define CONFIG_PCM_F64LE_DECODER 0
++#define CONFIG_PCM_LXF_DECODER 0
++#define CONFIG_PCM_MULAW_DECODER 1
++#define CONFIG_PCM_S8_DECODER 0
++#define CONFIG_PCM_S8_PLANAR_DECODER 0
++#define CONFIG_PCM_S16BE_DECODER 1
++#define CONFIG_PCM_S16BE_PLANAR_DECODER 0
++#define CONFIG_PCM_S16LE_DECODER 1
++#define CONFIG_PCM_S16LE_PLANAR_DECODER 0
++#define CONFIG_PCM_S24BE_DECODER 1
++#define CONFIG_PCM_S24DAUD_DECODER 0
++#define CONFIG_PCM_S24LE_DECODER 1
++#define CONFIG_PCM_S24LE_PLANAR_DECODER 0
++#define CONFIG_PCM_S32BE_DECODER 0
++#define CONFIG_PCM_S32LE_DECODER 1
++#define CONFIG_PCM_S32LE_PLANAR_DECODER 0
++#define CONFIG_PCM_S64BE_DECODER 0
++#define CONFIG_PCM_S64LE_DECODER 0
++#define CONFIG_PCM_SGA_DECODER 0
++#define CONFIG_PCM_U8_DECODER 1
++#define CONFIG_PCM_U16BE_DECODER 0
++#define CONFIG_PCM_U16LE_DECODER 0
++#define CONFIG_PCM_U24BE_DECODER 0
++#define CONFIG_PCM_U24LE_DECODER 0
++#define CONFIG_PCM_U32BE_DECODER 0
++#define CONFIG_PCM_U32LE_DECODER 0
++#define CONFIG_PCM_VIDC_DECODER 0
++#define CONFIG_CBD2_DPCM_DECODER 0
++#define CONFIG_DERF_DPCM_DECODER 0
++#define CONFIG_GREMLIN_DPCM_DECODER 0
++#define CONFIG_INTERPLAY_DPCM_DECODER 0
++#define CONFIG_ROQ_DPCM_DECODER 0
++#define CONFIG_SDX2_DPCM_DECODER 0
++#define CONFIG_SOL_DPCM_DECODER 0
++#define CONFIG_XAN_DPCM_DECODER 0
++#define CONFIG_WADY_DPCM_DECODER 0
++#define CONFIG_ADPCM_4XM_DECODER 0
++#define CONFIG_ADPCM_ADX_DECODER 0
++#define CONFIG_ADPCM_AFC_DECODER 0
++#define CONFIG_ADPCM_AGM_DECODER 0
++#define CONFIG_ADPCM_AICA_DECODER 0
++#define CONFIG_ADPCM_ARGO_DECODER 0
++#define CONFIG_ADPCM_CT_DECODER 0
++#define CONFIG_ADPCM_DTK_DECODER 0
++#define CONFIG_ADPCM_EA_DECODER 0
++#define CONFIG_ADPCM_EA_MAXIS_XA_DECODER 0
++#define CONFIG_ADPCM_EA_R1_DECODER 0
++#define CONFIG_ADPCM_EA_R2_DECODER 0
++#define CONFIG_ADPCM_EA_R3_DECODER 0
++#define CONFIG_ADPCM_EA_XAS_DECODER 0
++#define CONFIG_ADPCM_G722_DECODER 0
++#define CONFIG_ADPCM_G726_DECODER 0
++#define CONFIG_ADPCM_G726LE_DECODER 0
++#define CONFIG_ADPCM_IMA_ACORN_DECODER 0
++#define CONFIG_ADPCM_IMA_AMV_DECODER 0
++#define CONFIG_ADPCM_IMA_ALP_DECODER 0
++#define CONFIG_ADPCM_IMA_APC_DECODER 0
++#define CONFIG_ADPCM_IMA_APM_DECODER 0
++#define CONFIG_ADPCM_IMA_CUNNING_DECODER 0
++#define CONFIG_ADPCM_IMA_DAT4_DECODER 0
++#define CONFIG_ADPCM_IMA_DK3_DECODER 0
++#define CONFIG_ADPCM_IMA_DK4_DECODER 0
++#define CONFIG_ADPCM_IMA_EA_EACS_DECODER 0
++#define CONFIG_ADPCM_IMA_EA_SEAD_DECODER 0
++#define CONFIG_ADPCM_IMA_ISS_DECODER 0
++#define CONFIG_ADPCM_IMA_MOFLEX_DECODER 0
++#define CONFIG_ADPCM_IMA_MTF_DECODER 0
++#define CONFIG_ADPCM_IMA_OKI_DECODER 0
++#define CONFIG_ADPCM_IMA_QT_DECODER 0
++#define CONFIG_ADPCM_IMA_RAD_DECODER 0
++#define CONFIG_ADPCM_IMA_SSI_DECODER 0
++#define CONFIG_ADPCM_IMA_SMJPEG_DECODER 0
++#define CONFIG_ADPCM_IMA_WAV_DECODER 0
++#define CONFIG_ADPCM_IMA_WS_DECODER 0
++#define CONFIG_ADPCM_MS_DECODER 0
++#define CONFIG_ADPCM_MTAF_DECODER 0
++#define CONFIG_ADPCM_PSX_DECODER 0
++#define CONFIG_ADPCM_SBPRO_2_DECODER 0
++#define CONFIG_ADPCM_SBPRO_3_DECODER 0
++#define CONFIG_ADPCM_SBPRO_4_DECODER 0
++#define CONFIG_ADPCM_SWF_DECODER 0
++#define CONFIG_ADPCM_THP_DECODER 0
++#define CONFIG_ADPCM_THP_LE_DECODER 0
++#define CONFIG_ADPCM_VIMA_DECODER 0
++#define CONFIG_ADPCM_XA_DECODER 0
++#define CONFIG_ADPCM_XMD_DECODER 0
++#define CONFIG_ADPCM_YAMAHA_DECODER 0
++#define CONFIG_ADPCM_ZORK_DECODER 0
++#define CONFIG_SSA_DECODER 0
++#define CONFIG_ASS_DECODER 0
++#define CONFIG_CCAPTION_DECODER 0
++#define CONFIG_DVBSUB_DECODER 0
++#define CONFIG_DVDSUB_DECODER 0
++#define CONFIG_JACOSUB_DECODER 0
++#define CONFIG_MICRODVD_DECODER 0
++#define CONFIG_MOVTEXT_DECODER 0
++#define CONFIG_MPL2_DECODER 0
++#define CONFIG_PGSSUB_DECODER 0
++#define CONFIG_PJS_DECODER 0
++#define CONFIG_REALTEXT_DECODER 0
++#define CONFIG_SAMI_DECODER 0
++#define CONFIG_SRT_DECODER 0
++#define CONFIG_STL_DECODER 0
++#define CONFIG_SUBRIP_DECODER 0
++#define CONFIG_SUBVIEWER_DECODER 0
++#define CONFIG_SUBVIEWER1_DECODER 0
++#define CONFIG_TEXT_DECODER 0
++#define CONFIG_VPLAYER_DECODER 0
++#define CONFIG_WEBVTT_DECODER 0
++#define CONFIG_XSUB_DECODER 0
++#define CONFIG_AAC_AT_DECODER 0
++#define CONFIG_AC3_AT_DECODER 0
++#define CONFIG_ADPCM_IMA_QT_AT_DECODER 0
++#define CONFIG_ALAC_AT_DECODER 0
++#define CONFIG_AMR_NB_AT_DECODER 0
++#define CONFIG_EAC3_AT_DECODER 0
++#define CONFIG_GSM_MS_AT_DECODER 0
++#define CONFIG_ILBC_AT_DECODER 0
++#define CONFIG_MP1_AT_DECODER 0
++#define CONFIG_MP2_AT_DECODER 0
++#define CONFIG_MP3_AT_DECODER 0
++#define CONFIG_PCM_ALAW_AT_DECODER 0
++#define CONFIG_PCM_MULAW_AT_DECODER 0
++#define CONFIG_QDMC_AT_DECODER 0
++#define CONFIG_QDM2_AT_DECODER 0
++#define CONFIG_LIBARIBCAPTION_DECODER 0
++#define CONFIG_LIBARIBB24_DECODER 0
++#define CONFIG_LIBCELT_DECODER 0
++#define CONFIG_LIBCODEC2_DECODER 0
++#define CONFIG_LIBDAV1D_DECODER 0
++#define CONFIG_LIBDAVS2_DECODER 0
++#define CONFIG_LIBFDK_AAC_DECODER 0
++#define CONFIG_LIBGSM_DECODER 0
++#define CONFIG_LIBGSM_MS_DECODER 0
++#define CONFIG_LIBILBC_DECODER 0
++#define CONFIG_LIBJXL_DECODER 0
++#define CONFIG_LIBOPENCORE_AMRNB_DECODER 0
++#define CONFIG_LIBOPENCORE_AMRWB_DECODER 0
++#define CONFIG_LIBOPUS_DECODER 1
++#define CONFIG_LIBRSVG_DECODER 0
++#define CONFIG_LIBSPEEX_DECODER 0
++#define CONFIG_LIBUAVS3D_DECODER 0
++#define CONFIG_LIBVORBIS_DECODER 0
++#define CONFIG_LIBVPX_VP8_DECODER 0
++#define CONFIG_LIBVPX_VP9_DECODER 0
++#define CONFIG_LIBXEVD_DECODER 0
++#define CONFIG_LIBZVBI_TELETEXT_DECODER 0
++#define CONFIG_BINTEXT_DECODER 0
++#define CONFIG_XBIN_DECODER 0
++#define CONFIG_IDF_DECODER 0
++#define CONFIG_LIBAOM_AV1_DECODER 0
++#define CONFIG_AV1_DECODER 0
++#define CONFIG_AV1_CUVID_DECODER 0
++#define CONFIG_AV1_MEDIACODEC_DECODER 0
++#define CONFIG_AV1_QSV_DECODER 0
++#define CONFIG_LIBOPENH264_DECODER 0
++#define CONFIG_H264_CUVID_DECODER 0
++#define CONFIG_HEVC_CUVID_DECODER 0
++#define CONFIG_HEVC_MEDIACODEC_DECODER 0
++#define CONFIG_MJPEG_CUVID_DECODER 0
++#define CONFIG_MJPEG_QSV_DECODER 0
++#define CONFIG_MPEG1_CUVID_DECODER 0
++#define CONFIG_MPEG2_CUVID_DECODER 0
++#define CONFIG_MPEG4_CUVID_DECODER 0
++#define CONFIG_MPEG4_MEDIACODEC_DECODER 0
++#define CONFIG_VC1_CUVID_DECODER 0
++#define CONFIG_VP8_CUVID_DECODER 0
++#define CONFIG_VP8_MEDIACODEC_DECODER 0
++#define CONFIG_VP8_QSV_DECODER 0
++#define CONFIG_VP9_CUVID_DECODER 0
++#define CONFIG_VP9_MEDIACODEC_DECODER 0
++#define CONFIG_VP9_QSV_DECODER 0
++#define CONFIG_VNULL_DECODER 0
++#define CONFIG_ANULL_DECODER 0
++#define CONFIG_A64MULTI_ENCODER 0
++#define CONFIG_A64MULTI5_ENCODER 0
++#define CONFIG_ALIAS_PIX_ENCODER 0
++#define CONFIG_AMV_ENCODER 0
++#define CONFIG_APNG_ENCODER 0
++#define CONFIG_ASV1_ENCODER 0
++#define CONFIG_ASV2_ENCODER 0
++#define CONFIG_AVRP_ENCODER 0
++#define CONFIG_AVUI_ENCODER 0
++#define CONFIG_AYUV_ENCODER 0
++#define CONFIG_BITPACKED_ENCODER 0
++#define CONFIG_BMP_ENCODER 0
++#define CONFIG_CFHD_ENCODER 0
++#define CONFIG_CINEPAK_ENCODER 0
++#define CONFIG_CLJR_ENCODER 0
++#define CONFIG_COMFORTNOISE_ENCODER 0
++#define CONFIG_DNXHD_ENCODER 0
++#define CONFIG_DPX_ENCODER 0
++#define CONFIG_DVVIDEO_ENCODER 0
++#define CONFIG_DXV_ENCODER 0
++#define CONFIG_EXR_ENCODER 0
++#define CONFIG_FFV1_ENCODER 0
++#define CONFIG_FFVHUFF_ENCODER 0
++#define CONFIG_FITS_ENCODER 0
++#define CONFIG_FLASHSV_ENCODER 0
++#define CONFIG_FLASHSV2_ENCODER 0
++#define CONFIG_FLV_ENCODER 0
++#define CONFIG_GIF_ENCODER 0
++#define CONFIG_H261_ENCODER 0
++#define CONFIG_H263_ENCODER 0
++#define CONFIG_H263P_ENCODER 0
++#define CONFIG_H264_MEDIACODEC_ENCODER 0
++#define CONFIG_HAP_ENCODER 0
++#define CONFIG_HUFFYUV_ENCODER 0
++#define CONFIG_JPEG2000_ENCODER 0
++#define CONFIG_JPEGLS_ENCODER 0
++#define CONFIG_LJPEG_ENCODER 0
++#define CONFIG_MAGICYUV_ENCODER 0
++#define CONFIG_MJPEG_ENCODER 0
++#define CONFIG_MPEG1VIDEO_ENCODER 0
++#define CONFIG_MPEG2VIDEO_ENCODER 0
++#define CONFIG_MPEG4_ENCODER 0
++#define CONFIG_MSMPEG4V2_ENCODER 0
++#define CONFIG_MSMPEG4V3_ENCODER 0
++#define CONFIG_MSRLE_ENCODER 0
++#define CONFIG_MSVIDEO1_ENCODER 0
++#define CONFIG_PAM_ENCODER 0
++#define CONFIG_PBM_ENCODER 0
++#define CONFIG_PCX_ENCODER 0
++#define CONFIG_PFM_ENCODER 0
++#define CONFIG_PGM_ENCODER 0
++#define CONFIG_PGMYUV_ENCODER 0
++#define CONFIG_PHM_ENCODER 0
++#define CONFIG_PNG_ENCODER 0
++#define CONFIG_PPM_ENCODER 0
++#define CONFIG_PRORES_ENCODER 0
++#define CONFIG_PRORES_AW_ENCODER 0
++#define CONFIG_PRORES_KS_ENCODER 0
++#define CONFIG_QOI_ENCODER 0
++#define CONFIG_QTRLE_ENCODER 0
++#define CONFIG_R10K_ENCODER 0
++#define CONFIG_R210_ENCODER 0
++#define CONFIG_RAWVIDEO_ENCODER 0
++#define CONFIG_ROQ_ENCODER 0
++#define CONFIG_RPZA_ENCODER 0
++#define CONFIG_RV10_ENCODER 0
++#define CONFIG_RV20_ENCODER 0
++#define CONFIG_S302M_ENCODER 0
++#define CONFIG_SGI_ENCODER 0
++#define CONFIG_SMC_ENCODER 0
++#define CONFIG_SNOW_ENCODER 0
++#define CONFIG_SPEEDHQ_ENCODER 0
++#define CONFIG_SUNRAST_ENCODER 0
++#define CONFIG_SVQ1_ENCODER 0
++#define CONFIG_TARGA_ENCODER 0
++#define CONFIG_TIFF_ENCODER 0
++#define CONFIG_UTVIDEO_ENCODER 0
++#define CONFIG_V210_ENCODER 0
++#define CONFIG_V308_ENCODER 0
++#define CONFIG_V408_ENCODER 0
++#define CONFIG_V410_ENCODER 0
++#define CONFIG_VBN_ENCODER 0
++#define CONFIG_VC2_ENCODER 0
++#define CONFIG_WBMP_ENCODER 0
++#define CONFIG_WRAPPED_AVFRAME_ENCODER 0
++#define CONFIG_WMV1_ENCODER 0
++#define CONFIG_WMV2_ENCODER 0
++#define CONFIG_XBM_ENCODER 0
++#define CONFIG_XFACE_ENCODER 0
++#define CONFIG_XWD_ENCODER 0
++#define CONFIG_Y41P_ENCODER 0
++#define CONFIG_YUV4_ENCODER 0
++#define CONFIG_ZLIB_ENCODER 0
++#define CONFIG_ZMBV_ENCODER 0
++#define CONFIG_AAC_ENCODER 0
++#define CONFIG_AC3_ENCODER 0
++#define CONFIG_AC3_FIXED_ENCODER 0
++#define CONFIG_ALAC_ENCODER 0
++#define CONFIG_APTX_ENCODER 0
++#define CONFIG_APTX_HD_ENCODER 0
++#define CONFIG_DCA_ENCODER 0
++#define CONFIG_DFPWM_ENCODER 0
++#define CONFIG_EAC3_ENCODER 0
++#define CONFIG_FLAC_ENCODER 0
++#define CONFIG_G723_1_ENCODER 0
++#define CONFIG_HDR_ENCODER 0
++#define CONFIG_MLP_ENCODER 0
++#define CONFIG_MP2_ENCODER 0
++#define CONFIG_MP2FIXED_ENCODER 0
++#define CONFIG_NELLYMOSER_ENCODER 0
++#define CONFIG_OPUS_ENCODER 0
++#define CONFIG_RA_144_ENCODER 0
++#define CONFIG_SBC_ENCODER 0
++#define CONFIG_SONIC_ENCODER 0
++#define CONFIG_SONIC_LS_ENCODER 0
++#define CONFIG_TRUEHD_ENCODER 0
++#define CONFIG_TTA_ENCODER 0
++#define CONFIG_VORBIS_ENCODER 0
++#define CONFIG_WAVPACK_ENCODER 0
++#define CONFIG_WMAV1_ENCODER 0
++#define CONFIG_WMAV2_ENCODER 0
++#define CONFIG_PCM_ALAW_ENCODER 0
++#define CONFIG_PCM_BLURAY_ENCODER 0
++#define CONFIG_PCM_DVD_ENCODER 0
++#define CONFIG_PCM_F32BE_ENCODER 0
++#define CONFIG_PCM_F32LE_ENCODER 0
++#define CONFIG_PCM_F64BE_ENCODER 0
++#define CONFIG_PCM_F64LE_ENCODER 0
++#define CONFIG_PCM_MULAW_ENCODER 0
++#define CONFIG_PCM_S8_ENCODER 0
++#define CONFIG_PCM_S8_PLANAR_ENCODER 0
++#define CONFIG_PCM_S16BE_ENCODER 0
++#define CONFIG_PCM_S16BE_PLANAR_ENCODER 0
++#define CONFIG_PCM_S16LE_ENCODER 0
++#define CONFIG_PCM_S16LE_PLANAR_ENCODER 0
++#define CONFIG_PCM_S24BE_ENCODER 0
++#define CONFIG_PCM_S24DAUD_ENCODER 0
++#define CONFIG_PCM_S24LE_ENCODER 0
++#define CONFIG_PCM_S24LE_PLANAR_ENCODER 0
++#define CONFIG_PCM_S32BE_ENCODER 0
++#define CONFIG_PCM_S32LE_ENCODER 0
++#define CONFIG_PCM_S32LE_PLANAR_ENCODER 0
++#define CONFIG_PCM_S64BE_ENCODER 0
++#define CONFIG_PCM_S64LE_ENCODER 0
++#define CONFIG_PCM_U8_ENCODER 0
++#define CONFIG_PCM_U16BE_ENCODER 0
++#define CONFIG_PCM_U16LE_ENCODER 0
++#define CONFIG_PCM_U24BE_ENCODER 0
++#define CONFIG_PCM_U24LE_ENCODER 0
++#define CONFIG_PCM_U32BE_ENCODER 0
++#define CONFIG_PCM_U32LE_ENCODER 0
++#define CONFIG_PCM_VIDC_ENCODER 0
++#define CONFIG_ROQ_DPCM_ENCODER 0
++#define CONFIG_ADPCM_ADX_ENCODER 0
++#define CONFIG_ADPCM_ARGO_ENCODER 0
++#define CONFIG_ADPCM_G722_ENCODER 0
++#define CONFIG_ADPCM_G726_ENCODER 0
++#define CONFIG_ADPCM_G726LE_ENCODER 0
++#define CONFIG_ADPCM_IMA_AMV_ENCODER 0
++#define CONFIG_ADPCM_IMA_ALP_ENCODER 0
++#define CONFIG_ADPCM_IMA_APM_ENCODER 0
++#define CONFIG_ADPCM_IMA_QT_ENCODER 0
++#define CONFIG_ADPCM_IMA_SSI_ENCODER 0
++#define CONFIG_ADPCM_IMA_WAV_ENCODER 0
++#define CONFIG_ADPCM_IMA_WS_ENCODER 0
++#define CONFIG_ADPCM_MS_ENCODER 0
++#define CONFIG_ADPCM_SWF_ENCODER 0
++#define CONFIG_ADPCM_YAMAHA_ENCODER 0
++#define CONFIG_SSA_ENCODER 0
++#define CONFIG_ASS_ENCODER 0
++#define CONFIG_DVBSUB_ENCODER 0
++#define CONFIG_DVDSUB_ENCODER 0
++#define CONFIG_MOVTEXT_ENCODER 0
++#define CONFIG_SRT_ENCODER 0
++#define CONFIG_SUBRIP_ENCODER 0
++#define CONFIG_TEXT_ENCODER 0
++#define CONFIG_TTML_ENCODER 0
++#define CONFIG_WEBVTT_ENCODER 0
++#define CONFIG_XSUB_ENCODER 0
++#define CONFIG_AAC_AT_ENCODER 0
++#define CONFIG_ALAC_AT_ENCODER 0
++#define CONFIG_ILBC_AT_ENCODER 0
++#define CONFIG_PCM_ALAW_AT_ENCODER 0
++#define CONFIG_PCM_MULAW_AT_ENCODER 0
++#define CONFIG_LIBAOM_AV1_ENCODER 0
++#define CONFIG_LIBCODEC2_ENCODER 0
++#define CONFIG_LIBFDK_AAC_ENCODER 0
++#define CONFIG_LIBGSM_ENCODER 0
++#define CONFIG_LIBGSM_MS_ENCODER 0
++#define CONFIG_LIBILBC_ENCODER 0
++#define CONFIG_LIBJXL_ENCODER 0
++#define CONFIG_LIBMP3LAME_ENCODER 0
++#define CONFIG_LIBOPENCORE_AMRNB_ENCODER 0
++#define CONFIG_LIBOPENJPEG_ENCODER 0
++#define CONFIG_LIBOPUS_ENCODER 0
++#define CONFIG_LIBRAV1E_ENCODER 0
++#define CONFIG_LIBSHINE_ENCODER 0
++#define CONFIG_LIBSPEEX_ENCODER 0
++#define CONFIG_LIBSVTAV1_ENCODER 0
++#define CONFIG_LIBTHEORA_ENCODER 0
++#define CONFIG_LIBTWOLAME_ENCODER 0
++#define CONFIG_LIBVO_AMRWBENC_ENCODER 0
++#define CONFIG_LIBVORBIS_ENCODER 0
++#define CONFIG_LIBVPX_VP8_ENCODER 0
++#define CONFIG_LIBVPX_VP9_ENCODER 0
++#define CONFIG_LIBWEBP_ANIM_ENCODER 0
++#define CONFIG_LIBWEBP_ENCODER 0
++#define CONFIG_LIBX262_ENCODER 0
++#define CONFIG_LIBX264_ENCODER 0
++#define CONFIG_LIBX264RGB_ENCODER 0
++#define CONFIG_LIBX265_ENCODER 0
++#define CONFIG_LIBXEVE_ENCODER 0
++#define CONFIG_LIBXAVS_ENCODER 0
++#define CONFIG_LIBXAVS2_ENCODER 0
++#define CONFIG_LIBXVID_ENCODER 0
++#define CONFIG_AAC_MF_ENCODER 0
++#define CONFIG_AC3_MF_ENCODER 0
++#define CONFIG_H263_V4L2M2M_ENCODER 0
++#define CONFIG_AV1_MEDIACODEC_ENCODER 0
++#define CONFIG_AV1_NVENC_ENCODER 0
++#define CONFIG_AV1_QSV_ENCODER 0
++#define CONFIG_AV1_AMF_ENCODER 0
++#define CONFIG_AV1_VAAPI_ENCODER 0
++#define CONFIG_LIBOPENH264_ENCODER 0
++#define CONFIG_H264_AMF_ENCODER 0
++#define CONFIG_H264_MF_ENCODER 0
++#define CONFIG_H264_NVENC_ENCODER 0
++#define CONFIG_H264_OMX_ENCODER 0
++#define CONFIG_H264_QSV_ENCODER 0
++#define CONFIG_H264_V4L2M2M_ENCODER 0
++#define CONFIG_H264_VAAPI_ENCODER 0
++#define CONFIG_H264_VIDEOTOOLBOX_ENCODER 0
++#define CONFIG_HEVC_AMF_ENCODER 0
++#define CONFIG_HEVC_MEDIACODEC_ENCODER 0
++#define CONFIG_HEVC_MF_ENCODER 0
++#define CONFIG_HEVC_NVENC_ENCODER 0
++#define CONFIG_HEVC_QSV_ENCODER 0
++#define CONFIG_HEVC_V4L2M2M_ENCODER 0
++#define CONFIG_HEVC_VAAPI_ENCODER 0
++#define CONFIG_HEVC_VIDEOTOOLBOX_ENCODER 0
++#define CONFIG_LIBKVAZAAR_ENCODER 0
++#define CONFIG_MJPEG_QSV_ENCODER 0
++#define CONFIG_MJPEG_VAAPI_ENCODER 0
++#define CONFIG_MP3_MF_ENCODER 0
++#define CONFIG_MPEG2_QSV_ENCODER 0
++#define CONFIG_MPEG2_VAAPI_ENCODER 0
++#define CONFIG_MPEG4_MEDIACODEC_ENCODER 0
++#define CONFIG_MPEG4_OMX_ENCODER 0
++#define CONFIG_MPEG4_V4L2M2M_ENCODER 0
++#define CONFIG_PRORES_VIDEOTOOLBOX_ENCODER 0
++#define CONFIG_VP8_MEDIACODEC_ENCODER 0
++#define CONFIG_VP8_V4L2M2M_ENCODER 0
++#define CONFIG_VP8_VAAPI_ENCODER 0
++#define CONFIG_VP9_MEDIACODEC_ENCODER 0
++#define CONFIG_VP9_VAAPI_ENCODER 0
++#define CONFIG_VP9_QSV_ENCODER 0
++#define CONFIG_VNULL_ENCODER 0
++#define CONFIG_ANULL_ENCODER 0
++#define CONFIG_AV1_D3D11VA_HWACCEL 0
++#define CONFIG_AV1_D3D11VA2_HWACCEL 0
++#define CONFIG_AV1_D3D12VA_HWACCEL 0
++#define CONFIG_AV1_DXVA2_HWACCEL 0
++#define CONFIG_AV1_NVDEC_HWACCEL 0
++#define CONFIG_AV1_VAAPI_HWACCEL 0
++#define CONFIG_AV1_VDPAU_HWACCEL 0
++#define CONFIG_AV1_VULKAN_HWACCEL 0
++#define CONFIG_H263_VAAPI_HWACCEL 0
++#define CONFIG_H263_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_H264_D3D11VA_HWACCEL 0
++#define CONFIG_H264_D3D11VA2_HWACCEL 0
++#define CONFIG_H264_D3D12VA_HWACCEL 0
++#define CONFIG_H264_DXVA2_HWACCEL 0
++#define CONFIG_H264_NVDEC_HWACCEL 0
++#define CONFIG_H264_VAAPI_HWACCEL 0
++#define CONFIG_H264_VDPAU_HWACCEL 0
++#define CONFIG_H264_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_H264_VULKAN_HWACCEL 0
++#define CONFIG_HEVC_D3D11VA_HWACCEL 0
++#define CONFIG_HEVC_D3D11VA2_HWACCEL 0
++#define CONFIG_HEVC_D3D12VA_HWACCEL 0
++#define CONFIG_HEVC_DXVA2_HWACCEL 0
++#define CONFIG_HEVC_NVDEC_HWACCEL 0
++#define CONFIG_HEVC_VAAPI_HWACCEL 0
++#define CONFIG_HEVC_VDPAU_HWACCEL 0
++#define CONFIG_HEVC_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_HEVC_VULKAN_HWACCEL 0
++#define CONFIG_MJPEG_NVDEC_HWACCEL 0
++#define CONFIG_MJPEG_VAAPI_HWACCEL 0
++#define CONFIG_MPEG1_NVDEC_HWACCEL 0
++#define CONFIG_MPEG1_VDPAU_HWACCEL 0
++#define CONFIG_MPEG1_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_MPEG2_D3D11VA_HWACCEL 0
++#define CONFIG_MPEG2_D3D11VA2_HWACCEL 0
++#define CONFIG_MPEG2_D3D12VA_HWACCEL 0
++#define CONFIG_MPEG2_DXVA2_HWACCEL 0
++#define CONFIG_MPEG2_NVDEC_HWACCEL 0
++#define CONFIG_MPEG2_VAAPI_HWACCEL 0
++#define CONFIG_MPEG2_VDPAU_HWACCEL 0
++#define CONFIG_MPEG2_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_MPEG4_NVDEC_HWACCEL 0
++#define CONFIG_MPEG4_VAAPI_HWACCEL 0
++#define CONFIG_MPEG4_VDPAU_HWACCEL 0
++#define CONFIG_MPEG4_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_PRORES_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_VC1_D3D11VA_HWACCEL 0
++#define CONFIG_VC1_D3D11VA2_HWACCEL 0
++#define CONFIG_VC1_D3D12VA_HWACCEL 0
++#define CONFIG_VC1_DXVA2_HWACCEL 0
++#define CONFIG_VC1_NVDEC_HWACCEL 0
++#define CONFIG_VC1_VAAPI_HWACCEL 0
++#define CONFIG_VC1_VDPAU_HWACCEL 0
++#define CONFIG_VP8_NVDEC_HWACCEL 0
++#define CONFIG_VP8_VAAPI_HWACCEL 0
++#define CONFIG_VP9_D3D11VA_HWACCEL 0
++#define CONFIG_VP9_D3D11VA2_HWACCEL 0
++#define CONFIG_VP9_D3D12VA_HWACCEL 0
++#define CONFIG_VP9_DXVA2_HWACCEL 0
++#define CONFIG_VP9_NVDEC_HWACCEL 0
++#define CONFIG_VP9_VAAPI_HWACCEL 0
++#define CONFIG_VP9_VDPAU_HWACCEL 0
++#define CONFIG_VP9_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_WMV3_D3D11VA_HWACCEL 0
++#define CONFIG_WMV3_D3D11VA2_HWACCEL 0
++#define CONFIG_WMV3_D3D12VA_HWACCEL 0
++#define CONFIG_WMV3_DXVA2_HWACCEL 0
++#define CONFIG_WMV3_NVDEC_HWACCEL 0
++#define CONFIG_WMV3_VAAPI_HWACCEL 0
++#define CONFIG_WMV3_VDPAU_HWACCEL 0
++#define CONFIG_AAC_PARSER 1
++#define CONFIG_AAC_LATM_PARSER 0
++#define CONFIG_AC3_PARSER 0
++#define CONFIG_ADX_PARSER 0
++#define CONFIG_AMR_PARSER 0
++#define CONFIG_AV1_PARSER 0
++#define CONFIG_AVS2_PARSER 0
++#define CONFIG_AVS3_PARSER 0
++#define CONFIG_BMP_PARSER 0
++#define CONFIG_CAVSVIDEO_PARSER 0
++#define CONFIG_COOK_PARSER 0
++#define CONFIG_CRI_PARSER 0
++#define CONFIG_DCA_PARSER 0
++#define CONFIG_DIRAC_PARSER 0
++#define CONFIG_DNXHD_PARSER 0
++#define CONFIG_DOLBY_E_PARSER 0
++#define CONFIG_DPX_PARSER 0
++#define CONFIG_DVAUDIO_PARSER 0
++#define CONFIG_DVBSUB_PARSER 0
++#define CONFIG_DVDSUB_PARSER 0
++#define CONFIG_DVD_NAV_PARSER 0
++#define CONFIG_EVC_PARSER 0
++#define CONFIG_FLAC_PARSER 1
++#define CONFIG_FTR_PARSER 0
++#define CONFIG_G723_1_PARSER 0
++#define CONFIG_G729_PARSER 0
++#define CONFIG_GIF_PARSER 0
++#define CONFIG_GSM_PARSER 0
++#define CONFIG_H261_PARSER 0
++#define CONFIG_H263_PARSER 0
++#define CONFIG_H264_PARSER 1
++#define CONFIG_HEVC_PARSER 0
++#define CONFIG_HDR_PARSER 0
++#define CONFIG_IPU_PARSER 0
++#define CONFIG_JPEG2000_PARSER 0
++#define CONFIG_JPEGXL_PARSER 0
++#define CONFIG_MISC4_PARSER 0
++#define CONFIG_MJPEG_PARSER 0
++#define CONFIG_MLP_PARSER 0
++#define CONFIG_MPEG4VIDEO_PARSER 0
++#define CONFIG_MPEGAUDIO_PARSER 1
++#define CONFIG_MPEGVIDEO_PARSER 0
++#define CONFIG_OPUS_PARSER 1
++#define CONFIG_PNG_PARSER 0
++#define CONFIG_PNM_PARSER 0
++#define CONFIG_QOI_PARSER 0
++#define CONFIG_RV34_PARSER 0
++#define CONFIG_SBC_PARSER 0
++#define CONFIG_SIPR_PARSER 0
++#define CONFIG_TAK_PARSER 0
++#define CONFIG_VC1_PARSER 0
++#define CONFIG_VORBIS_PARSER 1
++#define CONFIG_VP3_PARSER 0
++#define CONFIG_VP8_PARSER 0
++#define CONFIG_VP9_PARSER 1
++#define CONFIG_VVC_PARSER 0
++#define CONFIG_WEBP_PARSER 0
++#define CONFIG_XBM_PARSER 0
++#define CONFIG_XMA_PARSER 0
++#define CONFIG_XWD_PARSER 0
++#define CONFIG_ALSA_INDEV 0
++#define CONFIG_ANDROID_CAMERA_INDEV 0
++#define CONFIG_AVFOUNDATION_INDEV 0
++#define CONFIG_BKTR_INDEV 0
++#define CONFIG_DECKLINK_INDEV 0
++#define CONFIG_DSHOW_INDEV 0
++#define CONFIG_FBDEV_INDEV 0
++#define CONFIG_GDIGRAB_INDEV 0
++#define CONFIG_IEC61883_INDEV 0
++#define CONFIG_JACK_INDEV 0
++#define CONFIG_KMSGRAB_INDEV 0
++#define CONFIG_LAVFI_INDEV 0
++#define CONFIG_OPENAL_INDEV 0
++#define CONFIG_OSS_INDEV 0
++#define CONFIG_PULSE_INDEV 0
++#define CONFIG_SNDIO_INDEV 0
++#define CONFIG_V4L2_INDEV 0
++#define CONFIG_VFWCAP_INDEV 0
++#define CONFIG_XCBGRAB_INDEV 0
++#define CONFIG_LIBCDIO_INDEV 0
++#define CONFIG_LIBDC1394_INDEV 0
++#define CONFIG_ALSA_OUTDEV 0
++#define CONFIG_AUDIOTOOLBOX_OUTDEV 0
++#define CONFIG_CACA_OUTDEV 0
++#define CONFIG_DECKLINK_OUTDEV 0
++#define CONFIG_FBDEV_OUTDEV 0
++#define CONFIG_OPENGL_OUTDEV 0
++#define CONFIG_OSS_OUTDEV 0
++#define CONFIG_PULSE_OUTDEV 0
++#define CONFIG_SDL2_OUTDEV 0
++#define CONFIG_SNDIO_OUTDEV 0
++#define CONFIG_V4L2_OUTDEV 0
++#define CONFIG_XV_OUTDEV 0
++#define CONFIG_AAP_FILTER 0
++#define CONFIG_ABENCH_FILTER 0
++#define CONFIG_ACOMPRESSOR_FILTER 0
++#define CONFIG_ACONTRAST_FILTER 0
++#define CONFIG_ACOPY_FILTER 0
++#define CONFIG_ACUE_FILTER 0
++#define CONFIG_ACROSSFADE_FILTER 0
++#define CONFIG_ACROSSOVER_FILTER 0
++#define CONFIG_ACRUSHER_FILTER 0
++#define CONFIG_ADECLICK_FILTER 0
++#define CONFIG_ADECLIP_FILTER 0
++#define CONFIG_ADECORRELATE_FILTER 0
++#define CONFIG_ADELAY_FILTER 0
++#define CONFIG_ADENORM_FILTER 0
++#define CONFIG_ADERIVATIVE_FILTER 0
++#define CONFIG_ADRC_FILTER 0
++#define CONFIG_ADYNAMICEQUALIZER_FILTER 0
++#define CONFIG_ADYNAMICSMOOTH_FILTER 0
++#define CONFIG_AECHO_FILTER 0
++#define CONFIG_AEMPHASIS_FILTER 0
++#define CONFIG_AEVAL_FILTER 0
++#define CONFIG_AEXCITER_FILTER 0
++#define CONFIG_AFADE_FILTER 0
++#define CONFIG_AFFTDN_FILTER 0
++#define CONFIG_AFFTFILT_FILTER 0
++#define CONFIG_AFIR_FILTER 0
++#define CONFIG_AFORMAT_FILTER 0
++#define CONFIG_AFREQSHIFT_FILTER 0
++#define CONFIG_AFWTDN_FILTER 0
++#define CONFIG_AGATE_FILTER 0
++#define CONFIG_AIIR_FILTER 0
++#define CONFIG_AINTEGRAL_FILTER 0
++#define CONFIG_AINTERLEAVE_FILTER 0
++#define CONFIG_ALATENCY_FILTER 0
++#define CONFIG_ALIMITER_FILTER 0
++#define CONFIG_ALLPASS_FILTER 0
++#define CONFIG_ALOOP_FILTER 0
++#define CONFIG_AMERGE_FILTER 0
++#define CONFIG_AMETADATA_FILTER 0
++#define CONFIG_AMIX_FILTER 0
++#define CONFIG_AMULTIPLY_FILTER 0
++#define CONFIG_ANEQUALIZER_FILTER 0
++#define CONFIG_ANLMDN_FILTER 0
++#define CONFIG_ANLMF_FILTER 0
++#define CONFIG_ANLMS_FILTER 0
++#define CONFIG_ANULL_FILTER 0
++#define CONFIG_APAD_FILTER 0
++#define CONFIG_APERMS_FILTER 0
++#define CONFIG_APHASER_FILTER 0
++#define CONFIG_APHASESHIFT_FILTER 0
++#define CONFIG_APSNR_FILTER 0
++#define CONFIG_APSYCLIP_FILTER 0
++#define CONFIG_APULSATOR_FILTER 0
++#define CONFIG_AREALTIME_FILTER 0
++#define CONFIG_ARESAMPLE_FILTER 0
++#define CONFIG_AREVERSE_FILTER 0
++#define CONFIG_ARLS_FILTER 0
++#define CONFIG_ARNNDN_FILTER 0
++#define CONFIG_ASDR_FILTER 0
++#define CONFIG_ASEGMENT_FILTER 0
++#define CONFIG_ASELECT_FILTER 0
++#define CONFIG_ASENDCMD_FILTER 0
++#define CONFIG_ASETNSAMPLES_FILTER 0
++#define CONFIG_ASETPTS_FILTER 0
++#define CONFIG_ASETRATE_FILTER 0
++#define CONFIG_ASETTB_FILTER 0
++#define CONFIG_ASHOWINFO_FILTER 0
++#define CONFIG_ASIDEDATA_FILTER 0
++#define CONFIG_ASISDR_FILTER 0
++#define CONFIG_ASOFTCLIP_FILTER 0
++#define CONFIG_ASPECTRALSTATS_FILTER 0
++#define CONFIG_ASPLIT_FILTER 0
++#define CONFIG_ASR_FILTER 0
++#define CONFIG_ASTATS_FILTER 0
++#define CONFIG_ASTREAMSELECT_FILTER 0
++#define CONFIG_ASUBBOOST_FILTER 0
++#define CONFIG_ASUBCUT_FILTER 0
++#define CONFIG_ASUPERCUT_FILTER 0
++#define CONFIG_ASUPERPASS_FILTER 0
++#define CONFIG_ASUPERSTOP_FILTER 0
++#define CONFIG_ATEMPO_FILTER 0
++#define CONFIG_ATILT_FILTER 0
++#define CONFIG_ATRIM_FILTER 0
++#define CONFIG_AXCORRELATE_FILTER 0
++#define CONFIG_AZMQ_FILTER 0
++#define CONFIG_BANDPASS_FILTER 0
++#define CONFIG_BANDREJECT_FILTER 0
++#define CONFIG_BASS_FILTER 0
++#define CONFIG_BIQUAD_FILTER 0
++#define CONFIG_BS2B_FILTER 0
++#define CONFIG_CHANNELMAP_FILTER 0
++#define CONFIG_CHANNELSPLIT_FILTER 0
++#define CONFIG_CHORUS_FILTER 0
++#define CONFIG_COMPAND_FILTER 0
++#define CONFIG_COMPENSATIONDELAY_FILTER 0
++#define CONFIG_CROSSFEED_FILTER 0
++#define CONFIG_CRYSTALIZER_FILTER 0
++#define CONFIG_DCSHIFT_FILTER 0
++#define CONFIG_DEESSER_FILTER 0
++#define CONFIG_DIALOGUENHANCE_FILTER 0
++#define CONFIG_DRMETER_FILTER 0
++#define CONFIG_DYNAUDNORM_FILTER 0
++#define CONFIG_EARWAX_FILTER 0
++#define CONFIG_EBUR128_FILTER 0
++#define CONFIG_EQUALIZER_FILTER 0
++#define CONFIG_EXTRASTEREO_FILTER 0
++#define CONFIG_FIREQUALIZER_FILTER 0
++#define CONFIG_FLANGER_FILTER 0
++#define CONFIG_HAAS_FILTER 0
++#define CONFIG_HDCD_FILTER 0
++#define CONFIG_HEADPHONE_FILTER 0
++#define CONFIG_HIGHPASS_FILTER 0
++#define CONFIG_HIGHSHELF_FILTER 0
++#define CONFIG_JOIN_FILTER 0
++#define CONFIG_LADSPA_FILTER 0
++#define CONFIG_LOUDNORM_FILTER 0
++#define CONFIG_LOWPASS_FILTER 0
++#define CONFIG_LOWSHELF_FILTER 0
++#define CONFIG_LV2_FILTER 0
++#define CONFIG_MCOMPAND_FILTER 0
++#define CONFIG_PAN_FILTER 0
++#define CONFIG_REPLAYGAIN_FILTER 0
++#define CONFIG_RUBBERBAND_FILTER 0
++#define CONFIG_SIDECHAINCOMPRESS_FILTER 0
++#define CONFIG_SIDECHAINGATE_FILTER 0
++#define CONFIG_SILENCEDETECT_FILTER 0
++#define CONFIG_SILENCEREMOVE_FILTER 0
++#define CONFIG_SOFALIZER_FILTER 0
++#define CONFIG_SPEECHNORM_FILTER 0
++#define CONFIG_STEREOTOOLS_FILTER 0
++#define CONFIG_STEREOWIDEN_FILTER 0
++#define CONFIG_SUPEREQUALIZER_FILTER 0
++#define CONFIG_SURROUND_FILTER 0
++#define CONFIG_TILTSHELF_FILTER 0
++#define CONFIG_TREBLE_FILTER 0
++#define CONFIG_TREMOLO_FILTER 0
++#define CONFIG_VIBRATO_FILTER 0
++#define CONFIG_VIRTUALBASS_FILTER 0
++#define CONFIG_VOLUME_FILTER 0
++#define CONFIG_VOLUMEDETECT_FILTER 0
++#define CONFIG_AEVALSRC_FILTER 0
++#define CONFIG_AFDELAYSRC_FILTER 0
++#define CONFIG_AFIREQSRC_FILTER 0
++#define CONFIG_AFIRSRC_FILTER 0
++#define CONFIG_ANOISESRC_FILTER 0
++#define CONFIG_ANULLSRC_FILTER 0
++#define CONFIG_FLITE_FILTER 0
++#define CONFIG_HILBERT_FILTER 0
++#define CONFIG_SINC_FILTER 0
++#define CONFIG_SINE_FILTER 0
++#define CONFIG_ANULLSINK_FILTER 0
++#define CONFIG_ADDROI_FILTER 0
++#define CONFIG_ALPHAEXTRACT_FILTER 0
++#define CONFIG_ALPHAMERGE_FILTER 0
++#define CONFIG_AMPLIFY_FILTER 0
++#define CONFIG_ASS_FILTER 0
++#define CONFIG_ATADENOISE_FILTER 0
++#define CONFIG_AVGBLUR_FILTER 0
++#define CONFIG_AVGBLUR_OPENCL_FILTER 0
++#define CONFIG_AVGBLUR_VULKAN_FILTER 0
++#define CONFIG_BACKGROUNDKEY_FILTER 0
++#define CONFIG_BBOX_FILTER 0
++#define CONFIG_BENCH_FILTER 0
++#define CONFIG_BILATERAL_FILTER 0
++#define CONFIG_BILATERAL_CUDA_FILTER 0
++#define CONFIG_BITPLANENOISE_FILTER 0
++#define CONFIG_BLACKDETECT_FILTER 0
++#define CONFIG_BLACKFRAME_FILTER 0
++#define CONFIG_BLEND_FILTER 0
++#define CONFIG_BLEND_VULKAN_FILTER 0
++#define CONFIG_BLOCKDETECT_FILTER 0
++#define CONFIG_BLURDETECT_FILTER 0
++#define CONFIG_BM3D_FILTER 0
++#define CONFIG_BOXBLUR_FILTER 0
++#define CONFIG_BOXBLUR_OPENCL_FILTER 0
++#define CONFIG_BWDIF_FILTER 0
++#define CONFIG_BWDIF_CUDA_FILTER 0
++#define CONFIG_BWDIF_VULKAN_FILTER 0
++#define CONFIG_CAS_FILTER 0
++#define CONFIG_CCREPACK_FILTER 0
++#define CONFIG_CHROMABER_VULKAN_FILTER 0
++#define CONFIG_CHROMAHOLD_FILTER 0
++#define CONFIG_CHROMAKEY_FILTER 0
++#define CONFIG_CHROMAKEY_CUDA_FILTER 0
++#define CONFIG_CHROMANR_FILTER 0
++#define CONFIG_CHROMASHIFT_FILTER 0
++#define CONFIG_CIESCOPE_FILTER 0
++#define CONFIG_CODECVIEW_FILTER 0
++#define CONFIG_COLORBALANCE_FILTER 0
++#define CONFIG_COLORCHANNELMIXER_FILTER 0
++#define CONFIG_COLORCONTRAST_FILTER 0
++#define CONFIG_COLORCORRECT_FILTER 0
++#define CONFIG_COLORIZE_FILTER 0
++#define CONFIG_COLORKEY_FILTER 0
++#define CONFIG_COLORKEY_OPENCL_FILTER 0
++#define CONFIG_COLORHOLD_FILTER 0
++#define CONFIG_COLORLEVELS_FILTER 0
++#define CONFIG_COLORMAP_FILTER 0
++#define CONFIG_COLORMATRIX_FILTER 0
++#define CONFIG_COLORSPACE_FILTER 0
++#define CONFIG_COLORSPACE_CUDA_FILTER 0
++#define CONFIG_COLORTEMPERATURE_FILTER 0
++#define CONFIG_CONVOLUTION_FILTER 0
++#define CONFIG_CONVOLUTION_OPENCL_FILTER 0
++#define CONFIG_CONVOLVE_FILTER 0
++#define CONFIG_COPY_FILTER 0
++#define CONFIG_COREIMAGE_FILTER 0
++#define CONFIG_CORR_FILTER 0
++#define CONFIG_COVER_RECT_FILTER 0
++#define CONFIG_CROP_FILTER 0
++#define CONFIG_CROPDETECT_FILTER 0
++#define CONFIG_CUE_FILTER 0
++#define CONFIG_CURVES_FILTER 0
++#define CONFIG_DATASCOPE_FILTER 0
++#define CONFIG_DBLUR_FILTER 0
++#define CONFIG_DCTDNOIZ_FILTER 0
++#define CONFIG_DEBAND_FILTER 0
++#define CONFIG_DEBLOCK_FILTER 0
++#define CONFIG_DECIMATE_FILTER 0
++#define CONFIG_DECONVOLVE_FILTER 0
++#define CONFIG_DEDOT_FILTER 0
++#define CONFIG_DEFLATE_FILTER 0
++#define CONFIG_DEFLICKER_FILTER 0
++#define CONFIG_DEINTERLACE_QSV_FILTER 0
++#define CONFIG_DEINTERLACE_VAAPI_FILTER 0
++#define CONFIG_DEJUDDER_FILTER 0
++#define CONFIG_DELOGO_FILTER 0
++#define CONFIG_DENOISE_VAAPI_FILTER 0
++#define CONFIG_DERAIN_FILTER 0
++#define CONFIG_DESHAKE_FILTER 0
++#define CONFIG_DESHAKE_OPENCL_FILTER 0
++#define CONFIG_DESPILL_FILTER 0
++#define CONFIG_DETELECINE_FILTER 0
++#define CONFIG_DILATION_FILTER 0
++#define CONFIG_DILATION_OPENCL_FILTER 0
++#define CONFIG_DISPLACE_FILTER 0
++#define CONFIG_DNN_CLASSIFY_FILTER 0
++#define CONFIG_DNN_DETECT_FILTER 0
++#define CONFIG_DNN_PROCESSING_FILTER 0
++#define CONFIG_DOUBLEWEAVE_FILTER 0
++#define CONFIG_DRAWBOX_FILTER 0
++#define CONFIG_DRAWGRAPH_FILTER 0
++#define CONFIG_DRAWGRID_FILTER 0
++#define CONFIG_DRAWTEXT_FILTER 0
++#define CONFIG_EDGEDETECT_FILTER 0
++#define CONFIG_ELBG_FILTER 0
++#define CONFIG_ENTROPY_FILTER 0
++#define CONFIG_EPX_FILTER 0
++#define CONFIG_EQ_FILTER 0
++#define CONFIG_EROSION_FILTER 0
++#define CONFIG_EROSION_OPENCL_FILTER 0
++#define CONFIG_ESTDIF_FILTER 0
++#define CONFIG_EXPOSURE_FILTER 0
++#define CONFIG_EXTRACTPLANES_FILTER 0
++#define CONFIG_FADE_FILTER 0
++#define CONFIG_FEEDBACK_FILTER 0
++#define CONFIG_FFTDNOIZ_FILTER 0
++#define CONFIG_FFTFILT_FILTER 0
++#define CONFIG_FIELD_FILTER 0
++#define CONFIG_FIELDHINT_FILTER 0
++#define CONFIG_FIELDMATCH_FILTER 0
++#define CONFIG_FIELDORDER_FILTER 0
++#define CONFIG_FILLBORDERS_FILTER 0
++#define CONFIG_FIND_RECT_FILTER 0
++#define CONFIG_FLIP_VULKAN_FILTER 0
++#define CONFIG_FLOODFILL_FILTER 0
++#define CONFIG_FORMAT_FILTER 0
++#define CONFIG_FPS_FILTER 0
++#define CONFIG_FRAMEPACK_FILTER 0
++#define CONFIG_FRAMERATE_FILTER 0
++#define CONFIG_FRAMESTEP_FILTER 0
++#define CONFIG_FREEZEDETECT_FILTER 0
++#define CONFIG_FREEZEFRAMES_FILTER 0
++#define CONFIG_FREI0R_FILTER 0
++#define CONFIG_FSPP_FILTER 0
++#define CONFIG_FSYNC_FILTER 0
++#define CONFIG_GBLUR_FILTER 0
++#define CONFIG_GBLUR_VULKAN_FILTER 0
++#define CONFIG_GEQ_FILTER 0
++#define CONFIG_GRADFUN_FILTER 0
++#define CONFIG_GRAPHMONITOR_FILTER 0
++#define CONFIG_GRAYWORLD_FILTER 0
++#define CONFIG_GREYEDGE_FILTER 0
++#define CONFIG_GUIDED_FILTER 0
++#define CONFIG_HALDCLUT_FILTER 0
++#define CONFIG_HFLIP_FILTER 0
++#define CONFIG_HFLIP_VULKAN_FILTER 0
++#define CONFIG_HISTEQ_FILTER 0
++#define CONFIG_HISTOGRAM_FILTER 0
++#define CONFIG_HQDN3D_FILTER 0
++#define CONFIG_HQX_FILTER 0
++#define CONFIG_HSTACK_FILTER 0
++#define CONFIG_HSVHOLD_FILTER 0
++#define CONFIG_HSVKEY_FILTER 0
++#define CONFIG_HUE_FILTER 0
++#define CONFIG_HUESATURATION_FILTER 0
++#define CONFIG_HWDOWNLOAD_FILTER 0
++#define CONFIG_HWMAP_FILTER 0
++#define CONFIG_HWUPLOAD_FILTER 0
++#define CONFIG_HWUPLOAD_CUDA_FILTER 0
++#define CONFIG_HYSTERESIS_FILTER 0
++#define CONFIG_ICCDETECT_FILTER 0
++#define CONFIG_ICCGEN_FILTER 0
++#define CONFIG_IDENTITY_FILTER 0
++#define CONFIG_IDET_FILTER 0
++#define CONFIG_IL_FILTER 0
++#define CONFIG_INFLATE_FILTER 0
++#define CONFIG_INTERLACE_FILTER 0
++#define CONFIG_INTERLEAVE_FILTER 0
++#define CONFIG_KERNDEINT_FILTER 0
++#define CONFIG_KIRSCH_FILTER 0
++#define CONFIG_LAGFUN_FILTER 0
++#define CONFIG_LATENCY_FILTER 0
++#define CONFIG_LENSCORRECTION_FILTER 0
++#define CONFIG_LENSFUN_FILTER 0
++#define CONFIG_LIBPLACEBO_FILTER 0
++#define CONFIG_LIBVMAF_FILTER 0
++#define CONFIG_LIBVMAF_CUDA_FILTER 0
++#define CONFIG_LIMITDIFF_FILTER 0
++#define CONFIG_LIMITER_FILTER 0
++#define CONFIG_LOOP_FILTER 0
++#define CONFIG_LUMAKEY_FILTER 0
++#define CONFIG_LUT_FILTER 0
++#define CONFIG_LUT1D_FILTER 0
++#define CONFIG_LUT2_FILTER 0
++#define CONFIG_LUT3D_FILTER 0
++#define CONFIG_LUTRGB_FILTER 0
++#define CONFIG_LUTYUV_FILTER 0
++#define CONFIG_MASKEDCLAMP_FILTER 0
++#define CONFIG_MASKEDMAX_FILTER 0
++#define CONFIG_MASKEDMERGE_FILTER 0
++#define CONFIG_MASKEDMIN_FILTER 0
++#define CONFIG_MASKEDTHRESHOLD_FILTER 0
++#define CONFIG_MASKFUN_FILTER 0
++#define CONFIG_MCDEINT_FILTER 0
++#define CONFIG_MEDIAN_FILTER 0
++#define CONFIG_MERGEPLANES_FILTER 0
++#define CONFIG_MESTIMATE_FILTER 0
++#define CONFIG_METADATA_FILTER 0
++#define CONFIG_MIDEQUALIZER_FILTER 0
++#define CONFIG_MINTERPOLATE_FILTER 0
++#define CONFIG_MIX_FILTER 0
++#define CONFIG_MONOCHROME_FILTER 0
++#define CONFIG_MORPHO_FILTER 0
++#define CONFIG_MPDECIMATE_FILTER 0
++#define CONFIG_MSAD_FILTER 0
++#define CONFIG_MULTIPLY_FILTER 0
++#define CONFIG_NEGATE_FILTER 0
++#define CONFIG_NLMEANS_FILTER 0
++#define CONFIG_NLMEANS_OPENCL_FILTER 0
++#define CONFIG_NLMEANS_VULKAN_FILTER 0
++#define CONFIG_NNEDI_FILTER 0
++#define CONFIG_NOFORMAT_FILTER 0
++#define CONFIG_NOISE_FILTER 0
++#define CONFIG_NORMALIZE_FILTER 0
++#define CONFIG_NULL_FILTER 0
++#define CONFIG_OCR_FILTER 0
++#define CONFIG_OCV_FILTER 0
++#define CONFIG_OSCILLOSCOPE_FILTER 0
++#define CONFIG_OVERLAY_FILTER 0
++#define CONFIG_OVERLAY_OPENCL_FILTER 0
++#define CONFIG_OVERLAY_QSV_FILTER 0
++#define CONFIG_OVERLAY_VAAPI_FILTER 0
++#define CONFIG_OVERLAY_VULKAN_FILTER 0
++#define CONFIG_OVERLAY_CUDA_FILTER 0
++#define CONFIG_OWDENOISE_FILTER 0
++#define CONFIG_PAD_FILTER 0
++#define CONFIG_PAD_OPENCL_FILTER 0
++#define CONFIG_PALETTEGEN_FILTER 0
++#define CONFIG_PALETTEUSE_FILTER 0
++#define CONFIG_PERMS_FILTER 0
++#define CONFIG_PERSPECTIVE_FILTER 0
++#define CONFIG_PHASE_FILTER 0
++#define CONFIG_PHOTOSENSITIVITY_FILTER 0
++#define CONFIG_PIXDESCTEST_FILTER 0
++#define CONFIG_PIXELIZE_FILTER 0
++#define CONFIG_PIXSCOPE_FILTER 0
++#define CONFIG_PP_FILTER 0
++#define CONFIG_PP7_FILTER 0
++#define CONFIG_PREMULTIPLY_FILTER 0
++#define CONFIG_PREWITT_FILTER 0
++#define CONFIG_PREWITT_OPENCL_FILTER 0
++#define CONFIG_PROCAMP_VAAPI_FILTER 0
++#define CONFIG_PROGRAM_OPENCL_FILTER 0
++#define CONFIG_PSEUDOCOLOR_FILTER 0
++#define CONFIG_PSNR_FILTER 0
++#define CONFIG_PULLUP_FILTER 0
++#define CONFIG_QP_FILTER 0
++#define CONFIG_QRENCODE_FILTER 0
++#define CONFIG_QUIRC_FILTER 0
++#define CONFIG_RANDOM_FILTER 0
++#define CONFIG_READEIA608_FILTER 0
++#define CONFIG_READVITC_FILTER 0
++#define CONFIG_REALTIME_FILTER 0
++#define CONFIG_REMAP_FILTER 0
++#define CONFIG_REMAP_OPENCL_FILTER 0
++#define CONFIG_REMOVEGRAIN_FILTER 0
++#define CONFIG_REMOVELOGO_FILTER 0
++#define CONFIG_REPEATFIELDS_FILTER 0
++#define CONFIG_REVERSE_FILTER 0
++#define CONFIG_RGBASHIFT_FILTER 0
++#define CONFIG_ROBERTS_FILTER 0
++#define CONFIG_ROBERTS_OPENCL_FILTER 0
++#define CONFIG_ROTATE_FILTER 0
++#define CONFIG_SAB_FILTER 0
++#define CONFIG_SCALE_FILTER 0
++#define CONFIG_SCALE_CUDA_FILTER 0
++#define CONFIG_SCALE_NPP_FILTER 0
++#define CONFIG_SCALE_QSV_FILTER 0
++#define CONFIG_SCALE_VAAPI_FILTER 0
++#define CONFIG_SCALE_VT_FILTER 0
++#define CONFIG_SCALE_VULKAN_FILTER 0
++#define CONFIG_SCALE2REF_FILTER 0
++#define CONFIG_SCALE2REF_NPP_FILTER 0
++#define CONFIG_SCDET_FILTER 0
++#define CONFIG_SCHARR_FILTER 0
++#define CONFIG_SCROLL_FILTER 0
++#define CONFIG_SEGMENT_FILTER 0
++#define CONFIG_SELECT_FILTER 0
++#define CONFIG_SELECTIVECOLOR_FILTER 0
++#define CONFIG_SENDCMD_FILTER 0
++#define CONFIG_SEPARATEFIELDS_FILTER 0
++#define CONFIG_SETDAR_FILTER 0
++#define CONFIG_SETFIELD_FILTER 0
++#define CONFIG_SETPARAMS_FILTER 0
++#define CONFIG_SETPTS_FILTER 0
++#define CONFIG_SETRANGE_FILTER 0
++#define CONFIG_SETSAR_FILTER 0
++#define CONFIG_SETTB_FILTER 0
++#define CONFIG_SHARPEN_NPP_FILTER 0
++#define CONFIG_SHARPNESS_VAAPI_FILTER 0
++#define CONFIG_SHEAR_FILTER 0
++#define CONFIG_SHOWINFO_FILTER 0
++#define CONFIG_SHOWPALETTE_FILTER 0
++#define CONFIG_SHUFFLEFRAMES_FILTER 0
++#define CONFIG_SHUFFLEPIXELS_FILTER 0
++#define CONFIG_SHUFFLEPLANES_FILTER 0
++#define CONFIG_SIDEDATA_FILTER 0
++#define CONFIG_SIGNALSTATS_FILTER 0
++#define CONFIG_SIGNATURE_FILTER 0
++#define CONFIG_SITI_FILTER 0
++#define CONFIG_SMARTBLUR_FILTER 0
++#define CONFIG_SOBEL_FILTER 0
++#define CONFIG_SOBEL_OPENCL_FILTER 0
++#define CONFIG_SPLIT_FILTER 0
++#define CONFIG_SPP_FILTER 0
++#define CONFIG_SR_FILTER 0
++#define CONFIG_SSIM_FILTER 0
++#define CONFIG_SSIM360_FILTER 0
++#define CONFIG_STEREO3D_FILTER 0
++#define CONFIG_STREAMSELECT_FILTER 0
++#define CONFIG_SUBTITLES_FILTER 0
++#define CONFIG_SUPER2XSAI_FILTER 0
++#define CONFIG_SWAPRECT_FILTER 0
++#define CONFIG_SWAPUV_FILTER 0
++#define CONFIG_TBLEND_FILTER 0
++#define CONFIG_TELECINE_FILTER 0
++#define CONFIG_THISTOGRAM_FILTER 0
++#define CONFIG_THRESHOLD_FILTER 0
++#define CONFIG_THUMBNAIL_FILTER 0
++#define CONFIG_THUMBNAIL_CUDA_FILTER 0
++#define CONFIG_TILE_FILTER 0
++#define CONFIG_TILTANDSHIFT_FILTER 0
++#define CONFIG_TINTERLACE_FILTER 0
++#define CONFIG_TLUT2_FILTER 0
++#define CONFIG_TMEDIAN_FILTER 0
++#define CONFIG_TMIDEQUALIZER_FILTER 0
++#define CONFIG_TMIX_FILTER 0
++#define CONFIG_TONEMAP_FILTER 0
++#define CONFIG_TONEMAP_OPENCL_FILTER 0
++#define CONFIG_TONEMAP_VAAPI_FILTER 0
++#define CONFIG_TPAD_FILTER 0
++#define CONFIG_TRANSPOSE_FILTER 0
++#define CONFIG_TRANSPOSE_NPP_FILTER 0
++#define CONFIG_TRANSPOSE_OPENCL_FILTER 0
++#define CONFIG_TRANSPOSE_VAAPI_FILTER 0
++#define CONFIG_TRANSPOSE_VT_FILTER 0
++#define CONFIG_TRANSPOSE_VULKAN_FILTER 0
++#define CONFIG_TRIM_FILTER 0
++#define CONFIG_UNPREMULTIPLY_FILTER 0
++#define CONFIG_UNSHARP_FILTER 0
++#define CONFIG_UNSHARP_OPENCL_FILTER 0
++#define CONFIG_UNTILE_FILTER 0
++#define CONFIG_USPP_FILTER 0
++#define CONFIG_V360_FILTER 0
++#define CONFIG_VAGUEDENOISER_FILTER 0
++#define CONFIG_VARBLUR_FILTER 0
++#define CONFIG_VECTORSCOPE_FILTER 0
++#define CONFIG_VFLIP_FILTER 0
++#define CONFIG_VFLIP_VULKAN_FILTER 0
++#define CONFIG_VFRDET_FILTER 0
++#define CONFIG_VIBRANCE_FILTER 0
++#define CONFIG_VIDSTABDETECT_FILTER 0
++#define CONFIG_VIDSTABTRANSFORM_FILTER 0
++#define CONFIG_VIF_FILTER 0
++#define CONFIG_VIGNETTE_FILTER 0
++#define CONFIG_VMAFMOTION_FILTER 0
++#define CONFIG_VPP_QSV_FILTER 0
++#define CONFIG_VSTACK_FILTER 0
++#define CONFIG_W3FDIF_FILTER 0
++#define CONFIG_WAVEFORM_FILTER 0
++#define CONFIG_WEAVE_FILTER 0
++#define CONFIG_XBR_FILTER 0
++#define CONFIG_XCORRELATE_FILTER 0
++#define CONFIG_XFADE_FILTER 0
++#define CONFIG_XFADE_OPENCL_FILTER 0
++#define CONFIG_XFADE_VULKAN_FILTER 0
++#define CONFIG_XMEDIAN_FILTER 0
++#define CONFIG_XSTACK_FILTER 0
++#define CONFIG_YADIF_FILTER 0
++#define CONFIG_YADIF_CUDA_FILTER 0
++#define CONFIG_YADIF_VIDEOTOOLBOX_FILTER 0
++#define CONFIG_YAEPBLUR_FILTER 0
++#define CONFIG_ZMQ_FILTER 0
++#define CONFIG_ZOOMPAN_FILTER 0
++#define CONFIG_ZSCALE_FILTER 0
++#define CONFIG_HSTACK_VAAPI_FILTER 0
++#define CONFIG_VSTACK_VAAPI_FILTER 0
++#define CONFIG_XSTACK_VAAPI_FILTER 0
++#define CONFIG_HSTACK_QSV_FILTER 0
++#define CONFIG_VSTACK_QSV_FILTER 0
++#define CONFIG_XSTACK_QSV_FILTER 0
++#define CONFIG_ALLRGB_FILTER 0
++#define CONFIG_ALLYUV_FILTER 0
++#define CONFIG_CELLAUTO_FILTER 0
++#define CONFIG_COLOR_FILTER 0
++#define CONFIG_COLOR_VULKAN_FILTER 0
++#define CONFIG_COLORCHART_FILTER 0
++#define CONFIG_COLORSPECTRUM_FILTER 0
++#define CONFIG_COREIMAGESRC_FILTER 0
++#define CONFIG_DDAGRAB_FILTER 0
++#define CONFIG_FREI0R_SRC_FILTER 0
++#define CONFIG_GRADIENTS_FILTER 0
++#define CONFIG_HALDCLUTSRC_FILTER 0
++#define CONFIG_LIFE_FILTER 0
++#define CONFIG_MANDELBROT_FILTER 0
++#define CONFIG_MPTESTSRC_FILTER 0
++#define CONFIG_NULLSRC_FILTER 0
++#define CONFIG_OPENCLSRC_FILTER 0
++#define CONFIG_QRENCODESRC_FILTER 0
++#define CONFIG_PAL75BARS_FILTER 0
++#define CONFIG_PAL100BARS_FILTER 0
++#define CONFIG_RGBTESTSRC_FILTER 0
++#define CONFIG_SIERPINSKI_FILTER 0
++#define CONFIG_SMPTEBARS_FILTER 0
++#define CONFIG_SMPTEHDBARS_FILTER 0
++#define CONFIG_TESTSRC_FILTER 0
++#define CONFIG_TESTSRC2_FILTER 0
++#define CONFIG_YUVTESTSRC_FILTER 0
++#define CONFIG_ZONEPLATE_FILTER 0
++#define CONFIG_NULLSINK_FILTER 0
++#define CONFIG_A3DSCOPE_FILTER 0
++#define CONFIG_ABITSCOPE_FILTER 0
++#define CONFIG_ADRAWGRAPH_FILTER 0
++#define CONFIG_AGRAPHMONITOR_FILTER 0
++#define CONFIG_AHISTOGRAM_FILTER 0
++#define CONFIG_APHASEMETER_FILTER 0
++#define CONFIG_AVECTORSCOPE_FILTER 0
++#define CONFIG_CONCAT_FILTER 0
++#define CONFIG_SHOWCQT_FILTER 0
++#define CONFIG_SHOWCWT_FILTER 0
++#define CONFIG_SHOWFREQS_FILTER 0
++#define CONFIG_SHOWSPATIAL_FILTER 0
++#define CONFIG_SHOWSPECTRUM_FILTER 0
++#define CONFIG_SHOWSPECTRUMPIC_FILTER 0
++#define CONFIG_SHOWVOLUME_FILTER 0
++#define CONFIG_SHOWWAVES_FILTER 0
++#define CONFIG_SHOWWAVESPIC_FILTER 0
++#define CONFIG_SPECTRUMSYNTH_FILTER 0
++#define CONFIG_AVSYNCTEST_FILTER 0
++#define CONFIG_AMOVIE_FILTER 0
++#define CONFIG_MOVIE_FILTER 0
++#define CONFIG_AA_DEMUXER 0
++#define CONFIG_AAC_DEMUXER 1
++#define CONFIG_AAX_DEMUXER 0
++#define CONFIG_AC3_DEMUXER 0
++#define CONFIG_AC4_DEMUXER 0
++#define CONFIG_ACE_DEMUXER 0
++#define CONFIG_ACM_DEMUXER 0
++#define CONFIG_ACT_DEMUXER 0
++#define CONFIG_ADF_DEMUXER 0
++#define CONFIG_ADP_DEMUXER 0
++#define CONFIG_ADS_DEMUXER 0
++#define CONFIG_ADX_DEMUXER 0
++#define CONFIG_AEA_DEMUXER 0
++#define CONFIG_AFC_DEMUXER 0
++#define CONFIG_AIFF_DEMUXER 0
++#define CONFIG_AIX_DEMUXER 0
++#define CONFIG_ALP_DEMUXER 0
++#define CONFIG_AMR_DEMUXER 0
++#define CONFIG_AMRNB_DEMUXER 0
++#define CONFIG_AMRWB_DEMUXER 0
++#define CONFIG_ANM_DEMUXER 0
++#define CONFIG_APAC_DEMUXER 0
++#define CONFIG_APC_DEMUXER 0
++#define CONFIG_APE_DEMUXER 0
++#define CONFIG_APM_DEMUXER 0
++#define CONFIG_APNG_DEMUXER 0
++#define CONFIG_APTX_DEMUXER 0
++#define CONFIG_APTX_HD_DEMUXER 0
++#define CONFIG_AQTITLE_DEMUXER 0
++#define CONFIG_ARGO_ASF_DEMUXER 0
++#define CONFIG_ARGO_BRP_DEMUXER 0
++#define CONFIG_ARGO_CVG_DEMUXER 0
++#define CONFIG_ASF_DEMUXER 0
++#define CONFIG_ASF_O_DEMUXER 0
++#define CONFIG_ASS_DEMUXER 0
++#define CONFIG_AST_DEMUXER 0
++#define CONFIG_AU_DEMUXER 0
++#define CONFIG_AV1_DEMUXER 0
++#define CONFIG_AVI_DEMUXER 0
++#define CONFIG_AVISYNTH_DEMUXER 0
++#define CONFIG_AVR_DEMUXER 0
++#define CONFIG_AVS_DEMUXER 0
++#define CONFIG_AVS2_DEMUXER 0
++#define CONFIG_AVS3_DEMUXER 0
++#define CONFIG_BETHSOFTVID_DEMUXER 0
++#define CONFIG_BFI_DEMUXER 0
++#define CONFIG_BINTEXT_DEMUXER 0
++#define CONFIG_BINK_DEMUXER 0
++#define CONFIG_BINKA_DEMUXER 0
++#define CONFIG_BIT_DEMUXER 0
++#define CONFIG_BITPACKED_DEMUXER 0
++#define CONFIG_BMV_DEMUXER 0
++#define CONFIG_BFSTM_DEMUXER 0
++#define CONFIG_BRSTM_DEMUXER 0
++#define CONFIG_BOA_DEMUXER 0
++#define CONFIG_BONK_DEMUXER 0
++#define CONFIG_C93_DEMUXER 0
++#define CONFIG_CAF_DEMUXER 0
++#define CONFIG_CAVSVIDEO_DEMUXER 0
++#define CONFIG_CDG_DEMUXER 0
++#define CONFIG_CDXL_DEMUXER 0
++#define CONFIG_CINE_DEMUXER 0
++#define CONFIG_CODEC2_DEMUXER 0
++#define CONFIG_CODEC2RAW_DEMUXER 0
++#define CONFIG_CONCAT_DEMUXER 0
++#define CONFIG_DASH_DEMUXER 0
++#define CONFIG_DATA_DEMUXER 0
++#define CONFIG_DAUD_DEMUXER 0
++#define CONFIG_DCSTR_DEMUXER 0
++#define CONFIG_DERF_DEMUXER 0
++#define CONFIG_DFA_DEMUXER 0
++#define CONFIG_DFPWM_DEMUXER 0
++#define CONFIG_DHAV_DEMUXER 0
++#define CONFIG_DIRAC_DEMUXER 0
++#define CONFIG_DNXHD_DEMUXER 0
++#define CONFIG_DSF_DEMUXER 0
++#define CONFIG_DSICIN_DEMUXER 0
++#define CONFIG_DSS_DEMUXER 0
++#define CONFIG_DTS_DEMUXER 0
++#define CONFIG_DTSHD_DEMUXER 0
++#define CONFIG_DV_DEMUXER 0
++#define CONFIG_DVBSUB_DEMUXER 0
++#define CONFIG_DVBTXT_DEMUXER 0
++#define CONFIG_DXA_DEMUXER 0
++#define CONFIG_EA_DEMUXER 0
++#define CONFIG_EA_CDATA_DEMUXER 0
++#define CONFIG_EAC3_DEMUXER 0
++#define CONFIG_EPAF_DEMUXER 0
++#define CONFIG_EVC_DEMUXER 0
++#define CONFIG_FFMETADATA_DEMUXER 0
++#define CONFIG_FILMSTRIP_DEMUXER 0
++#define CONFIG_FITS_DEMUXER 0
++#define CONFIG_FLAC_DEMUXER 1
++#define CONFIG_FLIC_DEMUXER 0
++#define CONFIG_FLV_DEMUXER 0
++#define CONFIG_LIVE_FLV_DEMUXER 0
++#define CONFIG_FOURXM_DEMUXER 0
++#define CONFIG_FRM_DEMUXER 0
++#define CONFIG_FSB_DEMUXER 0
++#define CONFIG_FWSE_DEMUXER 0
++#define CONFIG_G722_DEMUXER 0
++#define CONFIG_G723_1_DEMUXER 0
++#define CONFIG_G726_DEMUXER 0
++#define CONFIG_G726LE_DEMUXER 0
++#define CONFIG_G729_DEMUXER 0
++#define CONFIG_GDV_DEMUXER 0
++#define CONFIG_GENH_DEMUXER 0
++#define CONFIG_GIF_DEMUXER 0
++#define CONFIG_GSM_DEMUXER 0
++#define CONFIG_GXF_DEMUXER 0
++#define CONFIG_H261_DEMUXER 0
++#define CONFIG_H263_DEMUXER 0
++#define CONFIG_H264_DEMUXER 0
++#define CONFIG_HCA_DEMUXER 0
++#define CONFIG_HCOM_DEMUXER 0
++#define CONFIG_HEVC_DEMUXER 0
++#define CONFIG_HLS_DEMUXER 0
++#define CONFIG_HNM_DEMUXER 0
++#define CONFIG_IAMF_DEMUXER 0
++#define CONFIG_ICO_DEMUXER 0
++#define CONFIG_IDCIN_DEMUXER 0
++#define CONFIG_IDF_DEMUXER 0
++#define CONFIG_IFF_DEMUXER 0
++#define CONFIG_IFV_DEMUXER 0
++#define CONFIG_ILBC_DEMUXER 0
++#define CONFIG_IMAGE2_DEMUXER 0
++#define CONFIG_IMAGE2PIPE_DEMUXER 0
++#define CONFIG_IMAGE2_ALIAS_PIX_DEMUXER 0
++#define CONFIG_IMAGE2_BRENDER_PIX_DEMUXER 0
++#define CONFIG_IMF_DEMUXER 0
++#define CONFIG_INGENIENT_DEMUXER 0
++#define CONFIG_IPMOVIE_DEMUXER 0
++#define CONFIG_IPU_DEMUXER 0
++#define CONFIG_IRCAM_DEMUXER 0
++#define CONFIG_ISS_DEMUXER 0
++#define CONFIG_IV8_DEMUXER 0
++#define CONFIG_IVF_DEMUXER 0
++#define CONFIG_IVR_DEMUXER 0
++#define CONFIG_JACOSUB_DEMUXER 0
++#define CONFIG_JV_DEMUXER 0
++#define CONFIG_JPEGXL_ANIM_DEMUXER 0
++#define CONFIG_KUX_DEMUXER 0
++#define CONFIG_KVAG_DEMUXER 0
++#define CONFIG_LAF_DEMUXER 0
++#define CONFIG_LMLM4_DEMUXER 0
++#define CONFIG_LOAS_DEMUXER 0
++#define CONFIG_LUODAT_DEMUXER 0
++#define CONFIG_LRC_DEMUXER 0
++#define CONFIG_LVF_DEMUXER 0
++#define CONFIG_LXF_DEMUXER 0
++#define CONFIG_M4V_DEMUXER 0
++#define CONFIG_MCA_DEMUXER 0
++#define CONFIG_MCC_DEMUXER 0
++#define CONFIG_MATROSKA_DEMUXER 1
++#define CONFIG_MGSTS_DEMUXER 0
++#define CONFIG_MICRODVD_DEMUXER 0
++#define CONFIG_MJPEG_DEMUXER 0
++#define CONFIG_MJPEG_2000_DEMUXER 0
++#define CONFIG_MLP_DEMUXER 0
++#define CONFIG_MLV_DEMUXER 0
++#define CONFIG_MM_DEMUXER 0
++#define CONFIG_MMF_DEMUXER 0
++#define CONFIG_MODS_DEMUXER 0
++#define CONFIG_MOFLEX_DEMUXER 0
++#define CONFIG_MOV_DEMUXER 1
++#define CONFIG_MP3_DEMUXER 1
++#define CONFIG_MPC_DEMUXER 0
++#define CONFIG_MPC8_DEMUXER 0
++#define CONFIG_MPEGPS_DEMUXER 0
++#define CONFIG_MPEGTS_DEMUXER 0
++#define CONFIG_MPEGTSRAW_DEMUXER 0
++#define CONFIG_MPEGVIDEO_DEMUXER 0
++#define CONFIG_MPJPEG_DEMUXER 0
++#define CONFIG_MPL2_DEMUXER 0
++#define CONFIG_MPSUB_DEMUXER 0
++#define CONFIG_MSF_DEMUXER 0
++#define CONFIG_MSNWC_TCP_DEMUXER 0
++#define CONFIG_MSP_DEMUXER 0
++#define CONFIG_MTAF_DEMUXER 0
++#define CONFIG_MTV_DEMUXER 0
++#define CONFIG_MUSX_DEMUXER 0
++#define CONFIG_MV_DEMUXER 0
++#define CONFIG_MVI_DEMUXER 0
++#define CONFIG_MXF_DEMUXER 0
++#define CONFIG_MXG_DEMUXER 0
++#define CONFIG_NC_DEMUXER 0
++#define CONFIG_NISTSPHERE_DEMUXER 0
++#define CONFIG_NSP_DEMUXER 0
++#define CONFIG_NSV_DEMUXER 0
++#define CONFIG_NUT_DEMUXER 0
++#define CONFIG_NUV_DEMUXER 0
++#define CONFIG_OBU_DEMUXER 0
++#define CONFIG_OGG_DEMUXER 1
++#define CONFIG_OMA_DEMUXER 0
++#define CONFIG_OSQ_DEMUXER 0
++#define CONFIG_PAF_DEMUXER 0
++#define CONFIG_PCM_ALAW_DEMUXER 0
++#define CONFIG_PCM_MULAW_DEMUXER 0
++#define CONFIG_PCM_VIDC_DEMUXER 0
++#define CONFIG_PCM_F64BE_DEMUXER 0
++#define CONFIG_PCM_F64LE_DEMUXER 0
++#define CONFIG_PCM_F32BE_DEMUXER 0
++#define CONFIG_PCM_F32LE_DEMUXER 0
++#define CONFIG_PCM_S32BE_DEMUXER 0
++#define CONFIG_PCM_S32LE_DEMUXER 0
++#define CONFIG_PCM_S24BE_DEMUXER 0
++#define CONFIG_PCM_S24LE_DEMUXER 0
++#define CONFIG_PCM_S16BE_DEMUXER 0
++#define CONFIG_PCM_S16LE_DEMUXER 0
++#define CONFIG_PCM_S8_DEMUXER 0
++#define CONFIG_PCM_U32BE_DEMUXER 0
++#define CONFIG_PCM_U32LE_DEMUXER 0
++#define CONFIG_PCM_U24BE_DEMUXER 0
++#define CONFIG_PCM_U24LE_DEMUXER 0
++#define CONFIG_PCM_U16BE_DEMUXER 0
++#define CONFIG_PCM_U16LE_DEMUXER 0
++#define CONFIG_PCM_U8_DEMUXER 0
++#define CONFIG_PDV_DEMUXER 0
++#define CONFIG_PJS_DEMUXER 0
++#define CONFIG_PMP_DEMUXER 0
++#define CONFIG_PP_BNK_DEMUXER 0
++#define CONFIG_PVA_DEMUXER 0
++#define CONFIG_PVF_DEMUXER 0
++#define CONFIG_QCP_DEMUXER 0
++#define CONFIG_QOA_DEMUXER 0
++#define CONFIG_R3D_DEMUXER 0
++#define CONFIG_RAWVIDEO_DEMUXER 0
++#define CONFIG_REALTEXT_DEMUXER 0
++#define CONFIG_REDSPARK_DEMUXER 0
++#define CONFIG_RKA_DEMUXER 0
++#define CONFIG_RL2_DEMUXER 0
++#define CONFIG_RM_DEMUXER 0
++#define CONFIG_ROQ_DEMUXER 0
++#define CONFIG_RPL_DEMUXER 0
++#define CONFIG_RSD_DEMUXER 0
++#define CONFIG_RSO_DEMUXER 0
++#define CONFIG_RTP_DEMUXER 0
++#define CONFIG_RTSP_DEMUXER 0
++#define CONFIG_S337M_DEMUXER 0
++#define CONFIG_SAMI_DEMUXER 0
++#define CONFIG_SAP_DEMUXER 0
++#define CONFIG_SBC_DEMUXER 0
++#define CONFIG_SBG_DEMUXER 0
++#define CONFIG_SCC_DEMUXER 0
++#define CONFIG_SCD_DEMUXER 0
++#define CONFIG_SDNS_DEMUXER 0
++#define CONFIG_SDP_DEMUXER 0
++#define CONFIG_SDR2_DEMUXER 0
++#define CONFIG_SDS_DEMUXER 0
++#define CONFIG_SDX_DEMUXER 0
++#define CONFIG_SEGAFILM_DEMUXER 0
++#define CONFIG_SER_DEMUXER 0
++#define CONFIG_SGA_DEMUXER 0
++#define CONFIG_SHORTEN_DEMUXER 0
++#define CONFIG_SIFF_DEMUXER 0
++#define CONFIG_SIMBIOSIS_IMX_DEMUXER 0
++#define CONFIG_SLN_DEMUXER 0
++#define CONFIG_SMACKER_DEMUXER 0
++#define CONFIG_SMJPEG_DEMUXER 0
++#define CONFIG_SMUSH_DEMUXER 0
++#define CONFIG_SOL_DEMUXER 0
++#define CONFIG_SOX_DEMUXER 0
++#define CONFIG_SPDIF_DEMUXER 0
++#define CONFIG_SRT_DEMUXER 0
++#define CONFIG_STR_DEMUXER 0
++#define CONFIG_STL_DEMUXER 0
++#define CONFIG_SUBVIEWER1_DEMUXER 0
++#define CONFIG_SUBVIEWER_DEMUXER 0
++#define CONFIG_SUP_DEMUXER 0
++#define CONFIG_SVAG_DEMUXER 0
++#define CONFIG_SVS_DEMUXER 0
++#define CONFIG_SWF_DEMUXER 0
++#define CONFIG_TAK_DEMUXER 0
++#define CONFIG_TEDCAPTIONS_DEMUXER 0
++#define CONFIG_THP_DEMUXER 0
++#define CONFIG_THREEDOSTR_DEMUXER 0
++#define CONFIG_TIERTEXSEQ_DEMUXER 0
++#define CONFIG_TMV_DEMUXER 0
++#define CONFIG_TRUEHD_DEMUXER 0
++#define CONFIG_TTA_DEMUXER 0
++#define CONFIG_TXD_DEMUXER 0
++#define CONFIG_TTY_DEMUXER 0
++#define CONFIG_TY_DEMUXER 0
++#define CONFIG_USM_DEMUXER 0
++#define CONFIG_V210_DEMUXER 0
++#define CONFIG_V210X_DEMUXER 0
++#define CONFIG_VAG_DEMUXER 0
++#define CONFIG_VC1_DEMUXER 0
++#define CONFIG_VC1T_DEMUXER 0
++#define CONFIG_VIVIDAS_DEMUXER 0
++#define CONFIG_VIVO_DEMUXER 0
++#define CONFIG_VMD_DEMUXER 0
++#define CONFIG_VOBSUB_DEMUXER 0
++#define CONFIG_VOC_DEMUXER 0
++#define CONFIG_VPK_DEMUXER 0
++#define CONFIG_VPLAYER_DEMUXER 0
++#define CONFIG_VQF_DEMUXER 0
++#define CONFIG_VVC_DEMUXER 0
++#define CONFIG_W64_DEMUXER 0
++#define CONFIG_WADY_DEMUXER 0
++#define CONFIG_WAVARC_DEMUXER 0
++#define CONFIG_WAV_DEMUXER 1
++#define CONFIG_WC3_DEMUXER 0
++#define CONFIG_WEBM_DASH_MANIFEST_DEMUXER 0
++#define CONFIG_WEBVTT_DEMUXER 0
++#define CONFIG_WSAUD_DEMUXER 0
++#define CONFIG_WSD_DEMUXER 0
++#define CONFIG_WSVQA_DEMUXER 0
++#define CONFIG_WTV_DEMUXER 0
++#define CONFIG_WVE_DEMUXER 0
++#define CONFIG_WV_DEMUXER 0
++#define CONFIG_XA_DEMUXER 0
++#define CONFIG_XBIN_DEMUXER 0
++#define CONFIG_XMD_DEMUXER 0
++#define CONFIG_XMV_DEMUXER 0
++#define CONFIG_XVAG_DEMUXER 0
++#define CONFIG_XWMA_DEMUXER 0
++#define CONFIG_YOP_DEMUXER 0
++#define CONFIG_YUV4MPEGPIPE_DEMUXER 0
++#define CONFIG_IMAGE_BMP_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_CRI_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_DDS_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_DPX_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_EXR_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_GEM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_GIF_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_HDR_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_J2K_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_JPEG_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_JPEGLS_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_JPEGXL_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PAM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PBM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PCX_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PFM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PGMYUV_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PGM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PGX_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PHM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PHOTOCD_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PICTOR_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PNG_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PPM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PSD_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_QDRAW_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_QOI_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_SGI_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_SVG_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_SUNRAST_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_TIFF_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_VBN_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_WEBP_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_XBM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_XPM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_XWD_PIPE_DEMUXER 0
++#define CONFIG_LIBGME_DEMUXER 0
++#define CONFIG_LIBMODPLUG_DEMUXER 0
++#define CONFIG_LIBOPENMPT_DEMUXER 0
++#define CONFIG_VAPOURSYNTH_DEMUXER 0
++#define CONFIG_A64_MUXER 0
++#define CONFIG_AC3_MUXER 0
++#define CONFIG_AC4_MUXER 0
++#define CONFIG_ADTS_MUXER 0
++#define CONFIG_ADX_MUXER 0
++#define CONFIG_AIFF_MUXER 0
++#define CONFIG_ALP_MUXER 0
++#define CONFIG_AMR_MUXER 0
++#define CONFIG_AMV_MUXER 0
++#define CONFIG_APM_MUXER 0
++#define CONFIG_APNG_MUXER 0
++#define CONFIG_APTX_MUXER 0
++#define CONFIG_APTX_HD_MUXER 0
++#define CONFIG_ARGO_ASF_MUXER 0
++#define CONFIG_ARGO_CVG_MUXER 0
++#define CONFIG_ASF_MUXER 0
++#define CONFIG_ASS_MUXER 0
++#define CONFIG_AST_MUXER 0
++#define CONFIG_ASF_STREAM_MUXER 0
++#define CONFIG_AU_MUXER 0
++#define CONFIG_AVI_MUXER 0
++#define CONFIG_AVIF_MUXER 0
++#define CONFIG_AVM2_MUXER 0
++#define CONFIG_AVS2_MUXER 0
++#define CONFIG_AVS3_MUXER 0
++#define CONFIG_BIT_MUXER 0
++#define CONFIG_CAF_MUXER 0
++#define CONFIG_CAVSVIDEO_MUXER 0
++#define CONFIG_CODEC2_MUXER 0
++#define CONFIG_CODEC2RAW_MUXER 0
++#define CONFIG_CRC_MUXER 0
++#define CONFIG_DASH_MUXER 0
++#define CONFIG_DATA_MUXER 0
++#define CONFIG_DAUD_MUXER 0
++#define CONFIG_DFPWM_MUXER 0
++#define CONFIG_DIRAC_MUXER 0
++#define CONFIG_DNXHD_MUXER 0
++#define CONFIG_DTS_MUXER 0
++#define CONFIG_DV_MUXER 0
++#define CONFIG_EAC3_MUXER 0
++#define CONFIG_EVC_MUXER 0
++#define CONFIG_F4V_MUXER 0
++#define CONFIG_FFMETADATA_MUXER 0
++#define CONFIG_FIFO_MUXER 0
++#define CONFIG_FIFO_TEST_MUXER 0
++#define CONFIG_FILMSTRIP_MUXER 0
++#define CONFIG_FITS_MUXER 0
++#define CONFIG_FLAC_MUXER 0
++#define CONFIG_FLV_MUXER 0
++#define CONFIG_FRAMECRC_MUXER 0
++#define CONFIG_FRAMEHASH_MUXER 0
++#define CONFIG_FRAMEMD5_MUXER 0
++#define CONFIG_G722_MUXER 0
++#define CONFIG_G723_1_MUXER 0
++#define CONFIG_G726_MUXER 0
++#define CONFIG_G726LE_MUXER 0
++#define CONFIG_GIF_MUXER 0
++#define CONFIG_GSM_MUXER 0
++#define CONFIG_GXF_MUXER 0
++#define CONFIG_H261_MUXER 0
++#define CONFIG_H263_MUXER 0
++#define CONFIG_H264_MUXER 0
++#define CONFIG_HASH_MUXER 0
++#define CONFIG_HDS_MUXER 0
++#define CONFIG_HEVC_MUXER 0
++#define CONFIG_HLS_MUXER 0
++#define CONFIG_IAMF_MUXER 0
++#define CONFIG_ICO_MUXER 0
++#define CONFIG_ILBC_MUXER 0
++#define CONFIG_IMAGE2_MUXER 0
++#define CONFIG_IMAGE2PIPE_MUXER 0
++#define CONFIG_IPOD_MUXER 0
++#define CONFIG_IRCAM_MUXER 0
++#define CONFIG_ISMV_MUXER 0
++#define CONFIG_IVF_MUXER 0
++#define CONFIG_JACOSUB_MUXER 0
++#define CONFIG_KVAG_MUXER 0
++#define CONFIG_LATM_MUXER 0
++#define CONFIG_LRC_MUXER 0
++#define CONFIG_M4V_MUXER 0
++#define CONFIG_MD5_MUXER 0
++#define CONFIG_MATROSKA_MUXER 0
++#define CONFIG_MATROSKA_AUDIO_MUXER 0
++#define CONFIG_MICRODVD_MUXER 0
++#define CONFIG_MJPEG_MUXER 0
++#define CONFIG_MLP_MUXER 0
++#define CONFIG_MMF_MUXER 0
++#define CONFIG_MOV_MUXER 0
++#define CONFIG_MP2_MUXER 0
++#define CONFIG_MP3_MUXER 0
++#define CONFIG_MP4_MUXER 0
++#define CONFIG_MPEG1SYSTEM_MUXER 0
++#define CONFIG_MPEG1VCD_MUXER 0
++#define CONFIG_MPEG1VIDEO_MUXER 0
++#define CONFIG_MPEG2DVD_MUXER 0
++#define CONFIG_MPEG2SVCD_MUXER 0
++#define CONFIG_MPEG2VIDEO_MUXER 0
++#define CONFIG_MPEG2VOB_MUXER 0
++#define CONFIG_MPEGTS_MUXER 0
++#define CONFIG_MPJPEG_MUXER 0
++#define CONFIG_MXF_MUXER 0
++#define CONFIG_MXF_D10_MUXER 0
++#define CONFIG_MXF_OPATOM_MUXER 0
++#define CONFIG_NULL_MUXER 0
++#define CONFIG_NUT_MUXER 0
++#define CONFIG_OBU_MUXER 0
++#define CONFIG_OGA_MUXER 0
++#define CONFIG_OGG_MUXER 0
++#define CONFIG_OGV_MUXER 0
++#define CONFIG_OMA_MUXER 0
++#define CONFIG_OPUS_MUXER 0
++#define CONFIG_PCM_ALAW_MUXER 0
++#define CONFIG_PCM_MULAW_MUXER 0
++#define CONFIG_PCM_VIDC_MUXER 0
++#define CONFIG_PCM_F64BE_MUXER 0
++#define CONFIG_PCM_F64LE_MUXER 0
++#define CONFIG_PCM_F32BE_MUXER 0
++#define CONFIG_PCM_F32LE_MUXER 0
++#define CONFIG_PCM_S32BE_MUXER 0
++#define CONFIG_PCM_S32LE_MUXER 0
++#define CONFIG_PCM_S24BE_MUXER 0
++#define CONFIG_PCM_S24LE_MUXER 0
++#define CONFIG_PCM_S16BE_MUXER 0
++#define CONFIG_PCM_S16LE_MUXER 0
++#define CONFIG_PCM_S8_MUXER 0
++#define CONFIG_PCM_U32BE_MUXER 0
++#define CONFIG_PCM_U32LE_MUXER 0
++#define CONFIG_PCM_U24BE_MUXER 0
++#define CONFIG_PCM_U24LE_MUXER 0
++#define CONFIG_PCM_U16BE_MUXER 0
++#define CONFIG_PCM_U16LE_MUXER 0
++#define CONFIG_PCM_U8_MUXER 0
++#define CONFIG_PSP_MUXER 0
++#define CONFIG_RAWVIDEO_MUXER 0
++#define CONFIG_RCWT_MUXER 0
++#define CONFIG_RM_MUXER 0
++#define CONFIG_ROQ_MUXER 0
++#define CONFIG_RSO_MUXER 0
++#define CONFIG_RTP_MUXER 0
++#define CONFIG_RTP_MPEGTS_MUXER 0
++#define CONFIG_RTSP_MUXER 0
++#define CONFIG_SAP_MUXER 0
++#define CONFIG_SBC_MUXER 0
++#define CONFIG_SCC_MUXER 0
++#define CONFIG_SEGAFILM_MUXER 0
++#define CONFIG_SEGMENT_MUXER 0
++#define CONFIG_STREAM_SEGMENT_MUXER 0
++#define CONFIG_SMJPEG_MUXER 0
++#define CONFIG_SMOOTHSTREAMING_MUXER 0
++#define CONFIG_SOX_MUXER 0
++#define CONFIG_SPX_MUXER 0
++#define CONFIG_SPDIF_MUXER 0
++#define CONFIG_SRT_MUXER 0
++#define CONFIG_STREAMHASH_MUXER 0
++#define CONFIG_SUP_MUXER 0
++#define CONFIG_SWF_MUXER 0
++#define CONFIG_TEE_MUXER 0
++#define CONFIG_TG2_MUXER 0
++#define CONFIG_TGP_MUXER 0
++#define CONFIG_MKVTIMESTAMP_V2_MUXER 0
++#define CONFIG_TRUEHD_MUXER 0
++#define CONFIG_TTA_MUXER 0
++#define CONFIG_TTML_MUXER 0
++#define CONFIG_UNCODEDFRAMECRC_MUXER 0
++#define CONFIG_VC1_MUXER 0
++#define CONFIG_VC1T_MUXER 0
++#define CONFIG_VOC_MUXER 0
++#define CONFIG_VVC_MUXER 0
++#define CONFIG_W64_MUXER 0
++#define CONFIG_WAV_MUXER 0
++#define CONFIG_WEBM_MUXER 0
++#define CONFIG_WEBM_DASH_MANIFEST_MUXER 0
++#define CONFIG_WEBM_CHUNK_MUXER 0
++#define CONFIG_WEBP_MUXER 0
++#define CONFIG_WEBVTT_MUXER 0
++#define CONFIG_WSAUD_MUXER 0
++#define CONFIG_WTV_MUXER 0
++#define CONFIG_WV_MUXER 0
++#define CONFIG_YUV4MPEGPIPE_MUXER 0
++#define CONFIG_CHROMAPRINT_MUXER 0
++#define CONFIG_ASYNC_PROTOCOL 0
++#define CONFIG_BLURAY_PROTOCOL 0
++#define CONFIG_CACHE_PROTOCOL 0
++#define CONFIG_CONCAT_PROTOCOL 0
++#define CONFIG_CONCATF_PROTOCOL 0
++#define CONFIG_CRYPTO_PROTOCOL 0
++#define CONFIG_DATA_PROTOCOL 0
++#define CONFIG_FD_PROTOCOL 0
++#define CONFIG_FFRTMPCRYPT_PROTOCOL 0
++#define CONFIG_FFRTMPHTTP_PROTOCOL 0
++#define CONFIG_FILE_PROTOCOL 0
++#define CONFIG_FTP_PROTOCOL 0
++#define CONFIG_GOPHER_PROTOCOL 0
++#define CONFIG_GOPHERS_PROTOCOL 0
++#define CONFIG_HLS_PROTOCOL 0
++#define CONFIG_HTTP_PROTOCOL 0
++#define CONFIG_HTTPPROXY_PROTOCOL 0
++#define CONFIG_HTTPS_PROTOCOL 0
++#define CONFIG_ICECAST_PROTOCOL 0
++#define CONFIG_MMSH_PROTOCOL 0
++#define CONFIG_MMST_PROTOCOL 0
++#define CONFIG_MD5_PROTOCOL 0
++#define CONFIG_PIPE_PROTOCOL 0
++#define CONFIG_PROMPEG_PROTOCOL 0
++#define CONFIG_RTMP_PROTOCOL 0
++#define CONFIG_RTMPE_PROTOCOL 0
++#define CONFIG_RTMPS_PROTOCOL 0
++#define CONFIG_RTMPT_PROTOCOL 0
++#define CONFIG_RTMPTE_PROTOCOL 0
++#define CONFIG_RTMPTS_PROTOCOL 0
++#define CONFIG_RTP_PROTOCOL 0
++#define CONFIG_SCTP_PROTOCOL 0
++#define CONFIG_SRTP_PROTOCOL 0
++#define CONFIG_SUBFILE_PROTOCOL 0
++#define CONFIG_TEE_PROTOCOL 0
++#define CONFIG_TCP_PROTOCOL 0
++#define CONFIG_TLS_PROTOCOL 0
++#define CONFIG_UDP_PROTOCOL 0
++#define CONFIG_UDPLITE_PROTOCOL 0
++#define CONFIG_UNIX_PROTOCOL 0
++#define CONFIG_LIBAMQP_PROTOCOL 0
++#define CONFIG_LIBRIST_PROTOCOL 0
++#define CONFIG_LIBRTMP_PROTOCOL 0
++#define CONFIG_LIBRTMPE_PROTOCOL 0
++#define CONFIG_LIBRTMPS_PROTOCOL 0
++#define CONFIG_LIBRTMPT_PROTOCOL 0
++#define CONFIG_LIBRTMPTE_PROTOCOL 0
++#define CONFIG_LIBSRT_PROTOCOL 0
++#define CONFIG_LIBSSH_PROTOCOL 0
++#define CONFIG_LIBSMBCLIENT_PROTOCOL 0
++#define CONFIG_LIBZMQ_PROTOCOL 0
++#define CONFIG_IPFS_GATEWAY_PROTOCOL 0
++#define CONFIG_IPNS_GATEWAY_PROTOCOL 0
++#endif /* FFMPEG_CONFIG_COMPONENTS_H */
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c b/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c
+--- a/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/bsf_list.c	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,2 @@
++static const FFBitStreamFilter * const bitstream_filters[] = {
++    NULL };
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c b/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c
+--- a/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/codec_list.c	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,17 @@
++static const FFCodec * const codec_list[] = {
++    &ff_h264_decoder,
++    &ff_aac_decoder,
++    &ff_flac_decoder,
++    &ff_mp3_decoder,
++    &ff_vorbis_decoder,
++    &ff_pcm_alaw_decoder,
++    &ff_pcm_f32le_decoder,
++    &ff_pcm_mulaw_decoder,
++    &ff_pcm_s16be_decoder,
++    &ff_pcm_s16le_decoder,
++    &ff_pcm_s24be_decoder,
++    &ff_pcm_s24le_decoder,
++    &ff_pcm_s32le_decoder,
++    &ff_pcm_u8_decoder,
++    &ff_libopus_decoder,
++    NULL };
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c b/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c
+--- a/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavcodec/parser_list.c	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,9 @@
++static const AVCodecParser * const parser_list[] = {
++    &ff_aac_parser,
++    &ff_flac_parser,
++    &ff_h264_parser,
++    &ff_mpegaudio_parser,
++    &ff_opus_parser,
++    &ff_vorbis_parser,
++    &ff_vp9_parser,
++    NULL };
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c b/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c
+--- a/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/demuxer_list.c	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,9 @@
++static const AVInputFormat * const demuxer_list[] = {
++    &ff_aac_demuxer,
++    &ff_flac_demuxer,
++    &ff_matroska_demuxer,
++    &ff_mov_demuxer,
++    &ff_mp3_demuxer,
++    &ff_ogg_demuxer,
++    &ff_wav_demuxer,
++    NULL };
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c b/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c
+--- a/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/muxer_list.c	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,2 @@
++static const FFOutputFormat * const muxer_list[] = {
++    NULL };
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c b/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c
+--- a/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavformat/protocol_list.c	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,2 @@
++static const URLProtocol * const url_protocols[] = {
++    NULL };
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h b/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h
+--- a/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/avconfig.h	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,6 @@
++/* Generated by ffmpeg configure */
++#ifndef AVUTIL_AVCONFIG_H
++#define AVUTIL_AVCONFIG_H
++#define AV_HAVE_BIGENDIAN 0
++#define AV_HAVE_FAST_UNALIGNED 1
++#endif /* AVUTIL_AVCONFIG_H */
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/ffversion.h b/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/ffversion.h
+--- a/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/ffversion.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/ffmpeg/chromium/config/Chrome/linux/loong64/libavutil/ffversion.h	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,5 @@
++/* Automatically generated by version.sh, do not manually edit! */
++#ifndef AVUTIL_FFVERSION_H
++#define AVUTIL_FFVERSION_H
++#define FFMPEG_VERSION "n5.0.1"
++#endif /* AVUTIL_FFVERSION_H */
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config.h b/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config.h
+--- a/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config.h	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,772 @@
++/* Automatically generated by configure - do not modify! */
++#ifndef FFMPEG_CONFIG_H
++#define FFMPEG_CONFIG_H
++/* #define FFMPEG_CONFIGURATION "--disable-everything --disable-all --disable-lsx --disable-lasx --disable-doc --disable-htmlpages --disable-manpages --disable-podpages --disable-txtpages --disable-static --enable-avcodec --enable-avformat --enable-avutil --enable-static --enable-libopus --disable-debug --disable-bzlib --disable-error-resilience --disable-iconv --disable-network --disable-schannel --disable-sdl2 --disable-symver --disable-xlib --disable-zlib --disable-securetransport --disable-faan --disable-alsa --disable-autodetect --enable-decoder='vorbis,libopus,flac' --enable-decoder='pcm_u8,pcm_s16le,pcm_s24le,pcm_s32le,pcm_f32le,mp3' --enable-decoder='pcm_s16be,pcm_s24be,pcm_mulaw,pcm_alaw' --enable-demuxer='ogg,matroska,wav,flac,mp3,mov' --enable-parser='opus,vorbis,flac,mpegaudio,vp9' --disable-linux-perf --x86asmexe=nasm --optflags='\\\\\\\\\"-O2\\\\\\\\\"' --cc=clang --cxx=clang++ --ld=clang" */
++#define FFMPEG_LICENSE "LGPL version 2.1 or later"
++#define CONFIG_THIS_YEAR 2024
++#define FFMPEG_DATADIR "/usr/local/share/ffmpeg"
++#define AVCONV_DATADIR "/usr/local/share/ffmpeg"
++#define CC_IDENT "clang version 17.0.6"
++#define OS_NAME linux
++#define av_restrict restrict
++#define EXTERN_PREFIX ""
++#define EXTERN_ASM 
++#define BUILDSUF ""
++#define SLIBSUF ".so"
++#define SWS_MAX_FILTER_SIZE 256
++#define ARCH_AARCH64 0
++#define ARCH_ALPHA 0
++#define ARCH_ARM 0
++#define ARCH_AVR32 0
++#define ARCH_AVR32_AP 0
++#define ARCH_AVR32_UC 0
++#define ARCH_BFIN 0
++#define ARCH_IA64 0
++#define ARCH_LOONGARCH 1
++#define ARCH_LOONGARCH32 0
++#define ARCH_LOONGARCH64 1
++#define ARCH_M68K 0
++#define ARCH_MIPS 0
++#define ARCH_MIPS64 0
++#define ARCH_PARISC 0
++#define ARCH_PPC 0
++#define ARCH_PPC64 0
++#define ARCH_RISCV 0
++#define ARCH_S390 0
++#define ARCH_SH4 0
++#define ARCH_SPARC 0
++#define ARCH_SPARC64 0
++#define ARCH_TILEGX 0
++#define ARCH_TILEPRO 0
++#define ARCH_X86 0
++#define ARCH_X86_32 0
++#define ARCH_X86_64 0
++#define HAVE_ARMV5TE 0
++#define HAVE_ARMV6 0
++#define HAVE_ARMV6T2 0
++#define HAVE_ARMV8 0
++#define HAVE_DOTPROD 0
++#define HAVE_I8MM 0
++#define HAVE_NEON 0
++#define HAVE_VFP 0
++#define HAVE_VFPV3 0
++#define HAVE_SETEND 0
++#define HAVE_ALTIVEC 0
++#define HAVE_DCBZL 0
++#define HAVE_LDBRX 0
++#define HAVE_POWER8 0
++#define HAVE_PPC4XX 0
++#define HAVE_VSX 0
++#define HAVE_RV 0
++#define HAVE_RVV 0
++#define HAVE_AESNI 0
++#define HAVE_AMD3DNOW 0
++#define HAVE_AMD3DNOWEXT 0
++#define HAVE_AVX 0
++#define HAVE_AVX2 0
++#define HAVE_AVX512 0
++#define HAVE_AVX512ICL 0
++#define HAVE_FMA3 0
++#define HAVE_FMA4 0
++#define HAVE_MMX 0
++#define HAVE_MMXEXT 0
++#define HAVE_SSE 0
++#define HAVE_SSE2 0
++#define HAVE_SSE3 0
++#define HAVE_SSE4 0
++#define HAVE_SSE42 0
++#define HAVE_SSSE3 0
++#define HAVE_XOP 0
++#define HAVE_CPUNOP 0
++#define HAVE_I686 0
++#define HAVE_MIPSFPU 0
++#define HAVE_MIPS32R2 0
++#define HAVE_MIPS32R5 0
++#define HAVE_MIPS64R2 0
++#define HAVE_MIPS32R6 0
++#define HAVE_MIPS64R6 0
++#define HAVE_MIPSDSP 0
++#define HAVE_MIPSDSPR2 0
++#define HAVE_MSA 0
++#define HAVE_LOONGSON2 0
++#define HAVE_LOONGSON3 0
++#define HAVE_MMI 0
++#define HAVE_LSX 0
++#define HAVE_LASX 0
++#define HAVE_ARMV5TE_EXTERNAL 0
++#define HAVE_ARMV6_EXTERNAL 0
++#define HAVE_ARMV6T2_EXTERNAL 0
++#define HAVE_ARMV8_EXTERNAL 0
++#define HAVE_DOTPROD_EXTERNAL 0
++#define HAVE_I8MM_EXTERNAL 0
++#define HAVE_NEON_EXTERNAL 0
++#define HAVE_VFP_EXTERNAL 0
++#define HAVE_VFPV3_EXTERNAL 0
++#define HAVE_SETEND_EXTERNAL 0
++#define HAVE_ALTIVEC_EXTERNAL 0
++#define HAVE_DCBZL_EXTERNAL 0
++#define HAVE_LDBRX_EXTERNAL 0
++#define HAVE_POWER8_EXTERNAL 0
++#define HAVE_PPC4XX_EXTERNAL 0
++#define HAVE_VSX_EXTERNAL 0
++#define HAVE_RV_EXTERNAL 0
++#define HAVE_RVV_EXTERNAL 0
++#define HAVE_AESNI_EXTERNAL 0
++#define HAVE_AMD3DNOW_EXTERNAL 0
++#define HAVE_AMD3DNOWEXT_EXTERNAL 0
++#define HAVE_AVX_EXTERNAL 0
++#define HAVE_AVX2_EXTERNAL 0
++#define HAVE_AVX512_EXTERNAL 0
++#define HAVE_AVX512ICL_EXTERNAL 0
++#define HAVE_FMA3_EXTERNAL 0
++#define HAVE_FMA4_EXTERNAL 0
++#define HAVE_MMX_EXTERNAL 0
++#define HAVE_MMXEXT_EXTERNAL 0
++#define HAVE_SSE_EXTERNAL 0
++#define HAVE_SSE2_EXTERNAL 0
++#define HAVE_SSE3_EXTERNAL 0
++#define HAVE_SSE4_EXTERNAL 0
++#define HAVE_SSE42_EXTERNAL 0
++#define HAVE_SSSE3_EXTERNAL 0
++#define HAVE_XOP_EXTERNAL 0
++#define HAVE_CPUNOP_EXTERNAL 0
++#define HAVE_I686_EXTERNAL 0
++#define HAVE_MIPSFPU_EXTERNAL 0
++#define HAVE_MIPS32R2_EXTERNAL 0
++#define HAVE_MIPS32R5_EXTERNAL 0
++#define HAVE_MIPS64R2_EXTERNAL 0
++#define HAVE_MIPS32R6_EXTERNAL 0
++#define HAVE_MIPS64R6_EXTERNAL 0
++#define HAVE_MIPSDSP_EXTERNAL 0
++#define HAVE_MIPSDSPR2_EXTERNAL 0
++#define HAVE_MSA_EXTERNAL 0
++#define HAVE_LOONGSON2_EXTERNAL 0
++#define HAVE_LOONGSON3_EXTERNAL 0
++#define HAVE_MMI_EXTERNAL 0
++#define HAVE_LSX_EXTERNAL 0
++#define HAVE_LASX_EXTERNAL 0
++#define HAVE_ARMV5TE_INLINE 0
++#define HAVE_ARMV6_INLINE 0
++#define HAVE_ARMV6T2_INLINE 0
++#define HAVE_ARMV8_INLINE 0
++#define HAVE_DOTPROD_INLINE 0
++#define HAVE_I8MM_INLINE 0
++#define HAVE_NEON_INLINE 0
++#define HAVE_VFP_INLINE 0
++#define HAVE_VFPV3_INLINE 0
++#define HAVE_SETEND_INLINE 0
++#define HAVE_ALTIVEC_INLINE 0
++#define HAVE_DCBZL_INLINE 0
++#define HAVE_LDBRX_INLINE 0
++#define HAVE_POWER8_INLINE 0
++#define HAVE_PPC4XX_INLINE 0
++#define HAVE_VSX_INLINE 0
++#define HAVE_RV_INLINE 0
++#define HAVE_RVV_INLINE 0
++#define HAVE_AESNI_INLINE 0
++#define HAVE_AMD3DNOW_INLINE 0
++#define HAVE_AMD3DNOWEXT_INLINE 0
++#define HAVE_AVX_INLINE 0
++#define HAVE_AVX2_INLINE 0
++#define HAVE_AVX512_INLINE 0
++#define HAVE_AVX512ICL_INLINE 0
++#define HAVE_FMA3_INLINE 0
++#define HAVE_FMA4_INLINE 0
++#define HAVE_MMX_INLINE 0
++#define HAVE_MMXEXT_INLINE 0
++#define HAVE_SSE_INLINE 0
++#define HAVE_SSE2_INLINE 0
++#define HAVE_SSE3_INLINE 0
++#define HAVE_SSE4_INLINE 0
++#define HAVE_SSE42_INLINE 0
++#define HAVE_SSSE3_INLINE 0
++#define HAVE_XOP_INLINE 0
++#define HAVE_CPUNOP_INLINE 0
++#define HAVE_I686_INLINE 0
++#define HAVE_MIPSFPU_INLINE 0
++#define HAVE_MIPS32R2_INLINE 0
++#define HAVE_MIPS32R5_INLINE 0
++#define HAVE_MIPS64R2_INLINE 0
++#define HAVE_MIPS32R6_INLINE 0
++#define HAVE_MIPS64R6_INLINE 0
++#define HAVE_MIPSDSP_INLINE 0
++#define HAVE_MIPSDSPR2_INLINE 0
++#define HAVE_MSA_INLINE 0
++#define HAVE_LOONGSON2_INLINE 0
++#define HAVE_LOONGSON3_INLINE 0
++#define HAVE_MMI_INLINE 0
++#define HAVE_LSX_INLINE 0
++#define HAVE_LASX_INLINE 0
++#define HAVE_ALIGNED_STACK 0
++#define HAVE_FAST_64BIT 1
++#define HAVE_FAST_CLZ 1
++#define HAVE_FAST_CMOV 0
++#define HAVE_FAST_FLOAT16 0
++#define HAVE_LOCAL_ALIGNED 1
++#define HAVE_SIMD_ALIGN_16 0
++#define HAVE_SIMD_ALIGN_32 1
++#define HAVE_SIMD_ALIGN_64 0
++#define HAVE_ATOMIC_CAS_PTR 0
++#define HAVE_MACHINE_RW_BARRIER 0
++#define HAVE_MEMORYBARRIER 0
++#define HAVE_MM_EMPTY 0
++#define HAVE_RDTSC 0
++#define HAVE_SEM_TIMEDWAIT 1
++#define HAVE_SYNC_VAL_COMPARE_AND_SWAP 1
++#define HAVE_INLINE_ASM 1
++#define HAVE_SYMVER 0
++#define HAVE_X86ASM 0
++#define HAVE_BIGENDIAN 0
++#define HAVE_FAST_UNALIGNED 1
++#define HAVE_ARPA_INET_H 0
++#define HAVE_ASM_TYPES_H 1
++#define HAVE_CDIO_PARANOIA_H 0
++#define HAVE_CDIO_PARANOIA_PARANOIA_H 0
++#define HAVE_CUDA_H 0
++#define HAVE_DISPATCH_DISPATCH_H 0
++#define HAVE_DEV_BKTR_IOCTL_BT848_H 0
++#define HAVE_DEV_BKTR_IOCTL_METEOR_H 0
++#define HAVE_DEV_IC_BT8XX_H 0
++#define HAVE_DEV_VIDEO_BKTR_IOCTL_BT848_H 0
++#define HAVE_DEV_VIDEO_METEOR_IOCTL_METEOR_H 0
++#define HAVE_DIRECT_H 0
++#define HAVE_DIRENT_H 1
++#define HAVE_DXGIDEBUG_H 0
++#define HAVE_DXVA_H 0
++#define HAVE_ES2_GL_H 0
++#define HAVE_GSM_H 0
++#define HAVE_IO_H 0
++#define HAVE_LINUX_DMA_BUF_H 0
++#define HAVE_LINUX_PERF_EVENT_H 1
++#define HAVE_MACHINE_IOCTL_BT848_H 0
++#define HAVE_MACHINE_IOCTL_METEOR_H 0
++#define HAVE_MALLOC_H 1
++#define HAVE_OPENCV2_CORE_CORE_C_H 0
++#define HAVE_OPENGL_GL3_H 0
++#define HAVE_POLL_H 1
++#define HAVE_PTHREAD_NP_H 0
++#define HAVE_SYS_PARAM_H 1
++#define HAVE_SYS_RESOURCE_H 1
++#define HAVE_SYS_SELECT_H 1
++#define HAVE_SYS_SOUNDCARD_H 1
++#define HAVE_SYS_TIME_H 1
++#define HAVE_SYS_UN_H 1
++#define HAVE_SYS_VIDEOIO_H 0
++#define HAVE_TERMIOS_H 1
++#define HAVE_UDPLITE_H 0
++#define HAVE_UNISTD_H 1
++#define HAVE_VALGRIND_VALGRIND_H 0
++#define HAVE_WINDOWS_H 0
++#define HAVE_WINSOCK2_H 0
++#define HAVE_INTRINSICS_NEON 0
++#define HAVE_ATANF 1
++#define HAVE_ATAN2F 1
++#define HAVE_CBRT 1
++#define HAVE_CBRTF 1
++#define HAVE_COPYSIGN 1
++#define HAVE_COSF 1
++#define HAVE_ERF 1
++#define HAVE_EXP2 1
++#define HAVE_EXP2F 1
++#define HAVE_EXPF 1
++#define HAVE_HYPOT 1
++#define HAVE_ISFINITE 1
++#define HAVE_ISINF 1
++#define HAVE_ISNAN 1
++#define HAVE_LDEXPF 1
++#define HAVE_LLRINT 1
++#define HAVE_LLRINTF 1
++#define HAVE_LOG2 1
++#define HAVE_LOG2F 1
++#define HAVE_LOG10F 1
++#define HAVE_LRINT 1
++#define HAVE_LRINTF 1
++#define HAVE_POWF 1
++#define HAVE_RINT 1
++#define HAVE_ROUND 1
++#define HAVE_ROUNDF 1
++#define HAVE_SINF 1
++#define HAVE_TRUNC 1
++#define HAVE_TRUNCF 1
++#define HAVE_DOS_PATHS 0
++#define HAVE_LIBC_MSVCRT 0
++#define HAVE_MMAL_PARAMETER_VIDEO_MAX_NUM_CALLBACKS 0
++#define HAVE_SECTION_DATA_REL_RO 1
++#define HAVE_THREADS 1
++#define HAVE_UWP 0
++#define HAVE_WINRT 0
++#define HAVE_ACCESS 1
++#define HAVE_ALIGNED_MALLOC 0
++#define HAVE_ARC4RANDOM_BUF 0
++#define HAVE_CLOCK_GETTIME 1
++#define HAVE_CLOSESOCKET 0
++#define HAVE_COMMANDLINETOARGVW 0
++#define HAVE_FCNTL 1
++#define HAVE_GETADDRINFO 0
++#define HAVE_GETAUXVAL 1
++#define HAVE_GETENV 1
++#define HAVE_GETHRTIME 0
++#define HAVE_GETOPT 1
++#define HAVE_GETMODULEHANDLE 0
++#define HAVE_GETPROCESSAFFINITYMASK 0
++#define HAVE_GETPROCESSMEMORYINFO 0
++#define HAVE_GETPROCESSTIMES 0
++#define HAVE_GETRUSAGE 1
++#define HAVE_GETSTDHANDLE 0
++#define HAVE_GETSYSTEMTIMEASFILETIME 0
++#define HAVE_GETTIMEOFDAY 1
++#define HAVE_GLOB 1
++#define HAVE_GLXGETPROCADDRESS 0
++#define HAVE_GMTIME_R 1
++#define HAVE_INET_ATON 0
++#define HAVE_ISATTY 1
++#define HAVE_KBHIT 0
++#define HAVE_LOCALTIME_R 1
++#define HAVE_LSTAT 1
++#define HAVE_LZO1X_999_COMPRESS 0
++#define HAVE_MACH_ABSOLUTE_TIME 0
++#define HAVE_MAPVIEWOFFILE 0
++#define HAVE_MEMALIGN 1
++#define HAVE_MKSTEMP 1
++#define HAVE_MMAP 1
++#define HAVE_MPROTECT 1
++#define HAVE_NANOSLEEP 1
++#define HAVE_PEEKNAMEDPIPE 0
++#define HAVE_POSIX_MEMALIGN 1
++#define HAVE_PRCTL 1
++#define HAVE_PTHREAD_CANCEL 1
++#define HAVE_PTHREAD_SET_NAME_NP 0
++#define HAVE_PTHREAD_SETNAME_NP 0
++#define HAVE_SCHED_GETAFFINITY 1
++#define HAVE_SECITEMIMPORT 0
++#define HAVE_SETCONSOLETEXTATTRIBUTE 0
++#define HAVE_SETCONSOLECTRLHANDLER 0
++#define HAVE_SETDLLDIRECTORY 0
++#define HAVE_SETMODE 0
++#define HAVE_SETRLIMIT 1
++#define HAVE_SLEEP 0
++#define HAVE_STRERROR_R 1
++#define HAVE_SYSCONF 1
++#define HAVE_SYSCTL 0
++#define HAVE_SYSCTLBYNAME 0
++#define HAVE_USLEEP 1
++#define HAVE_UTGETOSTYPEFROMSTRING 0
++#define HAVE_VIRTUALALLOC 0
++#define HAVE_WGLGETPROCADDRESS 0
++#define HAVE_BCRYPT 0
++#define HAVE_VAAPI_DRM 0
++#define HAVE_VAAPI_X11 0
++#define HAVE_VAAPI_WIN32 0
++#define HAVE_VDPAU_X11 0
++#define HAVE_PTHREADS 1
++#define HAVE_OS2THREADS 0
++#define HAVE_W32THREADS 0
++#define HAVE_AS_ARCH_DIRECTIVE 0
++#define HAVE_AS_ARCHEXT_DOTPROD_DIRECTIVE 0
++#define HAVE_AS_ARCHEXT_I8MM_DIRECTIVE 0
++#define HAVE_AS_DN_DIRECTIVE 0
++#define HAVE_AS_FPU_DIRECTIVE 0
++#define HAVE_AS_FUNC 0
++#define HAVE_AS_OBJECT_ARCH 0
++#define HAVE_ASM_MOD_Q 0
++#define HAVE_BLOCKS_EXTENSION 0
++#define HAVE_EBP_AVAILABLE 0
++#define HAVE_EBX_AVAILABLE 0
++#define HAVE_GNU_AS 0
++#define HAVE_GNU_WINDRES 0
++#define HAVE_IBM_ASM 0
++#define HAVE_INLINE_ASM_DIRECT_SYMBOL_REFS 0
++#define HAVE_INLINE_ASM_LABELS 1
++#define HAVE_INLINE_ASM_NONLOCAL_LABELS 1
++#define HAVE_PRAGMA_DEPRECATED 1
++#define HAVE_RSYNC_CONTIMEOUT 1
++#define HAVE_SYMVER_ASM_LABEL 1
++#define HAVE_SYMVER_GNU_ASM 1
++#define HAVE_VFP_ARGS 0
++#define HAVE_XFORM_ASM 0
++#define HAVE_XMM_CLOBBERS 0
++#define HAVE_DPI_AWARENESS_CONTEXT 0
++#define HAVE_IDXGIOUTPUT5 0
++#define HAVE_KCMVIDEOCODECTYPE_HEVC 0
++#define HAVE_KCMVIDEOCODECTYPE_HEVCWITHALPHA 0
++#define HAVE_KCMVIDEOCODECTYPE_VP9 0
++#define HAVE_KCVPIXELFORMATTYPE_420YPCBCR10BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR8BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR10BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_422YPCBCR16BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR8BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR10BIPLANARVIDEORANGE 0
++#define HAVE_KCVPIXELFORMATTYPE_444YPCBCR16BIPLANARVIDEORANGE 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_2084_PQ 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2100_HLG 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_LINEAR 0
++#define HAVE_KCVIMAGEBUFFERYCBCRMATRIX_ITU_R_2020 0
++#define HAVE_KCVIMAGEBUFFERCOLORPRIMARIES_ITU_R_2020 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_ITU_R_2020 0
++#define HAVE_KCVIMAGEBUFFERTRANSFERFUNCTION_SMPTE_ST_428_1 0
++#define HAVE_SOCKLEN_T 0
++#define HAVE_STRUCT_ADDRINFO 0
++#define HAVE_STRUCT_GROUP_SOURCE_REQ 0
++#define HAVE_STRUCT_IP_MREQ_SOURCE 0
++#define HAVE_STRUCT_IPV6_MREQ 0
++#define HAVE_STRUCT_MSGHDR_MSG_FLAGS 0
++#define HAVE_STRUCT_POLLFD 0
++#define HAVE_STRUCT_RUSAGE_RU_MAXRSS 1
++#define HAVE_STRUCT_SCTP_EVENT_SUBSCRIBE 0
++#define HAVE_STRUCT_SOCKADDR_IN6 0
++#define HAVE_STRUCT_SOCKADDR_SA_LEN 0
++#define HAVE_STRUCT_SOCKADDR_STORAGE 0
++#define HAVE_STRUCT_STAT_ST_MTIM_TV_NSEC 1
++#define HAVE_STRUCT_V4L2_FRMIVALENUM_DISCRETE 0
++#define HAVE_GZIP 1
++#define HAVE_LIBDRM_GETFB2 0
++#define HAVE_MAKEINFO 1
++#define HAVE_MAKEINFO_HTML 1
++#define HAVE_OPENCL_D3D11 0
++#define HAVE_OPENCL_DRM_ARM 0
++#define HAVE_OPENCL_DRM_BEIGNET 0
++#define HAVE_OPENCL_DXVA2 0
++#define HAVE_OPENCL_VAAPI_BEIGNET 0
++#define HAVE_OPENCL_VAAPI_INTEL_MEDIA 0
++#define HAVE_PERL 1
++#define HAVE_POD2MAN 1
++#define HAVE_TEXI2HTML 0
++#define HAVE_XMLLINT 1
++#define HAVE_ZLIB_GZIP 0
++#define HAVE_OPENVINO2 0
++#define CONFIG_DOC 0
++#define CONFIG_HTMLPAGES 0
++#define CONFIG_MANPAGES 0
++#define CONFIG_PODPAGES 0
++#define CONFIG_TXTPAGES 0
++#define CONFIG_AVIO_HTTP_SERVE_FILES_EXAMPLE 1
++#define CONFIG_AVIO_LIST_DIR_EXAMPLE 1
++#define CONFIG_AVIO_READ_CALLBACK_EXAMPLE 1
++#define CONFIG_DECODE_AUDIO_EXAMPLE 1
++#define CONFIG_DECODE_FILTER_AUDIO_EXAMPLE 0
++#define CONFIG_DECODE_FILTER_VIDEO_EXAMPLE 0
++#define CONFIG_DECODE_VIDEO_EXAMPLE 1
++#define CONFIG_DEMUX_DECODE_EXAMPLE 1
++#define CONFIG_ENCODE_AUDIO_EXAMPLE 1
++#define CONFIG_ENCODE_VIDEO_EXAMPLE 1
++#define CONFIG_EXTRACT_MVS_EXAMPLE 1
++#define CONFIG_FILTER_AUDIO_EXAMPLE 0
++#define CONFIG_HW_DECODE_EXAMPLE 1
++#define CONFIG_MUX_EXAMPLE 0
++#define CONFIG_QSV_DECODE_EXAMPLE 0
++#define CONFIG_REMUX_EXAMPLE 1
++#define CONFIG_RESAMPLE_AUDIO_EXAMPLE 0
++#define CONFIG_SCALE_VIDEO_EXAMPLE 0
++#define CONFIG_SHOW_METADATA_EXAMPLE 1
++#define CONFIG_TRANSCODE_AAC_EXAMPLE 0
++#define CONFIG_TRANSCODE_EXAMPLE 0
++#define CONFIG_VAAPI_ENCODE_EXAMPLE 0
++#define CONFIG_VAAPI_TRANSCODE_EXAMPLE 0
++#define CONFIG_QSV_TRANSCODE_EXAMPLE 0
++#define CONFIG_AVISYNTH 0
++#define CONFIG_FREI0R 0
++#define CONFIG_LIBCDIO 0
++#define CONFIG_LIBDAVS2 0
++#define CONFIG_LIBRUBBERBAND 0
++#define CONFIG_LIBVIDSTAB 0
++#define CONFIG_LIBX264 0
++#define CONFIG_LIBX265 0
++#define CONFIG_LIBXAVS 0
++#define CONFIG_LIBXAVS2 0
++#define CONFIG_LIBXVID 0
++#define CONFIG_DECKLINK 0
++#define CONFIG_LIBFDK_AAC 0
++#define CONFIG_LIBTLS 0
++#define CONFIG_GMP 0
++#define CONFIG_LIBARIBB24 0
++#define CONFIG_LIBLENSFUN 0
++#define CONFIG_LIBOPENCORE_AMRNB 0
++#define CONFIG_LIBOPENCORE_AMRWB 0
++#define CONFIG_LIBVO_AMRWBENC 0
++#define CONFIG_MBEDTLS 0
++#define CONFIG_RKMPP 0
++#define CONFIG_LIBSMBCLIENT 0
++#define CONFIG_CHROMAPRINT 0
++#define CONFIG_GCRYPT 0
++#define CONFIG_GNUTLS 0
++#define CONFIG_JNI 0
++#define CONFIG_LADSPA 0
++#define CONFIG_LCMS2 0
++#define CONFIG_LIBAOM 0
++#define CONFIG_LIBARIBCAPTION 0
++#define CONFIG_LIBASS 0
++#define CONFIG_LIBBLURAY 0
++#define CONFIG_LIBBS2B 0
++#define CONFIG_LIBCACA 0
++#define CONFIG_LIBCELT 0
++#define CONFIG_LIBCODEC2 0
++#define CONFIG_LIBDAV1D 0
++#define CONFIG_LIBDC1394 0
++#define CONFIG_LIBFLITE 0
++#define CONFIG_LIBFONTCONFIG 0
++#define CONFIG_LIBFREETYPE 0
++#define CONFIG_LIBFRIBIDI 0
++#define CONFIG_LIBHARFBUZZ 0
++#define CONFIG_LIBGLSLANG 0
++#define CONFIG_LIBGME 0
++#define CONFIG_LIBGSM 0
++#define CONFIG_LIBIEC61883 0
++#define CONFIG_LIBILBC 0
++#define CONFIG_LIBJACK 0
++#define CONFIG_LIBJXL 0
++#define CONFIG_LIBKLVANC 0
++#define CONFIG_LIBKVAZAAR 0
++#define CONFIG_LIBMODPLUG 0
++#define CONFIG_LIBMP3LAME 0
++#define CONFIG_LIBMYSOFA 0
++#define CONFIG_LIBOPENCV 0
++#define CONFIG_LIBOPENH264 0
++#define CONFIG_LIBOPENJPEG 0
++#define CONFIG_LIBOPENMPT 0
++#define CONFIG_LIBOPENVINO 0
++#define CONFIG_LIBOPUS 1
++#define CONFIG_LIBPLACEBO 0
++#define CONFIG_LIBPULSE 0
++#define CONFIG_LIBQRENCODE 0
++#define CONFIG_LIBQUIRC 0
++#define CONFIG_LIBRABBITMQ 0
++#define CONFIG_LIBRAV1E 0
++#define CONFIG_LIBRIST 0
++#define CONFIG_LIBRSVG 0
++#define CONFIG_LIBRTMP 0
++#define CONFIG_LIBSHADERC 0
++#define CONFIG_LIBSHINE 0
++#define CONFIG_LIBSMBCLIENT 0
++#define CONFIG_LIBSNAPPY 0
++#define CONFIG_LIBSOXR 0
++#define CONFIG_LIBSPEEX 0
++#define CONFIG_LIBSRT 0
++#define CONFIG_LIBSSH 0
++#define CONFIG_LIBSVTAV1 0
++#define CONFIG_LIBTENSORFLOW 0
++#define CONFIG_LIBTESSERACT 0
++#define CONFIG_LIBTHEORA 0
++#define CONFIG_LIBTWOLAME 0
++#define CONFIG_LIBUAVS3D 0
++#define CONFIG_LIBV4L2 0
++#define CONFIG_LIBVMAF 0
++#define CONFIG_LIBVORBIS 0
++#define CONFIG_LIBVPX 0
++#define CONFIG_LIBWEBP 0
++#define CONFIG_LIBXEVD 0
++#define CONFIG_LIBXEVE 0
++#define CONFIG_LIBXML2 0
++#define CONFIG_LIBZIMG 0
++#define CONFIG_LIBZMQ 0
++#define CONFIG_LIBZVBI 0
++#define CONFIG_LV2 0
++#define CONFIG_MEDIACODEC 0
++#define CONFIG_OPENAL 0
++#define CONFIG_OPENGL 0
++#define CONFIG_OPENSSL 0
++#define CONFIG_POCKETSPHINX 0
++#define CONFIG_VAPOURSYNTH 0
++#define CONFIG_ALSA 0
++#define CONFIG_APPKIT 0
++#define CONFIG_AVFOUNDATION 0
++#define CONFIG_BZLIB 0
++#define CONFIG_COREIMAGE 0
++#define CONFIG_ICONV 0
++#define CONFIG_LIBXCB 0
++#define CONFIG_LIBXCB_SHM 0
++#define CONFIG_LIBXCB_SHAPE 0
++#define CONFIG_LIBXCB_XFIXES 0
++#define CONFIG_LZMA 0
++#define CONFIG_MEDIAFOUNDATION 0
++#define CONFIG_METAL 0
++#define CONFIG_SCHANNEL 0
++#define CONFIG_SDL2 0
++#define CONFIG_SECURETRANSPORT 0
++#define CONFIG_SNDIO 0
++#define CONFIG_XLIB 0
++#define CONFIG_ZLIB 0
++#define CONFIG_CUDA_NVCC 0
++#define CONFIG_CUDA_SDK 0
++#define CONFIG_LIBNPP 0
++#define CONFIG_LIBMFX 0
++#define CONFIG_LIBVPL 0
++#define CONFIG_MMAL 0
++#define CONFIG_OMX 0
++#define CONFIG_OPENCL 0
++#define CONFIG_AMF 0
++#define CONFIG_AUDIOTOOLBOX 0
++#define CONFIG_CRYSTALHD 0
++#define CONFIG_CUDA 0
++#define CONFIG_CUDA_LLVM 0
++#define CONFIG_CUVID 0
++#define CONFIG_D3D11VA 0
++#define CONFIG_D3D12VA 0
++#define CONFIG_DXVA2 0
++#define CONFIG_FFNVCODEC 0
++#define CONFIG_LIBDRM 0
++#define CONFIG_NVDEC 0
++#define CONFIG_NVENC 0
++#define CONFIG_VAAPI 0
++#define CONFIG_VDPAU 0
++#define CONFIG_VIDEOTOOLBOX 0
++#define CONFIG_VULKAN 0
++#define CONFIG_V4L2_M2M 0
++#define CONFIG_FTRAPV 0
++#define CONFIG_GRAY 0
++#define CONFIG_HARDCODED_TABLES 0
++#define CONFIG_OMX_RPI 0
++#define CONFIG_RUNTIME_CPUDETECT 1
++#define CONFIG_SAFE_BITSTREAM_READER 1
++#define CONFIG_SHARED 0
++#define CONFIG_SMALL 0
++#define CONFIG_STATIC 1
++#define CONFIG_SWSCALE_ALPHA 1
++#define CONFIG_GPL 0
++#define CONFIG_NONFREE 0
++#define CONFIG_VERSION3 0
++#define CONFIG_AVDEVICE 0
++#define CONFIG_AVFILTER 0
++#define CONFIG_SWSCALE 0
++#define CONFIG_POSTPROC 0
++#define CONFIG_AVFORMAT 1
++#define CONFIG_AVCODEC 1
++#define CONFIG_SWRESAMPLE 0
++#define CONFIG_AVUTIL 1
++#define CONFIG_FFPLAY 0
++#define CONFIG_FFPROBE 0
++#define CONFIG_FFMPEG 0
++#define CONFIG_DWT 0
++#define CONFIG_ERROR_RESILIENCE 0
++#define CONFIG_FAAN 0
++#define CONFIG_FAST_UNALIGNED 1
++#define CONFIG_LSP 0
++#define CONFIG_PIXELUTILS 0
++#define CONFIG_NETWORK 0
++#define CONFIG_AUTODETECT 0
++#define CONFIG_FONTCONFIG 0
++#define CONFIG_LARGE_TESTS 1
++#define CONFIG_LINUX_PERF 0
++#define CONFIG_MACOS_KPERF 0
++#define CONFIG_MEMORY_POISONING 0
++#define CONFIG_NEON_CLOBBER_TEST 0
++#define CONFIG_OSSFUZZ 0
++#define CONFIG_PIC 1
++#define CONFIG_PTX_COMPRESSION 0
++#define CONFIG_THUMB 0
++#define CONFIG_VALGRIND_BACKTRACE 0
++#define CONFIG_XMM_CLOBBER_TEST 0
++#define CONFIG_BSFS 0
++#define CONFIG_DECODERS 1
++#define CONFIG_ENCODERS 0
++#define CONFIG_HWACCELS 0
++#define CONFIG_PARSERS 1
++#define CONFIG_INDEVS 0
++#define CONFIG_OUTDEVS 0
++#define CONFIG_FILTERS 0
++#define CONFIG_DEMUXERS 1
++#define CONFIG_MUXERS 0
++#define CONFIG_PROTOCOLS 0
++#define CONFIG_AANDCTTABLES 0
++#define CONFIG_AC3DSP 0
++#define CONFIG_ADTS_HEADER 0
++#define CONFIG_ATSC_A53 0
++#define CONFIG_AUDIO_FRAME_QUEUE 0
++#define CONFIG_AUDIODSP 0
++#define CONFIG_BLOCKDSP 0
++#define CONFIG_BSWAPDSP 0
++#define CONFIG_CABAC 0
++#define CONFIG_CBS 0
++#define CONFIG_CBS_AV1 0
++#define CONFIG_CBS_H264 0
++#define CONFIG_CBS_H265 0
++#define CONFIG_CBS_H266 0
++#define CONFIG_CBS_JPEG 0
++#define CONFIG_CBS_MPEG2 0
++#define CONFIG_CBS_VP8 0
++#define CONFIG_CBS_VP9 0
++#define CONFIG_DEFLATE_WRAPPER 0
++#define CONFIG_DIRAC_PARSE 1
++#define CONFIG_DNN 0
++#define CONFIG_DOVI_RPU 0
++#define CONFIG_DVPROFILE 0
++#define CONFIG_EVCPARSE 0
++#define CONFIG_EXIF 0
++#define CONFIG_FAANDCT 0
++#define CONFIG_FAANIDCT 0
++#define CONFIG_FDCTDSP 0
++#define CONFIG_FMTCONVERT 0
++#define CONFIG_FRAME_THREAD_ENCODER 0
++#define CONFIG_G722DSP 0
++#define CONFIG_GOLOMB 1
++#define CONFIG_GPLV3 0
++#define CONFIG_H263DSP 0
++#define CONFIG_H264CHROMA 0
++#define CONFIG_H264DSP 0
++#define CONFIG_H264PARSE 0
++#define CONFIG_H264PRED 0
++#define CONFIG_H264QPEL 0
++#define CONFIG_H264_SEI 0
++#define CONFIG_HEVCPARSE 0
++#define CONFIG_HEVC_SEI 0
++#define CONFIG_HPELDSP 0
++#define CONFIG_HUFFMAN 0
++#define CONFIG_HUFFYUVDSP 0
++#define CONFIG_HUFFYUVENCDSP 0
++#define CONFIG_IAMFDEC 0
++#define CONFIG_IAMFENC 0
++#define CONFIG_IDCTDSP 0
++#define CONFIG_IIRFILTER 0
++#define CONFIG_INFLATE_WRAPPER 0
++#define CONFIG_INTRAX8 0
++#define CONFIG_ISO_MEDIA 1
++#define CONFIG_IVIDSP 0
++#define CONFIG_JPEGTABLES 0
++#define CONFIG_LGPLV3 0
++#define CONFIG_LIBX262 0
++#define CONFIG_LLAUDDSP 0
++#define CONFIG_LLVIDDSP 0
++#define CONFIG_LLVIDENCDSP 0
++#define CONFIG_LPC 0
++#define CONFIG_LZF 0
++#define CONFIG_ME_CMP 0
++#define CONFIG_MPEG_ER 0
++#define CONFIG_MPEGAUDIO 1
++#define CONFIG_MPEGAUDIODSP 1
++#define CONFIG_MPEGAUDIOHEADER 1
++#define CONFIG_MPEG4AUDIO 1
++#define CONFIG_MPEGVIDEO 0
++#define CONFIG_MPEGVIDEODEC 0
++#define CONFIG_MPEGVIDEOENC 0
++#define CONFIG_MSMPEG4DEC 0
++#define CONFIG_MSMPEG4ENC 0
++#define CONFIG_MSS34DSP 0
++#define CONFIG_PIXBLOCKDSP 0
++#define CONFIG_QPELDSP 0
++#define CONFIG_QSV 0
++#define CONFIG_QSVDEC 0
++#define CONFIG_QSVENC 0
++#define CONFIG_QSVVPP 0
++#define CONFIG_RANGECODER 0
++#define CONFIG_RIFFDEC 1
++#define CONFIG_RIFFENC 0
++#define CONFIG_RTPDEC 0
++#define CONFIG_RTPENC_CHAIN 0
++#define CONFIG_RV34DSP 0
++#define CONFIG_SCENE_SAD 0
++#define CONFIG_SINEWIN 0
++#define CONFIG_SNAPPY 0
++#define CONFIG_SRTP 0
++#define CONFIG_STARTCODE 0
++#define CONFIG_TEXTUREDSP 0
++#define CONFIG_TEXTUREDSPENC 0
++#define CONFIG_TPELDSP 0
++#define CONFIG_VAAPI_1 0
++#define CONFIG_VAAPI_ENCODE 0
++#define CONFIG_VC1DSP 0
++#define CONFIG_VIDEODSP 0
++#define CONFIG_VP3DSP 0
++#define CONFIG_VP56DSP 0
++#define CONFIG_VP8DSP 0
++#define CONFIG_WMA_FREQS 0
++#define CONFIG_WMV2DSP 0
++#endif /* FFMPEG_CONFIG_H */
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config_components.h b/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config_components.h
+--- a/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config_components.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/config_components.h	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,2218 @@
++/* Automatically generated by configure - do not modify! */
++#ifndef FFMPEG_CONFIG_COMPONENTS_H
++#define FFMPEG_CONFIG_COMPONENTS_H
++#define CONFIG_AAC_ADTSTOASC_BSF 0
++#define CONFIG_AV1_FRAME_MERGE_BSF 0
++#define CONFIG_AV1_FRAME_SPLIT_BSF 0
++#define CONFIG_AV1_METADATA_BSF 0
++#define CONFIG_CHOMP_BSF 0
++#define CONFIG_DUMP_EXTRADATA_BSF 0
++#define CONFIG_DCA_CORE_BSF 0
++#define CONFIG_DTS2PTS_BSF 0
++#define CONFIG_DV_ERROR_MARKER_BSF 0
++#define CONFIG_EAC3_CORE_BSF 0
++#define CONFIG_EXTRACT_EXTRADATA_BSF 0
++#define CONFIG_FILTER_UNITS_BSF 0
++#define CONFIG_H264_METADATA_BSF 0
++#define CONFIG_H264_MP4TOANNEXB_BSF 0
++#define CONFIG_H264_REDUNDANT_PPS_BSF 0
++#define CONFIG_HAPQA_EXTRACT_BSF 0
++#define CONFIG_HEVC_METADATA_BSF 0
++#define CONFIG_HEVC_MP4TOANNEXB_BSF 0
++#define CONFIG_IMX_DUMP_HEADER_BSF 0
++#define CONFIG_MEDIA100_TO_MJPEGB_BSF 0
++#define CONFIG_MJPEG2JPEG_BSF 0
++#define CONFIG_MJPEGA_DUMP_HEADER_BSF 0
++#define CONFIG_MP3_HEADER_DECOMPRESS_BSF 0
++#define CONFIG_MPEG2_METADATA_BSF 0
++#define CONFIG_MPEG4_UNPACK_BFRAMES_BSF 0
++#define CONFIG_MOV2TEXTSUB_BSF 0
++#define CONFIG_NOISE_BSF 0
++#define CONFIG_NULL_BSF 0
++#define CONFIG_OPUS_METADATA_BSF 0
++#define CONFIG_PCM_RECHUNK_BSF 0
++#define CONFIG_PGS_FRAME_MERGE_BSF 0
++#define CONFIG_PRORES_METADATA_BSF 0
++#define CONFIG_REMOVE_EXTRADATA_BSF 0
++#define CONFIG_SETTS_BSF 0
++#define CONFIG_SHOWINFO_BSF 0
++#define CONFIG_TEXT2MOVSUB_BSF 0
++#define CONFIG_TRACE_HEADERS_BSF 0
++#define CONFIG_TRUEHD_CORE_BSF 0
++#define CONFIG_VP9_METADATA_BSF 0
++#define CONFIG_VP9_RAW_REORDER_BSF 0
++#define CONFIG_VP9_SUPERFRAME_BSF 0
++#define CONFIG_VP9_SUPERFRAME_SPLIT_BSF 0
++#define CONFIG_VVC_METADATA_BSF 0
++#define CONFIG_VVC_MP4TOANNEXB_BSF 0
++#define CONFIG_EVC_FRAME_MERGE_BSF 0
++#define CONFIG_AASC_DECODER 0
++#define CONFIG_AIC_DECODER 0
++#define CONFIG_ALIAS_PIX_DECODER 0
++#define CONFIG_AGM_DECODER 0
++#define CONFIG_AMV_DECODER 0
++#define CONFIG_ANM_DECODER 0
++#define CONFIG_ANSI_DECODER 0
++#define CONFIG_APNG_DECODER 0
++#define CONFIG_ARBC_DECODER 0
++#define CONFIG_ARGO_DECODER 0
++#define CONFIG_ASV1_DECODER 0
++#define CONFIG_ASV2_DECODER 0
++#define CONFIG_AURA_DECODER 0
++#define CONFIG_AURA2_DECODER 0
++#define CONFIG_AVRP_DECODER 0
++#define CONFIG_AVRN_DECODER 0
++#define CONFIG_AVS_DECODER 0
++#define CONFIG_AVUI_DECODER 0
++#define CONFIG_AYUV_DECODER 0
++#define CONFIG_BETHSOFTVID_DECODER 0
++#define CONFIG_BFI_DECODER 0
++#define CONFIG_BINK_DECODER 0
++#define CONFIG_BITPACKED_DECODER 0
++#define CONFIG_BMP_DECODER 0
++#define CONFIG_BMV_VIDEO_DECODER 0
++#define CONFIG_BRENDER_PIX_DECODER 0
++#define CONFIG_C93_DECODER 0
++#define CONFIG_CAVS_DECODER 0
++#define CONFIG_CDGRAPHICS_DECODER 0
++#define CONFIG_CDTOONS_DECODER 0
++#define CONFIG_CDXL_DECODER 0
++#define CONFIG_CFHD_DECODER 0
++#define CONFIG_CINEPAK_DECODER 0
++#define CONFIG_CLEARVIDEO_DECODER 0
++#define CONFIG_CLJR_DECODER 0
++#define CONFIG_CLLC_DECODER 0
++#define CONFIG_COMFORTNOISE_DECODER 0
++#define CONFIG_CPIA_DECODER 0
++#define CONFIG_CRI_DECODER 0
++#define CONFIG_CSCD_DECODER 0
++#define CONFIG_CYUV_DECODER 0
++#define CONFIG_DDS_DECODER 0
++#define CONFIG_DFA_DECODER 0
++#define CONFIG_DIRAC_DECODER 0
++#define CONFIG_DNXHD_DECODER 0
++#define CONFIG_DPX_DECODER 0
++#define CONFIG_DSICINVIDEO_DECODER 0
++#define CONFIG_DVAUDIO_DECODER 0
++#define CONFIG_DVVIDEO_DECODER 0
++#define CONFIG_DXA_DECODER 0
++#define CONFIG_DXTORY_DECODER 0
++#define CONFIG_DXV_DECODER 0
++#define CONFIG_EACMV_DECODER 0
++#define CONFIG_EAMAD_DECODER 0
++#define CONFIG_EATGQ_DECODER 0
++#define CONFIG_EATGV_DECODER 0
++#define CONFIG_EATQI_DECODER 0
++#define CONFIG_EIGHTBPS_DECODER 0
++#define CONFIG_EIGHTSVX_EXP_DECODER 0
++#define CONFIG_EIGHTSVX_FIB_DECODER 0
++#define CONFIG_ESCAPE124_DECODER 0
++#define CONFIG_ESCAPE130_DECODER 0
++#define CONFIG_EXR_DECODER 0
++#define CONFIG_FFV1_DECODER 0
++#define CONFIG_FFVHUFF_DECODER 0
++#define CONFIG_FIC_DECODER 0
++#define CONFIG_FITS_DECODER 0
++#define CONFIG_FLASHSV_DECODER 0
++#define CONFIG_FLASHSV2_DECODER 0
++#define CONFIG_FLIC_DECODER 0
++#define CONFIG_FLV_DECODER 0
++#define CONFIG_FMVC_DECODER 0
++#define CONFIG_FOURXM_DECODER 0
++#define CONFIG_FRAPS_DECODER 0
++#define CONFIG_FRWU_DECODER 0
++#define CONFIG_G2M_DECODER 0
++#define CONFIG_GDV_DECODER 0
++#define CONFIG_GEM_DECODER 0
++#define CONFIG_GIF_DECODER 0
++#define CONFIG_H261_DECODER 0
++#define CONFIG_H263_DECODER 0
++#define CONFIG_H263I_DECODER 0
++#define CONFIG_H263P_DECODER 0
++#define CONFIG_H263_V4L2M2M_DECODER 0
++#define CONFIG_H264_DECODER 0
++#define CONFIG_H264_CRYSTALHD_DECODER 0
++#define CONFIG_H264_V4L2M2M_DECODER 0
++#define CONFIG_H264_MEDIACODEC_DECODER 0
++#define CONFIG_H264_MMAL_DECODER 0
++#define CONFIG_H264_QSV_DECODER 0
++#define CONFIG_H264_RKMPP_DECODER 0
++#define CONFIG_HAP_DECODER 0
++#define CONFIG_HEVC_DECODER 0
++#define CONFIG_HEVC_QSV_DECODER 0
++#define CONFIG_HEVC_RKMPP_DECODER 0
++#define CONFIG_HEVC_V4L2M2M_DECODER 0
++#define CONFIG_HNM4_VIDEO_DECODER 0
++#define CONFIG_HQ_HQA_DECODER 0
++#define CONFIG_HQX_DECODER 0
++#define CONFIG_HUFFYUV_DECODER 0
++#define CONFIG_HYMT_DECODER 0
++#define CONFIG_IDCIN_DECODER 0
++#define CONFIG_IFF_ILBM_DECODER 0
++#define CONFIG_IMM4_DECODER 0
++#define CONFIG_IMM5_DECODER 0
++#define CONFIG_INDEO2_DECODER 0
++#define CONFIG_INDEO3_DECODER 0
++#define CONFIG_INDEO4_DECODER 0
++#define CONFIG_INDEO5_DECODER 0
++#define CONFIG_INTERPLAY_VIDEO_DECODER 0
++#define CONFIG_IPU_DECODER 0
++#define CONFIG_JPEG2000_DECODER 0
++#define CONFIG_JPEGLS_DECODER 0
++#define CONFIG_JV_DECODER 0
++#define CONFIG_KGV1_DECODER 0
++#define CONFIG_KMVC_DECODER 0
++#define CONFIG_LAGARITH_DECODER 0
++#define CONFIG_LEAD_DECODER 0
++#define CONFIG_LOCO_DECODER 0
++#define CONFIG_LSCR_DECODER 0
++#define CONFIG_M101_DECODER 0
++#define CONFIG_MAGICYUV_DECODER 0
++#define CONFIG_MDEC_DECODER 0
++#define CONFIG_MEDIA100_DECODER 0
++#define CONFIG_MIMIC_DECODER 0
++#define CONFIG_MJPEG_DECODER 0
++#define CONFIG_MJPEGB_DECODER 0
++#define CONFIG_MMVIDEO_DECODER 0
++#define CONFIG_MOBICLIP_DECODER 0
++#define CONFIG_MOTIONPIXELS_DECODER 0
++#define CONFIG_MPEG1VIDEO_DECODER 0
++#define CONFIG_MPEG2VIDEO_DECODER 0
++#define CONFIG_MPEG4_DECODER 0
++#define CONFIG_MPEG4_CRYSTALHD_DECODER 0
++#define CONFIG_MPEG4_V4L2M2M_DECODER 0
++#define CONFIG_MPEG4_MMAL_DECODER 0
++#define CONFIG_MPEGVIDEO_DECODER 0
++#define CONFIG_MPEG1_V4L2M2M_DECODER 0
++#define CONFIG_MPEG2_MMAL_DECODER 0
++#define CONFIG_MPEG2_CRYSTALHD_DECODER 0
++#define CONFIG_MPEG2_V4L2M2M_DECODER 0
++#define CONFIG_MPEG2_QSV_DECODER 0
++#define CONFIG_MPEG2_MEDIACODEC_DECODER 0
++#define CONFIG_MSA1_DECODER 0
++#define CONFIG_MSCC_DECODER 0
++#define CONFIG_MSMPEG4V1_DECODER 0
++#define CONFIG_MSMPEG4V2_DECODER 0
++#define CONFIG_MSMPEG4V3_DECODER 0
++#define CONFIG_MSMPEG4_CRYSTALHD_DECODER 0
++#define CONFIG_MSP2_DECODER 0
++#define CONFIG_MSRLE_DECODER 0
++#define CONFIG_MSS1_DECODER 0
++#define CONFIG_MSS2_DECODER 0
++#define CONFIG_MSVIDEO1_DECODER 0
++#define CONFIG_MSZH_DECODER 0
++#define CONFIG_MTS2_DECODER 0
++#define CONFIG_MV30_DECODER 0
++#define CONFIG_MVC1_DECODER 0
++#define CONFIG_MVC2_DECODER 0
++#define CONFIG_MVDV_DECODER 0
++#define CONFIG_MVHA_DECODER 0
++#define CONFIG_MWSC_DECODER 0
++#define CONFIG_MXPEG_DECODER 0
++#define CONFIG_NOTCHLC_DECODER 0
++#define CONFIG_NUV_DECODER 0
++#define CONFIG_PAF_VIDEO_DECODER 0
++#define CONFIG_PAM_DECODER 0
++#define CONFIG_PBM_DECODER 0
++#define CONFIG_PCX_DECODER 0
++#define CONFIG_PDV_DECODER 0
++#define CONFIG_PFM_DECODER 0
++#define CONFIG_PGM_DECODER 0
++#define CONFIG_PGMYUV_DECODER 0
++#define CONFIG_PGX_DECODER 0
++#define CONFIG_PHM_DECODER 0
++#define CONFIG_PHOTOCD_DECODER 0
++#define CONFIG_PICTOR_DECODER 0
++#define CONFIG_PIXLET_DECODER 0
++#define CONFIG_PNG_DECODER 0
++#define CONFIG_PPM_DECODER 0
++#define CONFIG_PRORES_DECODER 0
++#define CONFIG_PROSUMER_DECODER 0
++#define CONFIG_PSD_DECODER 0
++#define CONFIG_PTX_DECODER 0
++#define CONFIG_QDRAW_DECODER 0
++#define CONFIG_QOI_DECODER 0
++#define CONFIG_QPEG_DECODER 0
++#define CONFIG_QTRLE_DECODER 0
++#define CONFIG_R10K_DECODER 0
++#define CONFIG_R210_DECODER 0
++#define CONFIG_RASC_DECODER 0
++#define CONFIG_RAWVIDEO_DECODER 0
++#define CONFIG_RKA_DECODER 0
++#define CONFIG_RL2_DECODER 0
++#define CONFIG_ROQ_DECODER 0
++#define CONFIG_RPZA_DECODER 0
++#define CONFIG_RSCC_DECODER 0
++#define CONFIG_RTV1_DECODER 0
++#define CONFIG_RV10_DECODER 0
++#define CONFIG_RV20_DECODER 0
++#define CONFIG_RV30_DECODER 0
++#define CONFIG_RV40_DECODER 0
++#define CONFIG_S302M_DECODER 0
++#define CONFIG_SANM_DECODER 0
++#define CONFIG_SCPR_DECODER 0
++#define CONFIG_SCREENPRESSO_DECODER 0
++#define CONFIG_SGA_DECODER 0
++#define CONFIG_SGI_DECODER 0
++#define CONFIG_SGIRLE_DECODER 0
++#define CONFIG_SHEERVIDEO_DECODER 0
++#define CONFIG_SIMBIOSIS_IMX_DECODER 0
++#define CONFIG_SMACKER_DECODER 0
++#define CONFIG_SMC_DECODER 0
++#define CONFIG_SMVJPEG_DECODER 0
++#define CONFIG_SNOW_DECODER 0
++#define CONFIG_SP5X_DECODER 0
++#define CONFIG_SPEEDHQ_DECODER 0
++#define CONFIG_SPEEX_DECODER 0
++#define CONFIG_SRGC_DECODER 0
++#define CONFIG_SUNRAST_DECODER 0
++#define CONFIG_SVQ1_DECODER 0
++#define CONFIG_SVQ3_DECODER 0
++#define CONFIG_TARGA_DECODER 0
++#define CONFIG_TARGA_Y216_DECODER 0
++#define CONFIG_TDSC_DECODER 0
++#define CONFIG_THEORA_DECODER 0
++#define CONFIG_THP_DECODER 0
++#define CONFIG_TIERTEXSEQVIDEO_DECODER 0
++#define CONFIG_TIFF_DECODER 0
++#define CONFIG_TMV_DECODER 0
++#define CONFIG_TRUEMOTION1_DECODER 0
++#define CONFIG_TRUEMOTION2_DECODER 0
++#define CONFIG_TRUEMOTION2RT_DECODER 0
++#define CONFIG_TSCC_DECODER 0
++#define CONFIG_TSCC2_DECODER 0
++#define CONFIG_TXD_DECODER 0
++#define CONFIG_ULTI_DECODER 0
++#define CONFIG_UTVIDEO_DECODER 0
++#define CONFIG_V210_DECODER 0
++#define CONFIG_V210X_DECODER 0
++#define CONFIG_V308_DECODER 0
++#define CONFIG_V408_DECODER 0
++#define CONFIG_V410_DECODER 0
++#define CONFIG_VB_DECODER 0
++#define CONFIG_VBN_DECODER 0
++#define CONFIG_VBLE_DECODER 0
++#define CONFIG_VC1_DECODER 0
++#define CONFIG_VC1_CRYSTALHD_DECODER 0
++#define CONFIG_VC1IMAGE_DECODER 0
++#define CONFIG_VC1_MMAL_DECODER 0
++#define CONFIG_VC1_QSV_DECODER 0
++#define CONFIG_VC1_V4L2M2M_DECODER 0
++#define CONFIG_VCR1_DECODER 0
++#define CONFIG_VMDVIDEO_DECODER 0
++#define CONFIG_VMIX_DECODER 0
++#define CONFIG_VMNC_DECODER 0
++#define CONFIG_VP3_DECODER 0
++#define CONFIG_VP4_DECODER 0
++#define CONFIG_VP5_DECODER 0
++#define CONFIG_VP6_DECODER 0
++#define CONFIG_VP6A_DECODER 0
++#define CONFIG_VP6F_DECODER 0
++#define CONFIG_VP7_DECODER 0
++#define CONFIG_VP8_DECODER 0
++#define CONFIG_VP8_RKMPP_DECODER 0
++#define CONFIG_VP8_V4L2M2M_DECODER 0
++#define CONFIG_VP9_DECODER 0
++#define CONFIG_VP9_RKMPP_DECODER 0
++#define CONFIG_VP9_V4L2M2M_DECODER 0
++#define CONFIG_VQA_DECODER 0
++#define CONFIG_VQC_DECODER 0
++#define CONFIG_VVC_DECODER 0
++#define CONFIG_WBMP_DECODER 0
++#define CONFIG_WEBP_DECODER 0
++#define CONFIG_WCMV_DECODER 0
++#define CONFIG_WRAPPED_AVFRAME_DECODER 0
++#define CONFIG_WMV1_DECODER 0
++#define CONFIG_WMV2_DECODER 0
++#define CONFIG_WMV3_DECODER 0
++#define CONFIG_WMV3_CRYSTALHD_DECODER 0
++#define CONFIG_WMV3IMAGE_DECODER 0
++#define CONFIG_WNV1_DECODER 0
++#define CONFIG_XAN_WC3_DECODER 0
++#define CONFIG_XAN_WC4_DECODER 0
++#define CONFIG_XBM_DECODER 0
++#define CONFIG_XFACE_DECODER 0
++#define CONFIG_XL_DECODER 0
++#define CONFIG_XPM_DECODER 0
++#define CONFIG_XWD_DECODER 0
++#define CONFIG_Y41P_DECODER 0
++#define CONFIG_YLC_DECODER 0
++#define CONFIG_YOP_DECODER 0
++#define CONFIG_YUV4_DECODER 0
++#define CONFIG_ZERO12V_DECODER 0
++#define CONFIG_ZEROCODEC_DECODER 0
++#define CONFIG_ZLIB_DECODER 0
++#define CONFIG_ZMBV_DECODER 0
++#define CONFIG_AAC_DECODER 0
++#define CONFIG_AAC_FIXED_DECODER 0
++#define CONFIG_AAC_LATM_DECODER 0
++#define CONFIG_AC3_DECODER 0
++#define CONFIG_AC3_FIXED_DECODER 0
++#define CONFIG_ACELP_KELVIN_DECODER 0
++#define CONFIG_ALAC_DECODER 0
++#define CONFIG_ALS_DECODER 0
++#define CONFIG_AMRNB_DECODER 0
++#define CONFIG_AMRWB_DECODER 0
++#define CONFIG_APAC_DECODER 0
++#define CONFIG_APE_DECODER 0
++#define CONFIG_APTX_DECODER 0
++#define CONFIG_APTX_HD_DECODER 0
++#define CONFIG_ATRAC1_DECODER 0
++#define CONFIG_ATRAC3_DECODER 0
++#define CONFIG_ATRAC3AL_DECODER 0
++#define CONFIG_ATRAC3P_DECODER 0
++#define CONFIG_ATRAC3PAL_DECODER 0
++#define CONFIG_ATRAC9_DECODER 0
++#define CONFIG_BINKAUDIO_DCT_DECODER 0
++#define CONFIG_BINKAUDIO_RDFT_DECODER 0
++#define CONFIG_BMV_AUDIO_DECODER 0
++#define CONFIG_BONK_DECODER 0
++#define CONFIG_COOK_DECODER 0
++#define CONFIG_DCA_DECODER 0
++#define CONFIG_DFPWM_DECODER 0
++#define CONFIG_DOLBY_E_DECODER 0
++#define CONFIG_DSD_LSBF_DECODER 0
++#define CONFIG_DSD_MSBF_DECODER 0
++#define CONFIG_DSD_LSBF_PLANAR_DECODER 0
++#define CONFIG_DSD_MSBF_PLANAR_DECODER 0
++#define CONFIG_DSICINAUDIO_DECODER 0
++#define CONFIG_DSS_SP_DECODER 0
++#define CONFIG_DST_DECODER 0
++#define CONFIG_EAC3_DECODER 0
++#define CONFIG_EVRC_DECODER 0
++#define CONFIG_FASTAUDIO_DECODER 0
++#define CONFIG_FFWAVESYNTH_DECODER 0
++#define CONFIG_FLAC_DECODER 1
++#define CONFIG_FTR_DECODER 0
++#define CONFIG_G723_1_DECODER 0
++#define CONFIG_G729_DECODER 0
++#define CONFIG_GSM_DECODER 0
++#define CONFIG_GSM_MS_DECODER 0
++#define CONFIG_HCA_DECODER 0
++#define CONFIG_HCOM_DECODER 0
++#define CONFIG_HDR_DECODER 0
++#define CONFIG_IAC_DECODER 0
++#define CONFIG_ILBC_DECODER 0
++#define CONFIG_IMC_DECODER 0
++#define CONFIG_INTERPLAY_ACM_DECODER 0
++#define CONFIG_MACE3_DECODER 0
++#define CONFIG_MACE6_DECODER 0
++#define CONFIG_METASOUND_DECODER 0
++#define CONFIG_MISC4_DECODER 0
++#define CONFIG_MLP_DECODER 0
++#define CONFIG_MP1_DECODER 0
++#define CONFIG_MP1FLOAT_DECODER 0
++#define CONFIG_MP2_DECODER 0
++#define CONFIG_MP2FLOAT_DECODER 0
++#define CONFIG_MP3FLOAT_DECODER 0
++#define CONFIG_MP3_DECODER 1
++#define CONFIG_MP3ADUFLOAT_DECODER 0
++#define CONFIG_MP3ADU_DECODER 0
++#define CONFIG_MP3ON4FLOAT_DECODER 0
++#define CONFIG_MP3ON4_DECODER 0
++#define CONFIG_MPC7_DECODER 0
++#define CONFIG_MPC8_DECODER 0
++#define CONFIG_MSNSIREN_DECODER 0
++#define CONFIG_NELLYMOSER_DECODER 0
++#define CONFIG_ON2AVC_DECODER 0
++#define CONFIG_OPUS_DECODER 0
++#define CONFIG_OSQ_DECODER 0
++#define CONFIG_PAF_AUDIO_DECODER 0
++#define CONFIG_QCELP_DECODER 0
++#define CONFIG_QDM2_DECODER 0
++#define CONFIG_QDMC_DECODER 0
++#define CONFIG_QOA_DECODER 0
++#define CONFIG_RA_144_DECODER 0
++#define CONFIG_RA_288_DECODER 0
++#define CONFIG_RALF_DECODER 0
++#define CONFIG_SBC_DECODER 0
++#define CONFIG_SHORTEN_DECODER 0
++#define CONFIG_SIPR_DECODER 0
++#define CONFIG_SIREN_DECODER 0
++#define CONFIG_SMACKAUD_DECODER 0
++#define CONFIG_SONIC_DECODER 0
++#define CONFIG_TAK_DECODER 0
++#define CONFIG_TRUEHD_DECODER 0
++#define CONFIG_TRUESPEECH_DECODER 0
++#define CONFIG_TTA_DECODER 0
++#define CONFIG_TWINVQ_DECODER 0
++#define CONFIG_VMDAUDIO_DECODER 0
++#define CONFIG_VORBIS_DECODER 1
++#define CONFIG_WAVARC_DECODER 0
++#define CONFIG_WAVPACK_DECODER 0
++#define CONFIG_WMALOSSLESS_DECODER 0
++#define CONFIG_WMAPRO_DECODER 0
++#define CONFIG_WMAV1_DECODER 0
++#define CONFIG_WMAV2_DECODER 0
++#define CONFIG_WMAVOICE_DECODER 0
++#define CONFIG_WS_SND1_DECODER 0
++#define CONFIG_XMA1_DECODER 0
++#define CONFIG_XMA2_DECODER 0
++#define CONFIG_PCM_ALAW_DECODER 1
++#define CONFIG_PCM_BLURAY_DECODER 0
++#define CONFIG_PCM_DVD_DECODER 0
++#define CONFIG_PCM_F16LE_DECODER 0
++#define CONFIG_PCM_F24LE_DECODER 0
++#define CONFIG_PCM_F32BE_DECODER 0
++#define CONFIG_PCM_F32LE_DECODER 1
++#define CONFIG_PCM_F64BE_DECODER 0
++#define CONFIG_PCM_F64LE_DECODER 0
++#define CONFIG_PCM_LXF_DECODER 0
++#define CONFIG_PCM_MULAW_DECODER 1
++#define CONFIG_PCM_S8_DECODER 0
++#define CONFIG_PCM_S8_PLANAR_DECODER 0
++#define CONFIG_PCM_S16BE_DECODER 1
++#define CONFIG_PCM_S16BE_PLANAR_DECODER 0
++#define CONFIG_PCM_S16LE_DECODER 1
++#define CONFIG_PCM_S16LE_PLANAR_DECODER 0
++#define CONFIG_PCM_S24BE_DECODER 1
++#define CONFIG_PCM_S24DAUD_DECODER 0
++#define CONFIG_PCM_S24LE_DECODER 1
++#define CONFIG_PCM_S24LE_PLANAR_DECODER 0
++#define CONFIG_PCM_S32BE_DECODER 0
++#define CONFIG_PCM_S32LE_DECODER 1
++#define CONFIG_PCM_S32LE_PLANAR_DECODER 0
++#define CONFIG_PCM_S64BE_DECODER 0
++#define CONFIG_PCM_S64LE_DECODER 0
++#define CONFIG_PCM_SGA_DECODER 0
++#define CONFIG_PCM_U8_DECODER 1
++#define CONFIG_PCM_U16BE_DECODER 0
++#define CONFIG_PCM_U16LE_DECODER 0
++#define CONFIG_PCM_U24BE_DECODER 0
++#define CONFIG_PCM_U24LE_DECODER 0
++#define CONFIG_PCM_U32BE_DECODER 0
++#define CONFIG_PCM_U32LE_DECODER 0
++#define CONFIG_PCM_VIDC_DECODER 0
++#define CONFIG_CBD2_DPCM_DECODER 0
++#define CONFIG_DERF_DPCM_DECODER 0
++#define CONFIG_GREMLIN_DPCM_DECODER 0
++#define CONFIG_INTERPLAY_DPCM_DECODER 0
++#define CONFIG_ROQ_DPCM_DECODER 0
++#define CONFIG_SDX2_DPCM_DECODER 0
++#define CONFIG_SOL_DPCM_DECODER 0
++#define CONFIG_XAN_DPCM_DECODER 0
++#define CONFIG_WADY_DPCM_DECODER 0
++#define CONFIG_ADPCM_4XM_DECODER 0
++#define CONFIG_ADPCM_ADX_DECODER 0
++#define CONFIG_ADPCM_AFC_DECODER 0
++#define CONFIG_ADPCM_AGM_DECODER 0
++#define CONFIG_ADPCM_AICA_DECODER 0
++#define CONFIG_ADPCM_ARGO_DECODER 0
++#define CONFIG_ADPCM_CT_DECODER 0
++#define CONFIG_ADPCM_DTK_DECODER 0
++#define CONFIG_ADPCM_EA_DECODER 0
++#define CONFIG_ADPCM_EA_MAXIS_XA_DECODER 0
++#define CONFIG_ADPCM_EA_R1_DECODER 0
++#define CONFIG_ADPCM_EA_R2_DECODER 0
++#define CONFIG_ADPCM_EA_R3_DECODER 0
++#define CONFIG_ADPCM_EA_XAS_DECODER 0
++#define CONFIG_ADPCM_G722_DECODER 0
++#define CONFIG_ADPCM_G726_DECODER 0
++#define CONFIG_ADPCM_G726LE_DECODER 0
++#define CONFIG_ADPCM_IMA_ACORN_DECODER 0
++#define CONFIG_ADPCM_IMA_AMV_DECODER 0
++#define CONFIG_ADPCM_IMA_ALP_DECODER 0
++#define CONFIG_ADPCM_IMA_APC_DECODER 0
++#define CONFIG_ADPCM_IMA_APM_DECODER 0
++#define CONFIG_ADPCM_IMA_CUNNING_DECODER 0
++#define CONFIG_ADPCM_IMA_DAT4_DECODER 0
++#define CONFIG_ADPCM_IMA_DK3_DECODER 0
++#define CONFIG_ADPCM_IMA_DK4_DECODER 0
++#define CONFIG_ADPCM_IMA_EA_EACS_DECODER 0
++#define CONFIG_ADPCM_IMA_EA_SEAD_DECODER 0
++#define CONFIG_ADPCM_IMA_ISS_DECODER 0
++#define CONFIG_ADPCM_IMA_MOFLEX_DECODER 0
++#define CONFIG_ADPCM_IMA_MTF_DECODER 0
++#define CONFIG_ADPCM_IMA_OKI_DECODER 0
++#define CONFIG_ADPCM_IMA_QT_DECODER 0
++#define CONFIG_ADPCM_IMA_RAD_DECODER 0
++#define CONFIG_ADPCM_IMA_SSI_DECODER 0
++#define CONFIG_ADPCM_IMA_SMJPEG_DECODER 0
++#define CONFIG_ADPCM_IMA_WAV_DECODER 0
++#define CONFIG_ADPCM_IMA_WS_DECODER 0
++#define CONFIG_ADPCM_MS_DECODER 0
++#define CONFIG_ADPCM_MTAF_DECODER 0
++#define CONFIG_ADPCM_PSX_DECODER 0
++#define CONFIG_ADPCM_SBPRO_2_DECODER 0
++#define CONFIG_ADPCM_SBPRO_3_DECODER 0
++#define CONFIG_ADPCM_SBPRO_4_DECODER 0
++#define CONFIG_ADPCM_SWF_DECODER 0
++#define CONFIG_ADPCM_THP_DECODER 0
++#define CONFIG_ADPCM_THP_LE_DECODER 0
++#define CONFIG_ADPCM_VIMA_DECODER 0
++#define CONFIG_ADPCM_XA_DECODER 0
++#define CONFIG_ADPCM_XMD_DECODER 0
++#define CONFIG_ADPCM_YAMAHA_DECODER 0
++#define CONFIG_ADPCM_ZORK_DECODER 0
++#define CONFIG_SSA_DECODER 0
++#define CONFIG_ASS_DECODER 0
++#define CONFIG_CCAPTION_DECODER 0
++#define CONFIG_DVBSUB_DECODER 0
++#define CONFIG_DVDSUB_DECODER 0
++#define CONFIG_JACOSUB_DECODER 0
++#define CONFIG_MICRODVD_DECODER 0
++#define CONFIG_MOVTEXT_DECODER 0
++#define CONFIG_MPL2_DECODER 0
++#define CONFIG_PGSSUB_DECODER 0
++#define CONFIG_PJS_DECODER 0
++#define CONFIG_REALTEXT_DECODER 0
++#define CONFIG_SAMI_DECODER 0
++#define CONFIG_SRT_DECODER 0
++#define CONFIG_STL_DECODER 0
++#define CONFIG_SUBRIP_DECODER 0
++#define CONFIG_SUBVIEWER_DECODER 0
++#define CONFIG_SUBVIEWER1_DECODER 0
++#define CONFIG_TEXT_DECODER 0
++#define CONFIG_VPLAYER_DECODER 0
++#define CONFIG_WEBVTT_DECODER 0
++#define CONFIG_XSUB_DECODER 0
++#define CONFIG_AAC_AT_DECODER 0
++#define CONFIG_AC3_AT_DECODER 0
++#define CONFIG_ADPCM_IMA_QT_AT_DECODER 0
++#define CONFIG_ALAC_AT_DECODER 0
++#define CONFIG_AMR_NB_AT_DECODER 0
++#define CONFIG_EAC3_AT_DECODER 0
++#define CONFIG_GSM_MS_AT_DECODER 0
++#define CONFIG_ILBC_AT_DECODER 0
++#define CONFIG_MP1_AT_DECODER 0
++#define CONFIG_MP2_AT_DECODER 0
++#define CONFIG_MP3_AT_DECODER 0
++#define CONFIG_PCM_ALAW_AT_DECODER 0
++#define CONFIG_PCM_MULAW_AT_DECODER 0
++#define CONFIG_QDMC_AT_DECODER 0
++#define CONFIG_QDM2_AT_DECODER 0
++#define CONFIG_LIBARIBCAPTION_DECODER 0
++#define CONFIG_LIBARIBB24_DECODER 0
++#define CONFIG_LIBCELT_DECODER 0
++#define CONFIG_LIBCODEC2_DECODER 0
++#define CONFIG_LIBDAV1D_DECODER 0
++#define CONFIG_LIBDAVS2_DECODER 0
++#define CONFIG_LIBFDK_AAC_DECODER 0
++#define CONFIG_LIBGSM_DECODER 0
++#define CONFIG_LIBGSM_MS_DECODER 0
++#define CONFIG_LIBILBC_DECODER 0
++#define CONFIG_LIBJXL_DECODER 0
++#define CONFIG_LIBOPENCORE_AMRNB_DECODER 0
++#define CONFIG_LIBOPENCORE_AMRWB_DECODER 0
++#define CONFIG_LIBOPUS_DECODER 1
++#define CONFIG_LIBRSVG_DECODER 0
++#define CONFIG_LIBSPEEX_DECODER 0
++#define CONFIG_LIBUAVS3D_DECODER 0
++#define CONFIG_LIBVORBIS_DECODER 0
++#define CONFIG_LIBVPX_VP8_DECODER 0
++#define CONFIG_LIBVPX_VP9_DECODER 0
++#define CONFIG_LIBXEVD_DECODER 0
++#define CONFIG_LIBZVBI_TELETEXT_DECODER 0
++#define CONFIG_BINTEXT_DECODER 0
++#define CONFIG_XBIN_DECODER 0
++#define CONFIG_IDF_DECODER 0
++#define CONFIG_LIBAOM_AV1_DECODER 0
++#define CONFIG_AV1_DECODER 0
++#define CONFIG_AV1_CUVID_DECODER 0
++#define CONFIG_AV1_MEDIACODEC_DECODER 0
++#define CONFIG_AV1_QSV_DECODER 0
++#define CONFIG_LIBOPENH264_DECODER 0
++#define CONFIG_H264_CUVID_DECODER 0
++#define CONFIG_HEVC_CUVID_DECODER 0
++#define CONFIG_HEVC_MEDIACODEC_DECODER 0
++#define CONFIG_MJPEG_CUVID_DECODER 0
++#define CONFIG_MJPEG_QSV_DECODER 0
++#define CONFIG_MPEG1_CUVID_DECODER 0
++#define CONFIG_MPEG2_CUVID_DECODER 0
++#define CONFIG_MPEG4_CUVID_DECODER 0
++#define CONFIG_MPEG4_MEDIACODEC_DECODER 0
++#define CONFIG_VC1_CUVID_DECODER 0
++#define CONFIG_VP8_CUVID_DECODER 0
++#define CONFIG_VP8_MEDIACODEC_DECODER 0
++#define CONFIG_VP8_QSV_DECODER 0
++#define CONFIG_VP9_CUVID_DECODER 0
++#define CONFIG_VP9_MEDIACODEC_DECODER 0
++#define CONFIG_VP9_QSV_DECODER 0
++#define CONFIG_VNULL_DECODER 0
++#define CONFIG_ANULL_DECODER 0
++#define CONFIG_A64MULTI_ENCODER 0
++#define CONFIG_A64MULTI5_ENCODER 0
++#define CONFIG_ALIAS_PIX_ENCODER 0
++#define CONFIG_AMV_ENCODER 0
++#define CONFIG_APNG_ENCODER 0
++#define CONFIG_ASV1_ENCODER 0
++#define CONFIG_ASV2_ENCODER 0
++#define CONFIG_AVRP_ENCODER 0
++#define CONFIG_AVUI_ENCODER 0
++#define CONFIG_AYUV_ENCODER 0
++#define CONFIG_BITPACKED_ENCODER 0
++#define CONFIG_BMP_ENCODER 0
++#define CONFIG_CFHD_ENCODER 0
++#define CONFIG_CINEPAK_ENCODER 0
++#define CONFIG_CLJR_ENCODER 0
++#define CONFIG_COMFORTNOISE_ENCODER 0
++#define CONFIG_DNXHD_ENCODER 0
++#define CONFIG_DPX_ENCODER 0
++#define CONFIG_DVVIDEO_ENCODER 0
++#define CONFIG_DXV_ENCODER 0
++#define CONFIG_EXR_ENCODER 0
++#define CONFIG_FFV1_ENCODER 0
++#define CONFIG_FFVHUFF_ENCODER 0
++#define CONFIG_FITS_ENCODER 0
++#define CONFIG_FLASHSV_ENCODER 0
++#define CONFIG_FLASHSV2_ENCODER 0
++#define CONFIG_FLV_ENCODER 0
++#define CONFIG_GIF_ENCODER 0
++#define CONFIG_H261_ENCODER 0
++#define CONFIG_H263_ENCODER 0
++#define CONFIG_H263P_ENCODER 0
++#define CONFIG_H264_MEDIACODEC_ENCODER 0
++#define CONFIG_HAP_ENCODER 0
++#define CONFIG_HUFFYUV_ENCODER 0
++#define CONFIG_JPEG2000_ENCODER 0
++#define CONFIG_JPEGLS_ENCODER 0
++#define CONFIG_LJPEG_ENCODER 0
++#define CONFIG_MAGICYUV_ENCODER 0
++#define CONFIG_MJPEG_ENCODER 0
++#define CONFIG_MPEG1VIDEO_ENCODER 0
++#define CONFIG_MPEG2VIDEO_ENCODER 0
++#define CONFIG_MPEG4_ENCODER 0
++#define CONFIG_MSMPEG4V2_ENCODER 0
++#define CONFIG_MSMPEG4V3_ENCODER 0
++#define CONFIG_MSRLE_ENCODER 0
++#define CONFIG_MSVIDEO1_ENCODER 0
++#define CONFIG_PAM_ENCODER 0
++#define CONFIG_PBM_ENCODER 0
++#define CONFIG_PCX_ENCODER 0
++#define CONFIG_PFM_ENCODER 0
++#define CONFIG_PGM_ENCODER 0
++#define CONFIG_PGMYUV_ENCODER 0
++#define CONFIG_PHM_ENCODER 0
++#define CONFIG_PNG_ENCODER 0
++#define CONFIG_PPM_ENCODER 0
++#define CONFIG_PRORES_ENCODER 0
++#define CONFIG_PRORES_AW_ENCODER 0
++#define CONFIG_PRORES_KS_ENCODER 0
++#define CONFIG_QOI_ENCODER 0
++#define CONFIG_QTRLE_ENCODER 0
++#define CONFIG_R10K_ENCODER 0
++#define CONFIG_R210_ENCODER 0
++#define CONFIG_RAWVIDEO_ENCODER 0
++#define CONFIG_ROQ_ENCODER 0
++#define CONFIG_RPZA_ENCODER 0
++#define CONFIG_RV10_ENCODER 0
++#define CONFIG_RV20_ENCODER 0
++#define CONFIG_S302M_ENCODER 0
++#define CONFIG_SGI_ENCODER 0
++#define CONFIG_SMC_ENCODER 0
++#define CONFIG_SNOW_ENCODER 0
++#define CONFIG_SPEEDHQ_ENCODER 0
++#define CONFIG_SUNRAST_ENCODER 0
++#define CONFIG_SVQ1_ENCODER 0
++#define CONFIG_TARGA_ENCODER 0
++#define CONFIG_TIFF_ENCODER 0
++#define CONFIG_UTVIDEO_ENCODER 0
++#define CONFIG_V210_ENCODER 0
++#define CONFIG_V308_ENCODER 0
++#define CONFIG_V408_ENCODER 0
++#define CONFIG_V410_ENCODER 0
++#define CONFIG_VBN_ENCODER 0
++#define CONFIG_VC2_ENCODER 0
++#define CONFIG_WBMP_ENCODER 0
++#define CONFIG_WRAPPED_AVFRAME_ENCODER 0
++#define CONFIG_WMV1_ENCODER 0
++#define CONFIG_WMV2_ENCODER 0
++#define CONFIG_XBM_ENCODER 0
++#define CONFIG_XFACE_ENCODER 0
++#define CONFIG_XWD_ENCODER 0
++#define CONFIG_Y41P_ENCODER 0
++#define CONFIG_YUV4_ENCODER 0
++#define CONFIG_ZLIB_ENCODER 0
++#define CONFIG_ZMBV_ENCODER 0
++#define CONFIG_AAC_ENCODER 0
++#define CONFIG_AC3_ENCODER 0
++#define CONFIG_AC3_FIXED_ENCODER 0
++#define CONFIG_ALAC_ENCODER 0
++#define CONFIG_APTX_ENCODER 0
++#define CONFIG_APTX_HD_ENCODER 0
++#define CONFIG_DCA_ENCODER 0
++#define CONFIG_DFPWM_ENCODER 0
++#define CONFIG_EAC3_ENCODER 0
++#define CONFIG_FLAC_ENCODER 0
++#define CONFIG_G723_1_ENCODER 0
++#define CONFIG_HDR_ENCODER 0
++#define CONFIG_MLP_ENCODER 0
++#define CONFIG_MP2_ENCODER 0
++#define CONFIG_MP2FIXED_ENCODER 0
++#define CONFIG_NELLYMOSER_ENCODER 0
++#define CONFIG_OPUS_ENCODER 0
++#define CONFIG_RA_144_ENCODER 0
++#define CONFIG_SBC_ENCODER 0
++#define CONFIG_SONIC_ENCODER 0
++#define CONFIG_SONIC_LS_ENCODER 0
++#define CONFIG_TRUEHD_ENCODER 0
++#define CONFIG_TTA_ENCODER 0
++#define CONFIG_VORBIS_ENCODER 0
++#define CONFIG_WAVPACK_ENCODER 0
++#define CONFIG_WMAV1_ENCODER 0
++#define CONFIG_WMAV2_ENCODER 0
++#define CONFIG_PCM_ALAW_ENCODER 0
++#define CONFIG_PCM_BLURAY_ENCODER 0
++#define CONFIG_PCM_DVD_ENCODER 0
++#define CONFIG_PCM_F32BE_ENCODER 0
++#define CONFIG_PCM_F32LE_ENCODER 0
++#define CONFIG_PCM_F64BE_ENCODER 0
++#define CONFIG_PCM_F64LE_ENCODER 0
++#define CONFIG_PCM_MULAW_ENCODER 0
++#define CONFIG_PCM_S8_ENCODER 0
++#define CONFIG_PCM_S8_PLANAR_ENCODER 0
++#define CONFIG_PCM_S16BE_ENCODER 0
++#define CONFIG_PCM_S16BE_PLANAR_ENCODER 0
++#define CONFIG_PCM_S16LE_ENCODER 0
++#define CONFIG_PCM_S16LE_PLANAR_ENCODER 0
++#define CONFIG_PCM_S24BE_ENCODER 0
++#define CONFIG_PCM_S24DAUD_ENCODER 0
++#define CONFIG_PCM_S24LE_ENCODER 0
++#define CONFIG_PCM_S24LE_PLANAR_ENCODER 0
++#define CONFIG_PCM_S32BE_ENCODER 0
++#define CONFIG_PCM_S32LE_ENCODER 0
++#define CONFIG_PCM_S32LE_PLANAR_ENCODER 0
++#define CONFIG_PCM_S64BE_ENCODER 0
++#define CONFIG_PCM_S64LE_ENCODER 0
++#define CONFIG_PCM_U8_ENCODER 0
++#define CONFIG_PCM_U16BE_ENCODER 0
++#define CONFIG_PCM_U16LE_ENCODER 0
++#define CONFIG_PCM_U24BE_ENCODER 0
++#define CONFIG_PCM_U24LE_ENCODER 0
++#define CONFIG_PCM_U32BE_ENCODER 0
++#define CONFIG_PCM_U32LE_ENCODER 0
++#define CONFIG_PCM_VIDC_ENCODER 0
++#define CONFIG_ROQ_DPCM_ENCODER 0
++#define CONFIG_ADPCM_ADX_ENCODER 0
++#define CONFIG_ADPCM_ARGO_ENCODER 0
++#define CONFIG_ADPCM_G722_ENCODER 0
++#define CONFIG_ADPCM_G726_ENCODER 0
++#define CONFIG_ADPCM_G726LE_ENCODER 0
++#define CONFIG_ADPCM_IMA_AMV_ENCODER 0
++#define CONFIG_ADPCM_IMA_ALP_ENCODER 0
++#define CONFIG_ADPCM_IMA_APM_ENCODER 0
++#define CONFIG_ADPCM_IMA_QT_ENCODER 0
++#define CONFIG_ADPCM_IMA_SSI_ENCODER 0
++#define CONFIG_ADPCM_IMA_WAV_ENCODER 0
++#define CONFIG_ADPCM_IMA_WS_ENCODER 0
++#define CONFIG_ADPCM_MS_ENCODER 0
++#define CONFIG_ADPCM_SWF_ENCODER 0
++#define CONFIG_ADPCM_YAMAHA_ENCODER 0
++#define CONFIG_SSA_ENCODER 0
++#define CONFIG_ASS_ENCODER 0
++#define CONFIG_DVBSUB_ENCODER 0
++#define CONFIG_DVDSUB_ENCODER 0
++#define CONFIG_MOVTEXT_ENCODER 0
++#define CONFIG_SRT_ENCODER 0
++#define CONFIG_SUBRIP_ENCODER 0
++#define CONFIG_TEXT_ENCODER 0
++#define CONFIG_TTML_ENCODER 0
++#define CONFIG_WEBVTT_ENCODER 0
++#define CONFIG_XSUB_ENCODER 0
++#define CONFIG_AAC_AT_ENCODER 0
++#define CONFIG_ALAC_AT_ENCODER 0
++#define CONFIG_ILBC_AT_ENCODER 0
++#define CONFIG_PCM_ALAW_AT_ENCODER 0
++#define CONFIG_PCM_MULAW_AT_ENCODER 0
++#define CONFIG_LIBAOM_AV1_ENCODER 0
++#define CONFIG_LIBCODEC2_ENCODER 0
++#define CONFIG_LIBFDK_AAC_ENCODER 0
++#define CONFIG_LIBGSM_ENCODER 0
++#define CONFIG_LIBGSM_MS_ENCODER 0
++#define CONFIG_LIBILBC_ENCODER 0
++#define CONFIG_LIBJXL_ENCODER 0
++#define CONFIG_LIBMP3LAME_ENCODER 0
++#define CONFIG_LIBOPENCORE_AMRNB_ENCODER 0
++#define CONFIG_LIBOPENJPEG_ENCODER 0
++#define CONFIG_LIBOPUS_ENCODER 0
++#define CONFIG_LIBRAV1E_ENCODER 0
++#define CONFIG_LIBSHINE_ENCODER 0
++#define CONFIG_LIBSPEEX_ENCODER 0
++#define CONFIG_LIBSVTAV1_ENCODER 0
++#define CONFIG_LIBTHEORA_ENCODER 0
++#define CONFIG_LIBTWOLAME_ENCODER 0
++#define CONFIG_LIBVO_AMRWBENC_ENCODER 0
++#define CONFIG_LIBVORBIS_ENCODER 0
++#define CONFIG_LIBVPX_VP8_ENCODER 0
++#define CONFIG_LIBVPX_VP9_ENCODER 0
++#define CONFIG_LIBWEBP_ANIM_ENCODER 0
++#define CONFIG_LIBWEBP_ENCODER 0
++#define CONFIG_LIBX262_ENCODER 0
++#define CONFIG_LIBX264_ENCODER 0
++#define CONFIG_LIBX264RGB_ENCODER 0
++#define CONFIG_LIBX265_ENCODER 0
++#define CONFIG_LIBXEVE_ENCODER 0
++#define CONFIG_LIBXAVS_ENCODER 0
++#define CONFIG_LIBXAVS2_ENCODER 0
++#define CONFIG_LIBXVID_ENCODER 0
++#define CONFIG_AAC_MF_ENCODER 0
++#define CONFIG_AC3_MF_ENCODER 0
++#define CONFIG_H263_V4L2M2M_ENCODER 0
++#define CONFIG_AV1_MEDIACODEC_ENCODER 0
++#define CONFIG_AV1_NVENC_ENCODER 0
++#define CONFIG_AV1_QSV_ENCODER 0
++#define CONFIG_AV1_AMF_ENCODER 0
++#define CONFIG_AV1_VAAPI_ENCODER 0
++#define CONFIG_LIBOPENH264_ENCODER 0
++#define CONFIG_H264_AMF_ENCODER 0
++#define CONFIG_H264_MF_ENCODER 0
++#define CONFIG_H264_NVENC_ENCODER 0
++#define CONFIG_H264_OMX_ENCODER 0
++#define CONFIG_H264_QSV_ENCODER 0
++#define CONFIG_H264_V4L2M2M_ENCODER 0
++#define CONFIG_H264_VAAPI_ENCODER 0
++#define CONFIG_H264_VIDEOTOOLBOX_ENCODER 0
++#define CONFIG_HEVC_AMF_ENCODER 0
++#define CONFIG_HEVC_MEDIACODEC_ENCODER 0
++#define CONFIG_HEVC_MF_ENCODER 0
++#define CONFIG_HEVC_NVENC_ENCODER 0
++#define CONFIG_HEVC_QSV_ENCODER 0
++#define CONFIG_HEVC_V4L2M2M_ENCODER 0
++#define CONFIG_HEVC_VAAPI_ENCODER 0
++#define CONFIG_HEVC_VIDEOTOOLBOX_ENCODER 0
++#define CONFIG_LIBKVAZAAR_ENCODER 0
++#define CONFIG_MJPEG_QSV_ENCODER 0
++#define CONFIG_MJPEG_VAAPI_ENCODER 0
++#define CONFIG_MP3_MF_ENCODER 0
++#define CONFIG_MPEG2_QSV_ENCODER 0
++#define CONFIG_MPEG2_VAAPI_ENCODER 0
++#define CONFIG_MPEG4_MEDIACODEC_ENCODER 0
++#define CONFIG_MPEG4_OMX_ENCODER 0
++#define CONFIG_MPEG4_V4L2M2M_ENCODER 0
++#define CONFIG_PRORES_VIDEOTOOLBOX_ENCODER 0
++#define CONFIG_VP8_MEDIACODEC_ENCODER 0
++#define CONFIG_VP8_V4L2M2M_ENCODER 0
++#define CONFIG_VP8_VAAPI_ENCODER 0
++#define CONFIG_VP9_MEDIACODEC_ENCODER 0
++#define CONFIG_VP9_VAAPI_ENCODER 0
++#define CONFIG_VP9_QSV_ENCODER 0
++#define CONFIG_VNULL_ENCODER 0
++#define CONFIG_ANULL_ENCODER 0
++#define CONFIG_AV1_D3D11VA_HWACCEL 0
++#define CONFIG_AV1_D3D11VA2_HWACCEL 0
++#define CONFIG_AV1_D3D12VA_HWACCEL 0
++#define CONFIG_AV1_DXVA2_HWACCEL 0
++#define CONFIG_AV1_NVDEC_HWACCEL 0
++#define CONFIG_AV1_VAAPI_HWACCEL 0
++#define CONFIG_AV1_VDPAU_HWACCEL 0
++#define CONFIG_AV1_VULKAN_HWACCEL 0
++#define CONFIG_H263_VAAPI_HWACCEL 0
++#define CONFIG_H263_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_H264_D3D11VA_HWACCEL 0
++#define CONFIG_H264_D3D11VA2_HWACCEL 0
++#define CONFIG_H264_D3D12VA_HWACCEL 0
++#define CONFIG_H264_DXVA2_HWACCEL 0
++#define CONFIG_H264_NVDEC_HWACCEL 0
++#define CONFIG_H264_VAAPI_HWACCEL 0
++#define CONFIG_H264_VDPAU_HWACCEL 0
++#define CONFIG_H264_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_H264_VULKAN_HWACCEL 0
++#define CONFIG_HEVC_D3D11VA_HWACCEL 0
++#define CONFIG_HEVC_D3D11VA2_HWACCEL 0
++#define CONFIG_HEVC_D3D12VA_HWACCEL 0
++#define CONFIG_HEVC_DXVA2_HWACCEL 0
++#define CONFIG_HEVC_NVDEC_HWACCEL 0
++#define CONFIG_HEVC_VAAPI_HWACCEL 0
++#define CONFIG_HEVC_VDPAU_HWACCEL 0
++#define CONFIG_HEVC_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_HEVC_VULKAN_HWACCEL 0
++#define CONFIG_MJPEG_NVDEC_HWACCEL 0
++#define CONFIG_MJPEG_VAAPI_HWACCEL 0
++#define CONFIG_MPEG1_NVDEC_HWACCEL 0
++#define CONFIG_MPEG1_VDPAU_HWACCEL 0
++#define CONFIG_MPEG1_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_MPEG2_D3D11VA_HWACCEL 0
++#define CONFIG_MPEG2_D3D11VA2_HWACCEL 0
++#define CONFIG_MPEG2_D3D12VA_HWACCEL 0
++#define CONFIG_MPEG2_DXVA2_HWACCEL 0
++#define CONFIG_MPEG2_NVDEC_HWACCEL 0
++#define CONFIG_MPEG2_VAAPI_HWACCEL 0
++#define CONFIG_MPEG2_VDPAU_HWACCEL 0
++#define CONFIG_MPEG2_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_MPEG4_NVDEC_HWACCEL 0
++#define CONFIG_MPEG4_VAAPI_HWACCEL 0
++#define CONFIG_MPEG4_VDPAU_HWACCEL 0
++#define CONFIG_MPEG4_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_PRORES_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_VC1_D3D11VA_HWACCEL 0
++#define CONFIG_VC1_D3D11VA2_HWACCEL 0
++#define CONFIG_VC1_D3D12VA_HWACCEL 0
++#define CONFIG_VC1_DXVA2_HWACCEL 0
++#define CONFIG_VC1_NVDEC_HWACCEL 0
++#define CONFIG_VC1_VAAPI_HWACCEL 0
++#define CONFIG_VC1_VDPAU_HWACCEL 0
++#define CONFIG_VP8_NVDEC_HWACCEL 0
++#define CONFIG_VP8_VAAPI_HWACCEL 0
++#define CONFIG_VP9_D3D11VA_HWACCEL 0
++#define CONFIG_VP9_D3D11VA2_HWACCEL 0
++#define CONFIG_VP9_D3D12VA_HWACCEL 0
++#define CONFIG_VP9_DXVA2_HWACCEL 0
++#define CONFIG_VP9_NVDEC_HWACCEL 0
++#define CONFIG_VP9_VAAPI_HWACCEL 0
++#define CONFIG_VP9_VDPAU_HWACCEL 0
++#define CONFIG_VP9_VIDEOTOOLBOX_HWACCEL 0
++#define CONFIG_WMV3_D3D11VA_HWACCEL 0
++#define CONFIG_WMV3_D3D11VA2_HWACCEL 0
++#define CONFIG_WMV3_D3D12VA_HWACCEL 0
++#define CONFIG_WMV3_DXVA2_HWACCEL 0
++#define CONFIG_WMV3_NVDEC_HWACCEL 0
++#define CONFIG_WMV3_VAAPI_HWACCEL 0
++#define CONFIG_WMV3_VDPAU_HWACCEL 0
++#define CONFIG_AAC_PARSER 0
++#define CONFIG_AAC_LATM_PARSER 0
++#define CONFIG_AC3_PARSER 0
++#define CONFIG_ADX_PARSER 0
++#define CONFIG_AMR_PARSER 0
++#define CONFIG_AV1_PARSER 0
++#define CONFIG_AVS2_PARSER 0
++#define CONFIG_AVS3_PARSER 0
++#define CONFIG_BMP_PARSER 0
++#define CONFIG_CAVSVIDEO_PARSER 0
++#define CONFIG_COOK_PARSER 0
++#define CONFIG_CRI_PARSER 0
++#define CONFIG_DCA_PARSER 0
++#define CONFIG_DIRAC_PARSER 0
++#define CONFIG_DNXHD_PARSER 0
++#define CONFIG_DOLBY_E_PARSER 0
++#define CONFIG_DPX_PARSER 0
++#define CONFIG_DVAUDIO_PARSER 0
++#define CONFIG_DVBSUB_PARSER 0
++#define CONFIG_DVDSUB_PARSER 0
++#define CONFIG_DVD_NAV_PARSER 0
++#define CONFIG_EVC_PARSER 0
++#define CONFIG_FLAC_PARSER 1
++#define CONFIG_FTR_PARSER 0
++#define CONFIG_G723_1_PARSER 0
++#define CONFIG_G729_PARSER 0
++#define CONFIG_GIF_PARSER 0
++#define CONFIG_GSM_PARSER 0
++#define CONFIG_H261_PARSER 0
++#define CONFIG_H263_PARSER 0
++#define CONFIG_H264_PARSER 0
++#define CONFIG_HEVC_PARSER 0
++#define CONFIG_HDR_PARSER 0
++#define CONFIG_IPU_PARSER 0
++#define CONFIG_JPEG2000_PARSER 0
++#define CONFIG_JPEGXL_PARSER 0
++#define CONFIG_MISC4_PARSER 0
++#define CONFIG_MJPEG_PARSER 0
++#define CONFIG_MLP_PARSER 0
++#define CONFIG_MPEG4VIDEO_PARSER 0
++#define CONFIG_MPEGAUDIO_PARSER 1
++#define CONFIG_MPEGVIDEO_PARSER 0
++#define CONFIG_OPUS_PARSER 1
++#define CONFIG_PNG_PARSER 0
++#define CONFIG_PNM_PARSER 0
++#define CONFIG_QOI_PARSER 0
++#define CONFIG_RV34_PARSER 0
++#define CONFIG_SBC_PARSER 0
++#define CONFIG_SIPR_PARSER 0
++#define CONFIG_TAK_PARSER 0
++#define CONFIG_VC1_PARSER 0
++#define CONFIG_VORBIS_PARSER 1
++#define CONFIG_VP3_PARSER 0
++#define CONFIG_VP8_PARSER 0
++#define CONFIG_VP9_PARSER 1
++#define CONFIG_VVC_PARSER 0
++#define CONFIG_WEBP_PARSER 0
++#define CONFIG_XBM_PARSER 0
++#define CONFIG_XMA_PARSER 0
++#define CONFIG_XWD_PARSER 0
++#define CONFIG_ALSA_INDEV 0
++#define CONFIG_ANDROID_CAMERA_INDEV 0
++#define CONFIG_AVFOUNDATION_INDEV 0
++#define CONFIG_BKTR_INDEV 0
++#define CONFIG_DECKLINK_INDEV 0
++#define CONFIG_DSHOW_INDEV 0
++#define CONFIG_FBDEV_INDEV 0
++#define CONFIG_GDIGRAB_INDEV 0
++#define CONFIG_IEC61883_INDEV 0
++#define CONFIG_JACK_INDEV 0
++#define CONFIG_KMSGRAB_INDEV 0
++#define CONFIG_LAVFI_INDEV 0
++#define CONFIG_OPENAL_INDEV 0
++#define CONFIG_OSS_INDEV 0
++#define CONFIG_PULSE_INDEV 0
++#define CONFIG_SNDIO_INDEV 0
++#define CONFIG_V4L2_INDEV 0
++#define CONFIG_VFWCAP_INDEV 0
++#define CONFIG_XCBGRAB_INDEV 0
++#define CONFIG_LIBCDIO_INDEV 0
++#define CONFIG_LIBDC1394_INDEV 0
++#define CONFIG_ALSA_OUTDEV 0
++#define CONFIG_AUDIOTOOLBOX_OUTDEV 0
++#define CONFIG_CACA_OUTDEV 0
++#define CONFIG_DECKLINK_OUTDEV 0
++#define CONFIG_FBDEV_OUTDEV 0
++#define CONFIG_OPENGL_OUTDEV 0
++#define CONFIG_OSS_OUTDEV 0
++#define CONFIG_PULSE_OUTDEV 0
++#define CONFIG_SDL2_OUTDEV 0
++#define CONFIG_SNDIO_OUTDEV 0
++#define CONFIG_V4L2_OUTDEV 0
++#define CONFIG_XV_OUTDEV 0
++#define CONFIG_AAP_FILTER 0
++#define CONFIG_ABENCH_FILTER 0
++#define CONFIG_ACOMPRESSOR_FILTER 0
++#define CONFIG_ACONTRAST_FILTER 0
++#define CONFIG_ACOPY_FILTER 0
++#define CONFIG_ACUE_FILTER 0
++#define CONFIG_ACROSSFADE_FILTER 0
++#define CONFIG_ACROSSOVER_FILTER 0
++#define CONFIG_ACRUSHER_FILTER 0
++#define CONFIG_ADECLICK_FILTER 0
++#define CONFIG_ADECLIP_FILTER 0
++#define CONFIG_ADECORRELATE_FILTER 0
++#define CONFIG_ADELAY_FILTER 0
++#define CONFIG_ADENORM_FILTER 0
++#define CONFIG_ADERIVATIVE_FILTER 0
++#define CONFIG_ADRC_FILTER 0
++#define CONFIG_ADYNAMICEQUALIZER_FILTER 0
++#define CONFIG_ADYNAMICSMOOTH_FILTER 0
++#define CONFIG_AECHO_FILTER 0
++#define CONFIG_AEMPHASIS_FILTER 0
++#define CONFIG_AEVAL_FILTER 0
++#define CONFIG_AEXCITER_FILTER 0
++#define CONFIG_AFADE_FILTER 0
++#define CONFIG_AFFTDN_FILTER 0
++#define CONFIG_AFFTFILT_FILTER 0
++#define CONFIG_AFIR_FILTER 0
++#define CONFIG_AFORMAT_FILTER 0
++#define CONFIG_AFREQSHIFT_FILTER 0
++#define CONFIG_AFWTDN_FILTER 0
++#define CONFIG_AGATE_FILTER 0
++#define CONFIG_AIIR_FILTER 0
++#define CONFIG_AINTEGRAL_FILTER 0
++#define CONFIG_AINTERLEAVE_FILTER 0
++#define CONFIG_ALATENCY_FILTER 0
++#define CONFIG_ALIMITER_FILTER 0
++#define CONFIG_ALLPASS_FILTER 0
++#define CONFIG_ALOOP_FILTER 0
++#define CONFIG_AMERGE_FILTER 0
++#define CONFIG_AMETADATA_FILTER 0
++#define CONFIG_AMIX_FILTER 0
++#define CONFIG_AMULTIPLY_FILTER 0
++#define CONFIG_ANEQUALIZER_FILTER 0
++#define CONFIG_ANLMDN_FILTER 0
++#define CONFIG_ANLMF_FILTER 0
++#define CONFIG_ANLMS_FILTER 0
++#define CONFIG_ANULL_FILTER 0
++#define CONFIG_APAD_FILTER 0
++#define CONFIG_APERMS_FILTER 0
++#define CONFIG_APHASER_FILTER 0
++#define CONFIG_APHASESHIFT_FILTER 0
++#define CONFIG_APSNR_FILTER 0
++#define CONFIG_APSYCLIP_FILTER 0
++#define CONFIG_APULSATOR_FILTER 0
++#define CONFIG_AREALTIME_FILTER 0
++#define CONFIG_ARESAMPLE_FILTER 0
++#define CONFIG_AREVERSE_FILTER 0
++#define CONFIG_ARLS_FILTER 0
++#define CONFIG_ARNNDN_FILTER 0
++#define CONFIG_ASDR_FILTER 0
++#define CONFIG_ASEGMENT_FILTER 0
++#define CONFIG_ASELECT_FILTER 0
++#define CONFIG_ASENDCMD_FILTER 0
++#define CONFIG_ASETNSAMPLES_FILTER 0
++#define CONFIG_ASETPTS_FILTER 0
++#define CONFIG_ASETRATE_FILTER 0
++#define CONFIG_ASETTB_FILTER 0
++#define CONFIG_ASHOWINFO_FILTER 0
++#define CONFIG_ASIDEDATA_FILTER 0
++#define CONFIG_ASISDR_FILTER 0
++#define CONFIG_ASOFTCLIP_FILTER 0
++#define CONFIG_ASPECTRALSTATS_FILTER 0
++#define CONFIG_ASPLIT_FILTER 0
++#define CONFIG_ASR_FILTER 0
++#define CONFIG_ASTATS_FILTER 0
++#define CONFIG_ASTREAMSELECT_FILTER 0
++#define CONFIG_ASUBBOOST_FILTER 0
++#define CONFIG_ASUBCUT_FILTER 0
++#define CONFIG_ASUPERCUT_FILTER 0
++#define CONFIG_ASUPERPASS_FILTER 0
++#define CONFIG_ASUPERSTOP_FILTER 0
++#define CONFIG_ATEMPO_FILTER 0
++#define CONFIG_ATILT_FILTER 0
++#define CONFIG_ATRIM_FILTER 0
++#define CONFIG_AXCORRELATE_FILTER 0
++#define CONFIG_AZMQ_FILTER 0
++#define CONFIG_BANDPASS_FILTER 0
++#define CONFIG_BANDREJECT_FILTER 0
++#define CONFIG_BASS_FILTER 0
++#define CONFIG_BIQUAD_FILTER 0
++#define CONFIG_BS2B_FILTER 0
++#define CONFIG_CHANNELMAP_FILTER 0
++#define CONFIG_CHANNELSPLIT_FILTER 0
++#define CONFIG_CHORUS_FILTER 0
++#define CONFIG_COMPAND_FILTER 0
++#define CONFIG_COMPENSATIONDELAY_FILTER 0
++#define CONFIG_CROSSFEED_FILTER 0
++#define CONFIG_CRYSTALIZER_FILTER 0
++#define CONFIG_DCSHIFT_FILTER 0
++#define CONFIG_DEESSER_FILTER 0
++#define CONFIG_DIALOGUENHANCE_FILTER 0
++#define CONFIG_DRMETER_FILTER 0
++#define CONFIG_DYNAUDNORM_FILTER 0
++#define CONFIG_EARWAX_FILTER 0
++#define CONFIG_EBUR128_FILTER 0
++#define CONFIG_EQUALIZER_FILTER 0
++#define CONFIG_EXTRASTEREO_FILTER 0
++#define CONFIG_FIREQUALIZER_FILTER 0
++#define CONFIG_FLANGER_FILTER 0
++#define CONFIG_HAAS_FILTER 0
++#define CONFIG_HDCD_FILTER 0
++#define CONFIG_HEADPHONE_FILTER 0
++#define CONFIG_HIGHPASS_FILTER 0
++#define CONFIG_HIGHSHELF_FILTER 0
++#define CONFIG_JOIN_FILTER 0
++#define CONFIG_LADSPA_FILTER 0
++#define CONFIG_LOUDNORM_FILTER 0
++#define CONFIG_LOWPASS_FILTER 0
++#define CONFIG_LOWSHELF_FILTER 0
++#define CONFIG_LV2_FILTER 0
++#define CONFIG_MCOMPAND_FILTER 0
++#define CONFIG_PAN_FILTER 0
++#define CONFIG_REPLAYGAIN_FILTER 0
++#define CONFIG_RUBBERBAND_FILTER 0
++#define CONFIG_SIDECHAINCOMPRESS_FILTER 0
++#define CONFIG_SIDECHAINGATE_FILTER 0
++#define CONFIG_SILENCEDETECT_FILTER 0
++#define CONFIG_SILENCEREMOVE_FILTER 0
++#define CONFIG_SOFALIZER_FILTER 0
++#define CONFIG_SPEECHNORM_FILTER 0
++#define CONFIG_STEREOTOOLS_FILTER 0
++#define CONFIG_STEREOWIDEN_FILTER 0
++#define CONFIG_SUPEREQUALIZER_FILTER 0
++#define CONFIG_SURROUND_FILTER 0
++#define CONFIG_TILTSHELF_FILTER 0
++#define CONFIG_TREBLE_FILTER 0
++#define CONFIG_TREMOLO_FILTER 0
++#define CONFIG_VIBRATO_FILTER 0
++#define CONFIG_VIRTUALBASS_FILTER 0
++#define CONFIG_VOLUME_FILTER 0
++#define CONFIG_VOLUMEDETECT_FILTER 0
++#define CONFIG_AEVALSRC_FILTER 0
++#define CONFIG_AFDELAYSRC_FILTER 0
++#define CONFIG_AFIREQSRC_FILTER 0
++#define CONFIG_AFIRSRC_FILTER 0
++#define CONFIG_ANOISESRC_FILTER 0
++#define CONFIG_ANULLSRC_FILTER 0
++#define CONFIG_FLITE_FILTER 0
++#define CONFIG_HILBERT_FILTER 0
++#define CONFIG_SINC_FILTER 0
++#define CONFIG_SINE_FILTER 0
++#define CONFIG_ANULLSINK_FILTER 0
++#define CONFIG_ADDROI_FILTER 0
++#define CONFIG_ALPHAEXTRACT_FILTER 0
++#define CONFIG_ALPHAMERGE_FILTER 0
++#define CONFIG_AMPLIFY_FILTER 0
++#define CONFIG_ASS_FILTER 0
++#define CONFIG_ATADENOISE_FILTER 0
++#define CONFIG_AVGBLUR_FILTER 0
++#define CONFIG_AVGBLUR_OPENCL_FILTER 0
++#define CONFIG_AVGBLUR_VULKAN_FILTER 0
++#define CONFIG_BACKGROUNDKEY_FILTER 0
++#define CONFIG_BBOX_FILTER 0
++#define CONFIG_BENCH_FILTER 0
++#define CONFIG_BILATERAL_FILTER 0
++#define CONFIG_BILATERAL_CUDA_FILTER 0
++#define CONFIG_BITPLANENOISE_FILTER 0
++#define CONFIG_BLACKDETECT_FILTER 0
++#define CONFIG_BLACKFRAME_FILTER 0
++#define CONFIG_BLEND_FILTER 0
++#define CONFIG_BLEND_VULKAN_FILTER 0
++#define CONFIG_BLOCKDETECT_FILTER 0
++#define CONFIG_BLURDETECT_FILTER 0
++#define CONFIG_BM3D_FILTER 0
++#define CONFIG_BOXBLUR_FILTER 0
++#define CONFIG_BOXBLUR_OPENCL_FILTER 0
++#define CONFIG_BWDIF_FILTER 0
++#define CONFIG_BWDIF_CUDA_FILTER 0
++#define CONFIG_BWDIF_VULKAN_FILTER 0
++#define CONFIG_CAS_FILTER 0
++#define CONFIG_CCREPACK_FILTER 0
++#define CONFIG_CHROMABER_VULKAN_FILTER 0
++#define CONFIG_CHROMAHOLD_FILTER 0
++#define CONFIG_CHROMAKEY_FILTER 0
++#define CONFIG_CHROMAKEY_CUDA_FILTER 0
++#define CONFIG_CHROMANR_FILTER 0
++#define CONFIG_CHROMASHIFT_FILTER 0
++#define CONFIG_CIESCOPE_FILTER 0
++#define CONFIG_CODECVIEW_FILTER 0
++#define CONFIG_COLORBALANCE_FILTER 0
++#define CONFIG_COLORCHANNELMIXER_FILTER 0
++#define CONFIG_COLORCONTRAST_FILTER 0
++#define CONFIG_COLORCORRECT_FILTER 0
++#define CONFIG_COLORIZE_FILTER 0
++#define CONFIG_COLORKEY_FILTER 0
++#define CONFIG_COLORKEY_OPENCL_FILTER 0
++#define CONFIG_COLORHOLD_FILTER 0
++#define CONFIG_COLORLEVELS_FILTER 0
++#define CONFIG_COLORMAP_FILTER 0
++#define CONFIG_COLORMATRIX_FILTER 0
++#define CONFIG_COLORSPACE_FILTER 0
++#define CONFIG_COLORSPACE_CUDA_FILTER 0
++#define CONFIG_COLORTEMPERATURE_FILTER 0
++#define CONFIG_CONVOLUTION_FILTER 0
++#define CONFIG_CONVOLUTION_OPENCL_FILTER 0
++#define CONFIG_CONVOLVE_FILTER 0
++#define CONFIG_COPY_FILTER 0
++#define CONFIG_COREIMAGE_FILTER 0
++#define CONFIG_CORR_FILTER 0
++#define CONFIG_COVER_RECT_FILTER 0
++#define CONFIG_CROP_FILTER 0
++#define CONFIG_CROPDETECT_FILTER 0
++#define CONFIG_CUE_FILTER 0
++#define CONFIG_CURVES_FILTER 0
++#define CONFIG_DATASCOPE_FILTER 0
++#define CONFIG_DBLUR_FILTER 0
++#define CONFIG_DCTDNOIZ_FILTER 0
++#define CONFIG_DEBAND_FILTER 0
++#define CONFIG_DEBLOCK_FILTER 0
++#define CONFIG_DECIMATE_FILTER 0
++#define CONFIG_DECONVOLVE_FILTER 0
++#define CONFIG_DEDOT_FILTER 0
++#define CONFIG_DEFLATE_FILTER 0
++#define CONFIG_DEFLICKER_FILTER 0
++#define CONFIG_DEINTERLACE_QSV_FILTER 0
++#define CONFIG_DEINTERLACE_VAAPI_FILTER 0
++#define CONFIG_DEJUDDER_FILTER 0
++#define CONFIG_DELOGO_FILTER 0
++#define CONFIG_DENOISE_VAAPI_FILTER 0
++#define CONFIG_DERAIN_FILTER 0
++#define CONFIG_DESHAKE_FILTER 0
++#define CONFIG_DESHAKE_OPENCL_FILTER 0
++#define CONFIG_DESPILL_FILTER 0
++#define CONFIG_DETELECINE_FILTER 0
++#define CONFIG_DILATION_FILTER 0
++#define CONFIG_DILATION_OPENCL_FILTER 0
++#define CONFIG_DISPLACE_FILTER 0
++#define CONFIG_DNN_CLASSIFY_FILTER 0
++#define CONFIG_DNN_DETECT_FILTER 0
++#define CONFIG_DNN_PROCESSING_FILTER 0
++#define CONFIG_DOUBLEWEAVE_FILTER 0
++#define CONFIG_DRAWBOX_FILTER 0
++#define CONFIG_DRAWGRAPH_FILTER 0
++#define CONFIG_DRAWGRID_FILTER 0
++#define CONFIG_DRAWTEXT_FILTER 0
++#define CONFIG_EDGEDETECT_FILTER 0
++#define CONFIG_ELBG_FILTER 0
++#define CONFIG_ENTROPY_FILTER 0
++#define CONFIG_EPX_FILTER 0
++#define CONFIG_EQ_FILTER 0
++#define CONFIG_EROSION_FILTER 0
++#define CONFIG_EROSION_OPENCL_FILTER 0
++#define CONFIG_ESTDIF_FILTER 0
++#define CONFIG_EXPOSURE_FILTER 0
++#define CONFIG_EXTRACTPLANES_FILTER 0
++#define CONFIG_FADE_FILTER 0
++#define CONFIG_FEEDBACK_FILTER 0
++#define CONFIG_FFTDNOIZ_FILTER 0
++#define CONFIG_FFTFILT_FILTER 0
++#define CONFIG_FIELD_FILTER 0
++#define CONFIG_FIELDHINT_FILTER 0
++#define CONFIG_FIELDMATCH_FILTER 0
++#define CONFIG_FIELDORDER_FILTER 0
++#define CONFIG_FILLBORDERS_FILTER 0
++#define CONFIG_FIND_RECT_FILTER 0
++#define CONFIG_FLIP_VULKAN_FILTER 0
++#define CONFIG_FLOODFILL_FILTER 0
++#define CONFIG_FORMAT_FILTER 0
++#define CONFIG_FPS_FILTER 0
++#define CONFIG_FRAMEPACK_FILTER 0
++#define CONFIG_FRAMERATE_FILTER 0
++#define CONFIG_FRAMESTEP_FILTER 0
++#define CONFIG_FREEZEDETECT_FILTER 0
++#define CONFIG_FREEZEFRAMES_FILTER 0
++#define CONFIG_FREI0R_FILTER 0
++#define CONFIG_FSPP_FILTER 0
++#define CONFIG_FSYNC_FILTER 0
++#define CONFIG_GBLUR_FILTER 0
++#define CONFIG_GBLUR_VULKAN_FILTER 0
++#define CONFIG_GEQ_FILTER 0
++#define CONFIG_GRADFUN_FILTER 0
++#define CONFIG_GRAPHMONITOR_FILTER 0
++#define CONFIG_GRAYWORLD_FILTER 0
++#define CONFIG_GREYEDGE_FILTER 0
++#define CONFIG_GUIDED_FILTER 0
++#define CONFIG_HALDCLUT_FILTER 0
++#define CONFIG_HFLIP_FILTER 0
++#define CONFIG_HFLIP_VULKAN_FILTER 0
++#define CONFIG_HISTEQ_FILTER 0
++#define CONFIG_HISTOGRAM_FILTER 0
++#define CONFIG_HQDN3D_FILTER 0
++#define CONFIG_HQX_FILTER 0
++#define CONFIG_HSTACK_FILTER 0
++#define CONFIG_HSVHOLD_FILTER 0
++#define CONFIG_HSVKEY_FILTER 0
++#define CONFIG_HUE_FILTER 0
++#define CONFIG_HUESATURATION_FILTER 0
++#define CONFIG_HWDOWNLOAD_FILTER 0
++#define CONFIG_HWMAP_FILTER 0
++#define CONFIG_HWUPLOAD_FILTER 0
++#define CONFIG_HWUPLOAD_CUDA_FILTER 0
++#define CONFIG_HYSTERESIS_FILTER 0
++#define CONFIG_ICCDETECT_FILTER 0
++#define CONFIG_ICCGEN_FILTER 0
++#define CONFIG_IDENTITY_FILTER 0
++#define CONFIG_IDET_FILTER 0
++#define CONFIG_IL_FILTER 0
++#define CONFIG_INFLATE_FILTER 0
++#define CONFIG_INTERLACE_FILTER 0
++#define CONFIG_INTERLEAVE_FILTER 0
++#define CONFIG_KERNDEINT_FILTER 0
++#define CONFIG_KIRSCH_FILTER 0
++#define CONFIG_LAGFUN_FILTER 0
++#define CONFIG_LATENCY_FILTER 0
++#define CONFIG_LENSCORRECTION_FILTER 0
++#define CONFIG_LENSFUN_FILTER 0
++#define CONFIG_LIBPLACEBO_FILTER 0
++#define CONFIG_LIBVMAF_FILTER 0
++#define CONFIG_LIBVMAF_CUDA_FILTER 0
++#define CONFIG_LIMITDIFF_FILTER 0
++#define CONFIG_LIMITER_FILTER 0
++#define CONFIG_LOOP_FILTER 0
++#define CONFIG_LUMAKEY_FILTER 0
++#define CONFIG_LUT_FILTER 0
++#define CONFIG_LUT1D_FILTER 0
++#define CONFIG_LUT2_FILTER 0
++#define CONFIG_LUT3D_FILTER 0
++#define CONFIG_LUTRGB_FILTER 0
++#define CONFIG_LUTYUV_FILTER 0
++#define CONFIG_MASKEDCLAMP_FILTER 0
++#define CONFIG_MASKEDMAX_FILTER 0
++#define CONFIG_MASKEDMERGE_FILTER 0
++#define CONFIG_MASKEDMIN_FILTER 0
++#define CONFIG_MASKEDTHRESHOLD_FILTER 0
++#define CONFIG_MASKFUN_FILTER 0
++#define CONFIG_MCDEINT_FILTER 0
++#define CONFIG_MEDIAN_FILTER 0
++#define CONFIG_MERGEPLANES_FILTER 0
++#define CONFIG_MESTIMATE_FILTER 0
++#define CONFIG_METADATA_FILTER 0
++#define CONFIG_MIDEQUALIZER_FILTER 0
++#define CONFIG_MINTERPOLATE_FILTER 0
++#define CONFIG_MIX_FILTER 0
++#define CONFIG_MONOCHROME_FILTER 0
++#define CONFIG_MORPHO_FILTER 0
++#define CONFIG_MPDECIMATE_FILTER 0
++#define CONFIG_MSAD_FILTER 0
++#define CONFIG_MULTIPLY_FILTER 0
++#define CONFIG_NEGATE_FILTER 0
++#define CONFIG_NLMEANS_FILTER 0
++#define CONFIG_NLMEANS_OPENCL_FILTER 0
++#define CONFIG_NLMEANS_VULKAN_FILTER 0
++#define CONFIG_NNEDI_FILTER 0
++#define CONFIG_NOFORMAT_FILTER 0
++#define CONFIG_NOISE_FILTER 0
++#define CONFIG_NORMALIZE_FILTER 0
++#define CONFIG_NULL_FILTER 0
++#define CONFIG_OCR_FILTER 0
++#define CONFIG_OCV_FILTER 0
++#define CONFIG_OSCILLOSCOPE_FILTER 0
++#define CONFIG_OVERLAY_FILTER 0
++#define CONFIG_OVERLAY_OPENCL_FILTER 0
++#define CONFIG_OVERLAY_QSV_FILTER 0
++#define CONFIG_OVERLAY_VAAPI_FILTER 0
++#define CONFIG_OVERLAY_VULKAN_FILTER 0
++#define CONFIG_OVERLAY_CUDA_FILTER 0
++#define CONFIG_OWDENOISE_FILTER 0
++#define CONFIG_PAD_FILTER 0
++#define CONFIG_PAD_OPENCL_FILTER 0
++#define CONFIG_PALETTEGEN_FILTER 0
++#define CONFIG_PALETTEUSE_FILTER 0
++#define CONFIG_PERMS_FILTER 0
++#define CONFIG_PERSPECTIVE_FILTER 0
++#define CONFIG_PHASE_FILTER 0
++#define CONFIG_PHOTOSENSITIVITY_FILTER 0
++#define CONFIG_PIXDESCTEST_FILTER 0
++#define CONFIG_PIXELIZE_FILTER 0
++#define CONFIG_PIXSCOPE_FILTER 0
++#define CONFIG_PP_FILTER 0
++#define CONFIG_PP7_FILTER 0
++#define CONFIG_PREMULTIPLY_FILTER 0
++#define CONFIG_PREWITT_FILTER 0
++#define CONFIG_PREWITT_OPENCL_FILTER 0
++#define CONFIG_PROCAMP_VAAPI_FILTER 0
++#define CONFIG_PROGRAM_OPENCL_FILTER 0
++#define CONFIG_PSEUDOCOLOR_FILTER 0
++#define CONFIG_PSNR_FILTER 0
++#define CONFIG_PULLUP_FILTER 0
++#define CONFIG_QP_FILTER 0
++#define CONFIG_QRENCODE_FILTER 0
++#define CONFIG_QUIRC_FILTER 0
++#define CONFIG_RANDOM_FILTER 0
++#define CONFIG_READEIA608_FILTER 0
++#define CONFIG_READVITC_FILTER 0
++#define CONFIG_REALTIME_FILTER 0
++#define CONFIG_REMAP_FILTER 0
++#define CONFIG_REMAP_OPENCL_FILTER 0
++#define CONFIG_REMOVEGRAIN_FILTER 0
++#define CONFIG_REMOVELOGO_FILTER 0
++#define CONFIG_REPEATFIELDS_FILTER 0
++#define CONFIG_REVERSE_FILTER 0
++#define CONFIG_RGBASHIFT_FILTER 0
++#define CONFIG_ROBERTS_FILTER 0
++#define CONFIG_ROBERTS_OPENCL_FILTER 0
++#define CONFIG_ROTATE_FILTER 0
++#define CONFIG_SAB_FILTER 0
++#define CONFIG_SCALE_FILTER 0
++#define CONFIG_SCALE_CUDA_FILTER 0
++#define CONFIG_SCALE_NPP_FILTER 0
++#define CONFIG_SCALE_QSV_FILTER 0
++#define CONFIG_SCALE_VAAPI_FILTER 0
++#define CONFIG_SCALE_VT_FILTER 0
++#define CONFIG_SCALE_VULKAN_FILTER 0
++#define CONFIG_SCALE2REF_FILTER 0
++#define CONFIG_SCALE2REF_NPP_FILTER 0
++#define CONFIG_SCDET_FILTER 0
++#define CONFIG_SCHARR_FILTER 0
++#define CONFIG_SCROLL_FILTER 0
++#define CONFIG_SEGMENT_FILTER 0
++#define CONFIG_SELECT_FILTER 0
++#define CONFIG_SELECTIVECOLOR_FILTER 0
++#define CONFIG_SENDCMD_FILTER 0
++#define CONFIG_SEPARATEFIELDS_FILTER 0
++#define CONFIG_SETDAR_FILTER 0
++#define CONFIG_SETFIELD_FILTER 0
++#define CONFIG_SETPARAMS_FILTER 0
++#define CONFIG_SETPTS_FILTER 0
++#define CONFIG_SETRANGE_FILTER 0
++#define CONFIG_SETSAR_FILTER 0
++#define CONFIG_SETTB_FILTER 0
++#define CONFIG_SHARPEN_NPP_FILTER 0
++#define CONFIG_SHARPNESS_VAAPI_FILTER 0
++#define CONFIG_SHEAR_FILTER 0
++#define CONFIG_SHOWINFO_FILTER 0
++#define CONFIG_SHOWPALETTE_FILTER 0
++#define CONFIG_SHUFFLEFRAMES_FILTER 0
++#define CONFIG_SHUFFLEPIXELS_FILTER 0
++#define CONFIG_SHUFFLEPLANES_FILTER 0
++#define CONFIG_SIDEDATA_FILTER 0
++#define CONFIG_SIGNALSTATS_FILTER 0
++#define CONFIG_SIGNATURE_FILTER 0
++#define CONFIG_SITI_FILTER 0
++#define CONFIG_SMARTBLUR_FILTER 0
++#define CONFIG_SOBEL_FILTER 0
++#define CONFIG_SOBEL_OPENCL_FILTER 0
++#define CONFIG_SPLIT_FILTER 0
++#define CONFIG_SPP_FILTER 0
++#define CONFIG_SR_FILTER 0
++#define CONFIG_SSIM_FILTER 0
++#define CONFIG_SSIM360_FILTER 0
++#define CONFIG_STEREO3D_FILTER 0
++#define CONFIG_STREAMSELECT_FILTER 0
++#define CONFIG_SUBTITLES_FILTER 0
++#define CONFIG_SUPER2XSAI_FILTER 0
++#define CONFIG_SWAPRECT_FILTER 0
++#define CONFIG_SWAPUV_FILTER 0
++#define CONFIG_TBLEND_FILTER 0
++#define CONFIG_TELECINE_FILTER 0
++#define CONFIG_THISTOGRAM_FILTER 0
++#define CONFIG_THRESHOLD_FILTER 0
++#define CONFIG_THUMBNAIL_FILTER 0
++#define CONFIG_THUMBNAIL_CUDA_FILTER 0
++#define CONFIG_TILE_FILTER 0
++#define CONFIG_TILTANDSHIFT_FILTER 0
++#define CONFIG_TINTERLACE_FILTER 0
++#define CONFIG_TLUT2_FILTER 0
++#define CONFIG_TMEDIAN_FILTER 0
++#define CONFIG_TMIDEQUALIZER_FILTER 0
++#define CONFIG_TMIX_FILTER 0
++#define CONFIG_TONEMAP_FILTER 0
++#define CONFIG_TONEMAP_OPENCL_FILTER 0
++#define CONFIG_TONEMAP_VAAPI_FILTER 0
++#define CONFIG_TPAD_FILTER 0
++#define CONFIG_TRANSPOSE_FILTER 0
++#define CONFIG_TRANSPOSE_NPP_FILTER 0
++#define CONFIG_TRANSPOSE_OPENCL_FILTER 0
++#define CONFIG_TRANSPOSE_VAAPI_FILTER 0
++#define CONFIG_TRANSPOSE_VT_FILTER 0
++#define CONFIG_TRANSPOSE_VULKAN_FILTER 0
++#define CONFIG_TRIM_FILTER 0
++#define CONFIG_UNPREMULTIPLY_FILTER 0
++#define CONFIG_UNSHARP_FILTER 0
++#define CONFIG_UNSHARP_OPENCL_FILTER 0
++#define CONFIG_UNTILE_FILTER 0
++#define CONFIG_USPP_FILTER 0
++#define CONFIG_V360_FILTER 0
++#define CONFIG_VAGUEDENOISER_FILTER 0
++#define CONFIG_VARBLUR_FILTER 0
++#define CONFIG_VECTORSCOPE_FILTER 0
++#define CONFIG_VFLIP_FILTER 0
++#define CONFIG_VFLIP_VULKAN_FILTER 0
++#define CONFIG_VFRDET_FILTER 0
++#define CONFIG_VIBRANCE_FILTER 0
++#define CONFIG_VIDSTABDETECT_FILTER 0
++#define CONFIG_VIDSTABTRANSFORM_FILTER 0
++#define CONFIG_VIF_FILTER 0
++#define CONFIG_VIGNETTE_FILTER 0
++#define CONFIG_VMAFMOTION_FILTER 0
++#define CONFIG_VPP_QSV_FILTER 0
++#define CONFIG_VSTACK_FILTER 0
++#define CONFIG_W3FDIF_FILTER 0
++#define CONFIG_WAVEFORM_FILTER 0
++#define CONFIG_WEAVE_FILTER 0
++#define CONFIG_XBR_FILTER 0
++#define CONFIG_XCORRELATE_FILTER 0
++#define CONFIG_XFADE_FILTER 0
++#define CONFIG_XFADE_OPENCL_FILTER 0
++#define CONFIG_XFADE_VULKAN_FILTER 0
++#define CONFIG_XMEDIAN_FILTER 0
++#define CONFIG_XSTACK_FILTER 0
++#define CONFIG_YADIF_FILTER 0
++#define CONFIG_YADIF_CUDA_FILTER 0
++#define CONFIG_YADIF_VIDEOTOOLBOX_FILTER 0
++#define CONFIG_YAEPBLUR_FILTER 0
++#define CONFIG_ZMQ_FILTER 0
++#define CONFIG_ZOOMPAN_FILTER 0
++#define CONFIG_ZSCALE_FILTER 0
++#define CONFIG_HSTACK_VAAPI_FILTER 0
++#define CONFIG_VSTACK_VAAPI_FILTER 0
++#define CONFIG_XSTACK_VAAPI_FILTER 0
++#define CONFIG_HSTACK_QSV_FILTER 0
++#define CONFIG_VSTACK_QSV_FILTER 0
++#define CONFIG_XSTACK_QSV_FILTER 0
++#define CONFIG_ALLRGB_FILTER 0
++#define CONFIG_ALLYUV_FILTER 0
++#define CONFIG_CELLAUTO_FILTER 0
++#define CONFIG_COLOR_FILTER 0
++#define CONFIG_COLOR_VULKAN_FILTER 0
++#define CONFIG_COLORCHART_FILTER 0
++#define CONFIG_COLORSPECTRUM_FILTER 0
++#define CONFIG_COREIMAGESRC_FILTER 0
++#define CONFIG_DDAGRAB_FILTER 0
++#define CONFIG_FREI0R_SRC_FILTER 0
++#define CONFIG_GRADIENTS_FILTER 0
++#define CONFIG_HALDCLUTSRC_FILTER 0
++#define CONFIG_LIFE_FILTER 0
++#define CONFIG_MANDELBROT_FILTER 0
++#define CONFIG_MPTESTSRC_FILTER 0
++#define CONFIG_NULLSRC_FILTER 0
++#define CONFIG_OPENCLSRC_FILTER 0
++#define CONFIG_QRENCODESRC_FILTER 0
++#define CONFIG_PAL75BARS_FILTER 0
++#define CONFIG_PAL100BARS_FILTER 0
++#define CONFIG_RGBTESTSRC_FILTER 0
++#define CONFIG_SIERPINSKI_FILTER 0
++#define CONFIG_SMPTEBARS_FILTER 0
++#define CONFIG_SMPTEHDBARS_FILTER 0
++#define CONFIG_TESTSRC_FILTER 0
++#define CONFIG_TESTSRC2_FILTER 0
++#define CONFIG_YUVTESTSRC_FILTER 0
++#define CONFIG_ZONEPLATE_FILTER 0
++#define CONFIG_NULLSINK_FILTER 0
++#define CONFIG_A3DSCOPE_FILTER 0
++#define CONFIG_ABITSCOPE_FILTER 0
++#define CONFIG_ADRAWGRAPH_FILTER 0
++#define CONFIG_AGRAPHMONITOR_FILTER 0
++#define CONFIG_AHISTOGRAM_FILTER 0
++#define CONFIG_APHASEMETER_FILTER 0
++#define CONFIG_AVECTORSCOPE_FILTER 0
++#define CONFIG_CONCAT_FILTER 0
++#define CONFIG_SHOWCQT_FILTER 0
++#define CONFIG_SHOWCWT_FILTER 0
++#define CONFIG_SHOWFREQS_FILTER 0
++#define CONFIG_SHOWSPATIAL_FILTER 0
++#define CONFIG_SHOWSPECTRUM_FILTER 0
++#define CONFIG_SHOWSPECTRUMPIC_FILTER 0
++#define CONFIG_SHOWVOLUME_FILTER 0
++#define CONFIG_SHOWWAVES_FILTER 0
++#define CONFIG_SHOWWAVESPIC_FILTER 0
++#define CONFIG_SPECTRUMSYNTH_FILTER 0
++#define CONFIG_AVSYNCTEST_FILTER 0
++#define CONFIG_AMOVIE_FILTER 0
++#define CONFIG_MOVIE_FILTER 0
++#define CONFIG_AA_DEMUXER 0
++#define CONFIG_AAC_DEMUXER 0
++#define CONFIG_AAX_DEMUXER 0
++#define CONFIG_AC3_DEMUXER 0
++#define CONFIG_AC4_DEMUXER 0
++#define CONFIG_ACE_DEMUXER 0
++#define CONFIG_ACM_DEMUXER 0
++#define CONFIG_ACT_DEMUXER 0
++#define CONFIG_ADF_DEMUXER 0
++#define CONFIG_ADP_DEMUXER 0
++#define CONFIG_ADS_DEMUXER 0
++#define CONFIG_ADX_DEMUXER 0
++#define CONFIG_AEA_DEMUXER 0
++#define CONFIG_AFC_DEMUXER 0
++#define CONFIG_AIFF_DEMUXER 0
++#define CONFIG_AIX_DEMUXER 0
++#define CONFIG_ALP_DEMUXER 0
++#define CONFIG_AMR_DEMUXER 0
++#define CONFIG_AMRNB_DEMUXER 0
++#define CONFIG_AMRWB_DEMUXER 0
++#define CONFIG_ANM_DEMUXER 0
++#define CONFIG_APAC_DEMUXER 0
++#define CONFIG_APC_DEMUXER 0
++#define CONFIG_APE_DEMUXER 0
++#define CONFIG_APM_DEMUXER 0
++#define CONFIG_APNG_DEMUXER 0
++#define CONFIG_APTX_DEMUXER 0
++#define CONFIG_APTX_HD_DEMUXER 0
++#define CONFIG_AQTITLE_DEMUXER 0
++#define CONFIG_ARGO_ASF_DEMUXER 0
++#define CONFIG_ARGO_BRP_DEMUXER 0
++#define CONFIG_ARGO_CVG_DEMUXER 0
++#define CONFIG_ASF_DEMUXER 0
++#define CONFIG_ASF_O_DEMUXER 0
++#define CONFIG_ASS_DEMUXER 0
++#define CONFIG_AST_DEMUXER 0
++#define CONFIG_AU_DEMUXER 0
++#define CONFIG_AV1_DEMUXER 0
++#define CONFIG_AVI_DEMUXER 0
++#define CONFIG_AVISYNTH_DEMUXER 0
++#define CONFIG_AVR_DEMUXER 0
++#define CONFIG_AVS_DEMUXER 0
++#define CONFIG_AVS2_DEMUXER 0
++#define CONFIG_AVS3_DEMUXER 0
++#define CONFIG_BETHSOFTVID_DEMUXER 0
++#define CONFIG_BFI_DEMUXER 0
++#define CONFIG_BINTEXT_DEMUXER 0
++#define CONFIG_BINK_DEMUXER 0
++#define CONFIG_BINKA_DEMUXER 0
++#define CONFIG_BIT_DEMUXER 0
++#define CONFIG_BITPACKED_DEMUXER 0
++#define CONFIG_BMV_DEMUXER 0
++#define CONFIG_BFSTM_DEMUXER 0
++#define CONFIG_BRSTM_DEMUXER 0
++#define CONFIG_BOA_DEMUXER 0
++#define CONFIG_BONK_DEMUXER 0
++#define CONFIG_C93_DEMUXER 0
++#define CONFIG_CAF_DEMUXER 0
++#define CONFIG_CAVSVIDEO_DEMUXER 0
++#define CONFIG_CDG_DEMUXER 0
++#define CONFIG_CDXL_DEMUXER 0
++#define CONFIG_CINE_DEMUXER 0
++#define CONFIG_CODEC2_DEMUXER 0
++#define CONFIG_CODEC2RAW_DEMUXER 0
++#define CONFIG_CONCAT_DEMUXER 0
++#define CONFIG_DASH_DEMUXER 0
++#define CONFIG_DATA_DEMUXER 0
++#define CONFIG_DAUD_DEMUXER 0
++#define CONFIG_DCSTR_DEMUXER 0
++#define CONFIG_DERF_DEMUXER 0
++#define CONFIG_DFA_DEMUXER 0
++#define CONFIG_DFPWM_DEMUXER 0
++#define CONFIG_DHAV_DEMUXER 0
++#define CONFIG_DIRAC_DEMUXER 0
++#define CONFIG_DNXHD_DEMUXER 0
++#define CONFIG_DSF_DEMUXER 0
++#define CONFIG_DSICIN_DEMUXER 0
++#define CONFIG_DSS_DEMUXER 0
++#define CONFIG_DTS_DEMUXER 0
++#define CONFIG_DTSHD_DEMUXER 0
++#define CONFIG_DV_DEMUXER 0
++#define CONFIG_DVBSUB_DEMUXER 0
++#define CONFIG_DVBTXT_DEMUXER 0
++#define CONFIG_DXA_DEMUXER 0
++#define CONFIG_EA_DEMUXER 0
++#define CONFIG_EA_CDATA_DEMUXER 0
++#define CONFIG_EAC3_DEMUXER 0
++#define CONFIG_EPAF_DEMUXER 0
++#define CONFIG_EVC_DEMUXER 0
++#define CONFIG_FFMETADATA_DEMUXER 0
++#define CONFIG_FILMSTRIP_DEMUXER 0
++#define CONFIG_FITS_DEMUXER 0
++#define CONFIG_FLAC_DEMUXER 1
++#define CONFIG_FLIC_DEMUXER 0
++#define CONFIG_FLV_DEMUXER 0
++#define CONFIG_LIVE_FLV_DEMUXER 0
++#define CONFIG_FOURXM_DEMUXER 0
++#define CONFIG_FRM_DEMUXER 0
++#define CONFIG_FSB_DEMUXER 0
++#define CONFIG_FWSE_DEMUXER 0
++#define CONFIG_G722_DEMUXER 0
++#define CONFIG_G723_1_DEMUXER 0
++#define CONFIG_G726_DEMUXER 0
++#define CONFIG_G726LE_DEMUXER 0
++#define CONFIG_G729_DEMUXER 0
++#define CONFIG_GDV_DEMUXER 0
++#define CONFIG_GENH_DEMUXER 0
++#define CONFIG_GIF_DEMUXER 0
++#define CONFIG_GSM_DEMUXER 0
++#define CONFIG_GXF_DEMUXER 0
++#define CONFIG_H261_DEMUXER 0
++#define CONFIG_H263_DEMUXER 0
++#define CONFIG_H264_DEMUXER 0
++#define CONFIG_HCA_DEMUXER 0
++#define CONFIG_HCOM_DEMUXER 0
++#define CONFIG_HEVC_DEMUXER 0
++#define CONFIG_HLS_DEMUXER 0
++#define CONFIG_HNM_DEMUXER 0
++#define CONFIG_IAMF_DEMUXER 0
++#define CONFIG_ICO_DEMUXER 0
++#define CONFIG_IDCIN_DEMUXER 0
++#define CONFIG_IDF_DEMUXER 0
++#define CONFIG_IFF_DEMUXER 0
++#define CONFIG_IFV_DEMUXER 0
++#define CONFIG_ILBC_DEMUXER 0
++#define CONFIG_IMAGE2_DEMUXER 0
++#define CONFIG_IMAGE2PIPE_DEMUXER 0
++#define CONFIG_IMAGE2_ALIAS_PIX_DEMUXER 0
++#define CONFIG_IMAGE2_BRENDER_PIX_DEMUXER 0
++#define CONFIG_IMF_DEMUXER 0
++#define CONFIG_INGENIENT_DEMUXER 0
++#define CONFIG_IPMOVIE_DEMUXER 0
++#define CONFIG_IPU_DEMUXER 0
++#define CONFIG_IRCAM_DEMUXER 0
++#define CONFIG_ISS_DEMUXER 0
++#define CONFIG_IV8_DEMUXER 0
++#define CONFIG_IVF_DEMUXER 0
++#define CONFIG_IVR_DEMUXER 0
++#define CONFIG_JACOSUB_DEMUXER 0
++#define CONFIG_JV_DEMUXER 0
++#define CONFIG_JPEGXL_ANIM_DEMUXER 0
++#define CONFIG_KUX_DEMUXER 0
++#define CONFIG_KVAG_DEMUXER 0
++#define CONFIG_LAF_DEMUXER 0
++#define CONFIG_LMLM4_DEMUXER 0
++#define CONFIG_LOAS_DEMUXER 0
++#define CONFIG_LUODAT_DEMUXER 0
++#define CONFIG_LRC_DEMUXER 0
++#define CONFIG_LVF_DEMUXER 0
++#define CONFIG_LXF_DEMUXER 0
++#define CONFIG_M4V_DEMUXER 0
++#define CONFIG_MCA_DEMUXER 0
++#define CONFIG_MCC_DEMUXER 0
++#define CONFIG_MATROSKA_DEMUXER 1
++#define CONFIG_MGSTS_DEMUXER 0
++#define CONFIG_MICRODVD_DEMUXER 0
++#define CONFIG_MJPEG_DEMUXER 0
++#define CONFIG_MJPEG_2000_DEMUXER 0
++#define CONFIG_MLP_DEMUXER 0
++#define CONFIG_MLV_DEMUXER 0
++#define CONFIG_MM_DEMUXER 0
++#define CONFIG_MMF_DEMUXER 0
++#define CONFIG_MODS_DEMUXER 0
++#define CONFIG_MOFLEX_DEMUXER 0
++#define CONFIG_MOV_DEMUXER 1
++#define CONFIG_MP3_DEMUXER 1
++#define CONFIG_MPC_DEMUXER 0
++#define CONFIG_MPC8_DEMUXER 0
++#define CONFIG_MPEGPS_DEMUXER 0
++#define CONFIG_MPEGTS_DEMUXER 0
++#define CONFIG_MPEGTSRAW_DEMUXER 0
++#define CONFIG_MPEGVIDEO_DEMUXER 0
++#define CONFIG_MPJPEG_DEMUXER 0
++#define CONFIG_MPL2_DEMUXER 0
++#define CONFIG_MPSUB_DEMUXER 0
++#define CONFIG_MSF_DEMUXER 0
++#define CONFIG_MSNWC_TCP_DEMUXER 0
++#define CONFIG_MSP_DEMUXER 0
++#define CONFIG_MTAF_DEMUXER 0
++#define CONFIG_MTV_DEMUXER 0
++#define CONFIG_MUSX_DEMUXER 0
++#define CONFIG_MV_DEMUXER 0
++#define CONFIG_MVI_DEMUXER 0
++#define CONFIG_MXF_DEMUXER 0
++#define CONFIG_MXG_DEMUXER 0
++#define CONFIG_NC_DEMUXER 0
++#define CONFIG_NISTSPHERE_DEMUXER 0
++#define CONFIG_NSP_DEMUXER 0
++#define CONFIG_NSV_DEMUXER 0
++#define CONFIG_NUT_DEMUXER 0
++#define CONFIG_NUV_DEMUXER 0
++#define CONFIG_OBU_DEMUXER 0
++#define CONFIG_OGG_DEMUXER 1
++#define CONFIG_OMA_DEMUXER 0
++#define CONFIG_OSQ_DEMUXER 0
++#define CONFIG_PAF_DEMUXER 0
++#define CONFIG_PCM_ALAW_DEMUXER 0
++#define CONFIG_PCM_MULAW_DEMUXER 0
++#define CONFIG_PCM_VIDC_DEMUXER 0
++#define CONFIG_PCM_F64BE_DEMUXER 0
++#define CONFIG_PCM_F64LE_DEMUXER 0
++#define CONFIG_PCM_F32BE_DEMUXER 0
++#define CONFIG_PCM_F32LE_DEMUXER 0
++#define CONFIG_PCM_S32BE_DEMUXER 0
++#define CONFIG_PCM_S32LE_DEMUXER 0
++#define CONFIG_PCM_S24BE_DEMUXER 0
++#define CONFIG_PCM_S24LE_DEMUXER 0
++#define CONFIG_PCM_S16BE_DEMUXER 0
++#define CONFIG_PCM_S16LE_DEMUXER 0
++#define CONFIG_PCM_S8_DEMUXER 0
++#define CONFIG_PCM_U32BE_DEMUXER 0
++#define CONFIG_PCM_U32LE_DEMUXER 0
++#define CONFIG_PCM_U24BE_DEMUXER 0
++#define CONFIG_PCM_U24LE_DEMUXER 0
++#define CONFIG_PCM_U16BE_DEMUXER 0
++#define CONFIG_PCM_U16LE_DEMUXER 0
++#define CONFIG_PCM_U8_DEMUXER 0
++#define CONFIG_PDV_DEMUXER 0
++#define CONFIG_PJS_DEMUXER 0
++#define CONFIG_PMP_DEMUXER 0
++#define CONFIG_PP_BNK_DEMUXER 0
++#define CONFIG_PVA_DEMUXER 0
++#define CONFIG_PVF_DEMUXER 0
++#define CONFIG_QCP_DEMUXER 0
++#define CONFIG_QOA_DEMUXER 0
++#define CONFIG_R3D_DEMUXER 0
++#define CONFIG_RAWVIDEO_DEMUXER 0
++#define CONFIG_REALTEXT_DEMUXER 0
++#define CONFIG_REDSPARK_DEMUXER 0
++#define CONFIG_RKA_DEMUXER 0
++#define CONFIG_RL2_DEMUXER 0
++#define CONFIG_RM_DEMUXER 0
++#define CONFIG_ROQ_DEMUXER 0
++#define CONFIG_RPL_DEMUXER 0
++#define CONFIG_RSD_DEMUXER 0
++#define CONFIG_RSO_DEMUXER 0
++#define CONFIG_RTP_DEMUXER 0
++#define CONFIG_RTSP_DEMUXER 0
++#define CONFIG_S337M_DEMUXER 0
++#define CONFIG_SAMI_DEMUXER 0
++#define CONFIG_SAP_DEMUXER 0
++#define CONFIG_SBC_DEMUXER 0
++#define CONFIG_SBG_DEMUXER 0
++#define CONFIG_SCC_DEMUXER 0
++#define CONFIG_SCD_DEMUXER 0
++#define CONFIG_SDNS_DEMUXER 0
++#define CONFIG_SDP_DEMUXER 0
++#define CONFIG_SDR2_DEMUXER 0
++#define CONFIG_SDS_DEMUXER 0
++#define CONFIG_SDX_DEMUXER 0
++#define CONFIG_SEGAFILM_DEMUXER 0
++#define CONFIG_SER_DEMUXER 0
++#define CONFIG_SGA_DEMUXER 0
++#define CONFIG_SHORTEN_DEMUXER 0
++#define CONFIG_SIFF_DEMUXER 0
++#define CONFIG_SIMBIOSIS_IMX_DEMUXER 0
++#define CONFIG_SLN_DEMUXER 0
++#define CONFIG_SMACKER_DEMUXER 0
++#define CONFIG_SMJPEG_DEMUXER 0
++#define CONFIG_SMUSH_DEMUXER 0
++#define CONFIG_SOL_DEMUXER 0
++#define CONFIG_SOX_DEMUXER 0
++#define CONFIG_SPDIF_DEMUXER 0
++#define CONFIG_SRT_DEMUXER 0
++#define CONFIG_STR_DEMUXER 0
++#define CONFIG_STL_DEMUXER 0
++#define CONFIG_SUBVIEWER1_DEMUXER 0
++#define CONFIG_SUBVIEWER_DEMUXER 0
++#define CONFIG_SUP_DEMUXER 0
++#define CONFIG_SVAG_DEMUXER 0
++#define CONFIG_SVS_DEMUXER 0
++#define CONFIG_SWF_DEMUXER 0
++#define CONFIG_TAK_DEMUXER 0
++#define CONFIG_TEDCAPTIONS_DEMUXER 0
++#define CONFIG_THP_DEMUXER 0
++#define CONFIG_THREEDOSTR_DEMUXER 0
++#define CONFIG_TIERTEXSEQ_DEMUXER 0
++#define CONFIG_TMV_DEMUXER 0
++#define CONFIG_TRUEHD_DEMUXER 0
++#define CONFIG_TTA_DEMUXER 0
++#define CONFIG_TXD_DEMUXER 0
++#define CONFIG_TTY_DEMUXER 0
++#define CONFIG_TY_DEMUXER 0
++#define CONFIG_USM_DEMUXER 0
++#define CONFIG_V210_DEMUXER 0
++#define CONFIG_V210X_DEMUXER 0
++#define CONFIG_VAG_DEMUXER 0
++#define CONFIG_VC1_DEMUXER 0
++#define CONFIG_VC1T_DEMUXER 0
++#define CONFIG_VIVIDAS_DEMUXER 0
++#define CONFIG_VIVO_DEMUXER 0
++#define CONFIG_VMD_DEMUXER 0
++#define CONFIG_VOBSUB_DEMUXER 0
++#define CONFIG_VOC_DEMUXER 0
++#define CONFIG_VPK_DEMUXER 0
++#define CONFIG_VPLAYER_DEMUXER 0
++#define CONFIG_VQF_DEMUXER 0
++#define CONFIG_VVC_DEMUXER 0
++#define CONFIG_W64_DEMUXER 0
++#define CONFIG_WADY_DEMUXER 0
++#define CONFIG_WAVARC_DEMUXER 0
++#define CONFIG_WAV_DEMUXER 1
++#define CONFIG_WC3_DEMUXER 0
++#define CONFIG_WEBM_DASH_MANIFEST_DEMUXER 0
++#define CONFIG_WEBVTT_DEMUXER 0
++#define CONFIG_WSAUD_DEMUXER 0
++#define CONFIG_WSD_DEMUXER 0
++#define CONFIG_WSVQA_DEMUXER 0
++#define CONFIG_WTV_DEMUXER 0
++#define CONFIG_WVE_DEMUXER 0
++#define CONFIG_WV_DEMUXER 0
++#define CONFIG_XA_DEMUXER 0
++#define CONFIG_XBIN_DEMUXER 0
++#define CONFIG_XMD_DEMUXER 0
++#define CONFIG_XMV_DEMUXER 0
++#define CONFIG_XVAG_DEMUXER 0
++#define CONFIG_XWMA_DEMUXER 0
++#define CONFIG_YOP_DEMUXER 0
++#define CONFIG_YUV4MPEGPIPE_DEMUXER 0
++#define CONFIG_IMAGE_BMP_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_CRI_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_DDS_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_DPX_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_EXR_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_GEM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_GIF_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_HDR_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_J2K_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_JPEG_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_JPEGLS_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_JPEGXL_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PAM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PBM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PCX_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PFM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PGMYUV_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PGM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PGX_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PHM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PHOTOCD_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PICTOR_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PNG_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PPM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_PSD_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_QDRAW_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_QOI_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_SGI_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_SVG_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_SUNRAST_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_TIFF_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_VBN_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_WEBP_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_XBM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_XPM_PIPE_DEMUXER 0
++#define CONFIG_IMAGE_XWD_PIPE_DEMUXER 0
++#define CONFIG_LIBGME_DEMUXER 0
++#define CONFIG_LIBMODPLUG_DEMUXER 0
++#define CONFIG_LIBOPENMPT_DEMUXER 0
++#define CONFIG_VAPOURSYNTH_DEMUXER 0
++#define CONFIG_A64_MUXER 0
++#define CONFIG_AC3_MUXER 0
++#define CONFIG_AC4_MUXER 0
++#define CONFIG_ADTS_MUXER 0
++#define CONFIG_ADX_MUXER 0
++#define CONFIG_AIFF_MUXER 0
++#define CONFIG_ALP_MUXER 0
++#define CONFIG_AMR_MUXER 0
++#define CONFIG_AMV_MUXER 0
++#define CONFIG_APM_MUXER 0
++#define CONFIG_APNG_MUXER 0
++#define CONFIG_APTX_MUXER 0
++#define CONFIG_APTX_HD_MUXER 0
++#define CONFIG_ARGO_ASF_MUXER 0
++#define CONFIG_ARGO_CVG_MUXER 0
++#define CONFIG_ASF_MUXER 0
++#define CONFIG_ASS_MUXER 0
++#define CONFIG_AST_MUXER 0
++#define CONFIG_ASF_STREAM_MUXER 0
++#define CONFIG_AU_MUXER 0
++#define CONFIG_AVI_MUXER 0
++#define CONFIG_AVIF_MUXER 0
++#define CONFIG_AVM2_MUXER 0
++#define CONFIG_AVS2_MUXER 0
++#define CONFIG_AVS3_MUXER 0
++#define CONFIG_BIT_MUXER 0
++#define CONFIG_CAF_MUXER 0
++#define CONFIG_CAVSVIDEO_MUXER 0
++#define CONFIG_CODEC2_MUXER 0
++#define CONFIG_CODEC2RAW_MUXER 0
++#define CONFIG_CRC_MUXER 0
++#define CONFIG_DASH_MUXER 0
++#define CONFIG_DATA_MUXER 0
++#define CONFIG_DAUD_MUXER 0
++#define CONFIG_DFPWM_MUXER 0
++#define CONFIG_DIRAC_MUXER 0
++#define CONFIG_DNXHD_MUXER 0
++#define CONFIG_DTS_MUXER 0
++#define CONFIG_DV_MUXER 0
++#define CONFIG_EAC3_MUXER 0
++#define CONFIG_EVC_MUXER 0
++#define CONFIG_F4V_MUXER 0
++#define CONFIG_FFMETADATA_MUXER 0
++#define CONFIG_FIFO_MUXER 0
++#define CONFIG_FIFO_TEST_MUXER 0
++#define CONFIG_FILMSTRIP_MUXER 0
++#define CONFIG_FITS_MUXER 0
++#define CONFIG_FLAC_MUXER 0
++#define CONFIG_FLV_MUXER 0
++#define CONFIG_FRAMECRC_MUXER 0
++#define CONFIG_FRAMEHASH_MUXER 0
++#define CONFIG_FRAMEMD5_MUXER 0
++#define CONFIG_G722_MUXER 0
++#define CONFIG_G723_1_MUXER 0
++#define CONFIG_G726_MUXER 0
++#define CONFIG_G726LE_MUXER 0
++#define CONFIG_GIF_MUXER 0
++#define CONFIG_GSM_MUXER 0
++#define CONFIG_GXF_MUXER 0
++#define CONFIG_H261_MUXER 0
++#define CONFIG_H263_MUXER 0
++#define CONFIG_H264_MUXER 0
++#define CONFIG_HASH_MUXER 0
++#define CONFIG_HDS_MUXER 0
++#define CONFIG_HEVC_MUXER 0
++#define CONFIG_HLS_MUXER 0
++#define CONFIG_IAMF_MUXER 0
++#define CONFIG_ICO_MUXER 0
++#define CONFIG_ILBC_MUXER 0
++#define CONFIG_IMAGE2_MUXER 0
++#define CONFIG_IMAGE2PIPE_MUXER 0
++#define CONFIG_IPOD_MUXER 0
++#define CONFIG_IRCAM_MUXER 0
++#define CONFIG_ISMV_MUXER 0
++#define CONFIG_IVF_MUXER 0
++#define CONFIG_JACOSUB_MUXER 0
++#define CONFIG_KVAG_MUXER 0
++#define CONFIG_LATM_MUXER 0
++#define CONFIG_LRC_MUXER 0
++#define CONFIG_M4V_MUXER 0
++#define CONFIG_MD5_MUXER 0
++#define CONFIG_MATROSKA_MUXER 0
++#define CONFIG_MATROSKA_AUDIO_MUXER 0
++#define CONFIG_MICRODVD_MUXER 0
++#define CONFIG_MJPEG_MUXER 0
++#define CONFIG_MLP_MUXER 0
++#define CONFIG_MMF_MUXER 0
++#define CONFIG_MOV_MUXER 0
++#define CONFIG_MP2_MUXER 0
++#define CONFIG_MP3_MUXER 0
++#define CONFIG_MP4_MUXER 0
++#define CONFIG_MPEG1SYSTEM_MUXER 0
++#define CONFIG_MPEG1VCD_MUXER 0
++#define CONFIG_MPEG1VIDEO_MUXER 0
++#define CONFIG_MPEG2DVD_MUXER 0
++#define CONFIG_MPEG2SVCD_MUXER 0
++#define CONFIG_MPEG2VIDEO_MUXER 0
++#define CONFIG_MPEG2VOB_MUXER 0
++#define CONFIG_MPEGTS_MUXER 0
++#define CONFIG_MPJPEG_MUXER 0
++#define CONFIG_MXF_MUXER 0
++#define CONFIG_MXF_D10_MUXER 0
++#define CONFIG_MXF_OPATOM_MUXER 0
++#define CONFIG_NULL_MUXER 0
++#define CONFIG_NUT_MUXER 0
++#define CONFIG_OBU_MUXER 0
++#define CONFIG_OGA_MUXER 0
++#define CONFIG_OGG_MUXER 0
++#define CONFIG_OGV_MUXER 0
++#define CONFIG_OMA_MUXER 0
++#define CONFIG_OPUS_MUXER 0
++#define CONFIG_PCM_ALAW_MUXER 0
++#define CONFIG_PCM_MULAW_MUXER 0
++#define CONFIG_PCM_VIDC_MUXER 0
++#define CONFIG_PCM_F64BE_MUXER 0
++#define CONFIG_PCM_F64LE_MUXER 0
++#define CONFIG_PCM_F32BE_MUXER 0
++#define CONFIG_PCM_F32LE_MUXER 0
++#define CONFIG_PCM_S32BE_MUXER 0
++#define CONFIG_PCM_S32LE_MUXER 0
++#define CONFIG_PCM_S24BE_MUXER 0
++#define CONFIG_PCM_S24LE_MUXER 0
++#define CONFIG_PCM_S16BE_MUXER 0
++#define CONFIG_PCM_S16LE_MUXER 0
++#define CONFIG_PCM_S8_MUXER 0
++#define CONFIG_PCM_U32BE_MUXER 0
++#define CONFIG_PCM_U32LE_MUXER 0
++#define CONFIG_PCM_U24BE_MUXER 0
++#define CONFIG_PCM_U24LE_MUXER 0
++#define CONFIG_PCM_U16BE_MUXER 0
++#define CONFIG_PCM_U16LE_MUXER 0
++#define CONFIG_PCM_U8_MUXER 0
++#define CONFIG_PSP_MUXER 0
++#define CONFIG_RAWVIDEO_MUXER 0
++#define CONFIG_RCWT_MUXER 0
++#define CONFIG_RM_MUXER 0
++#define CONFIG_ROQ_MUXER 0
++#define CONFIG_RSO_MUXER 0
++#define CONFIG_RTP_MUXER 0
++#define CONFIG_RTP_MPEGTS_MUXER 0
++#define CONFIG_RTSP_MUXER 0
++#define CONFIG_SAP_MUXER 0
++#define CONFIG_SBC_MUXER 0
++#define CONFIG_SCC_MUXER 0
++#define CONFIG_SEGAFILM_MUXER 0
++#define CONFIG_SEGMENT_MUXER 0
++#define CONFIG_STREAM_SEGMENT_MUXER 0
++#define CONFIG_SMJPEG_MUXER 0
++#define CONFIG_SMOOTHSTREAMING_MUXER 0
++#define CONFIG_SOX_MUXER 0
++#define CONFIG_SPX_MUXER 0
++#define CONFIG_SPDIF_MUXER 0
++#define CONFIG_SRT_MUXER 0
++#define CONFIG_STREAMHASH_MUXER 0
++#define CONFIG_SUP_MUXER 0
++#define CONFIG_SWF_MUXER 0
++#define CONFIG_TEE_MUXER 0
++#define CONFIG_TG2_MUXER 0
++#define CONFIG_TGP_MUXER 0
++#define CONFIG_MKVTIMESTAMP_V2_MUXER 0
++#define CONFIG_TRUEHD_MUXER 0
++#define CONFIG_TTA_MUXER 0
++#define CONFIG_TTML_MUXER 0
++#define CONFIG_UNCODEDFRAMECRC_MUXER 0
++#define CONFIG_VC1_MUXER 0
++#define CONFIG_VC1T_MUXER 0
++#define CONFIG_VOC_MUXER 0
++#define CONFIG_VVC_MUXER 0
++#define CONFIG_W64_MUXER 0
++#define CONFIG_WAV_MUXER 0
++#define CONFIG_WEBM_MUXER 0
++#define CONFIG_WEBM_DASH_MANIFEST_MUXER 0
++#define CONFIG_WEBM_CHUNK_MUXER 0
++#define CONFIG_WEBP_MUXER 0
++#define CONFIG_WEBVTT_MUXER 0
++#define CONFIG_WSAUD_MUXER 0
++#define CONFIG_WTV_MUXER 0
++#define CONFIG_WV_MUXER 0
++#define CONFIG_YUV4MPEGPIPE_MUXER 0
++#define CONFIG_CHROMAPRINT_MUXER 0
++#define CONFIG_ASYNC_PROTOCOL 0
++#define CONFIG_BLURAY_PROTOCOL 0
++#define CONFIG_CACHE_PROTOCOL 0
++#define CONFIG_CONCAT_PROTOCOL 0
++#define CONFIG_CONCATF_PROTOCOL 0
++#define CONFIG_CRYPTO_PROTOCOL 0
++#define CONFIG_DATA_PROTOCOL 0
++#define CONFIG_FD_PROTOCOL 0
++#define CONFIG_FFRTMPCRYPT_PROTOCOL 0
++#define CONFIG_FFRTMPHTTP_PROTOCOL 0
++#define CONFIG_FILE_PROTOCOL 0
++#define CONFIG_FTP_PROTOCOL 0
++#define CONFIG_GOPHER_PROTOCOL 0
++#define CONFIG_GOPHERS_PROTOCOL 0
++#define CONFIG_HLS_PROTOCOL 0
++#define CONFIG_HTTP_PROTOCOL 0
++#define CONFIG_HTTPPROXY_PROTOCOL 0
++#define CONFIG_HTTPS_PROTOCOL 0
++#define CONFIG_ICECAST_PROTOCOL 0
++#define CONFIG_MMSH_PROTOCOL 0
++#define CONFIG_MMST_PROTOCOL 0
++#define CONFIG_MD5_PROTOCOL 0
++#define CONFIG_PIPE_PROTOCOL 0
++#define CONFIG_PROMPEG_PROTOCOL 0
++#define CONFIG_RTMP_PROTOCOL 0
++#define CONFIG_RTMPE_PROTOCOL 0
++#define CONFIG_RTMPS_PROTOCOL 0
++#define CONFIG_RTMPT_PROTOCOL 0
++#define CONFIG_RTMPTE_PROTOCOL 0
++#define CONFIG_RTMPTS_PROTOCOL 0
++#define CONFIG_RTP_PROTOCOL 0
++#define CONFIG_SCTP_PROTOCOL 0
++#define CONFIG_SRTP_PROTOCOL 0
++#define CONFIG_SUBFILE_PROTOCOL 0
++#define CONFIG_TEE_PROTOCOL 0
++#define CONFIG_TCP_PROTOCOL 0
++#define CONFIG_TLS_PROTOCOL 0
++#define CONFIG_UDP_PROTOCOL 0
++#define CONFIG_UDPLITE_PROTOCOL 0
++#define CONFIG_UNIX_PROTOCOL 0
++#define CONFIG_LIBAMQP_PROTOCOL 0
++#define CONFIG_LIBRIST_PROTOCOL 0
++#define CONFIG_LIBRTMP_PROTOCOL 0
++#define CONFIG_LIBRTMPE_PROTOCOL 0
++#define CONFIG_LIBRTMPS_PROTOCOL 0
++#define CONFIG_LIBRTMPT_PROTOCOL 0
++#define CONFIG_LIBRTMPTE_PROTOCOL 0
++#define CONFIG_LIBSRT_PROTOCOL 0
++#define CONFIG_LIBSSH_PROTOCOL 0
++#define CONFIG_LIBSMBCLIENT_PROTOCOL 0
++#define CONFIG_LIBZMQ_PROTOCOL 0
++#define CONFIG_IPFS_GATEWAY_PROTOCOL 0
++#define CONFIG_IPNS_GATEWAY_PROTOCOL 0
++#endif /* FFMPEG_CONFIG_COMPONENTS_H */
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c b/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c
+--- a/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/bsf_list.c	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,2 @@
++static const FFBitStreamFilter * const bitstream_filters[] = {
++    NULL };
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c b/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c
+--- a/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/codec_list.c	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,15 @@
++static const FFCodec * const codec_list[] = {
++    &ff_flac_decoder,
++    &ff_mp3_decoder,
++    &ff_vorbis_decoder,
++    &ff_pcm_alaw_decoder,
++    &ff_pcm_f32le_decoder,
++    &ff_pcm_mulaw_decoder,
++    &ff_pcm_s16be_decoder,
++    &ff_pcm_s16le_decoder,
++    &ff_pcm_s24be_decoder,
++    &ff_pcm_s24le_decoder,
++    &ff_pcm_s32le_decoder,
++    &ff_pcm_u8_decoder,
++    &ff_libopus_decoder,
++    NULL };
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c b/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c
+--- a/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavcodec/parser_list.c	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,7 @@
++static const AVCodecParser * const parser_list[] = {
++    &ff_flac_parser,
++    &ff_mpegaudio_parser,
++    &ff_opus_parser,
++    &ff_vorbis_parser,
++    &ff_vp9_parser,
++    NULL };
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c b/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c
+--- a/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/demuxer_list.c	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,8 @@
++static const AVInputFormat * const demuxer_list[] = {
++    &ff_flac_demuxer,
++    &ff_matroska_demuxer,
++    &ff_mov_demuxer,
++    &ff_mp3_demuxer,
++    &ff_ogg_demuxer,
++    &ff_wav_demuxer,
++    NULL };
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c b/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c
+--- a/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/muxer_list.c	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,2 @@
++static const FFOutputFormat * const muxer_list[] = {
++    NULL };
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c b/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c
+--- a/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavformat/protocol_list.c	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,2 @@
++static const URLProtocol * const url_protocols[] = {
++    NULL };
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h b/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h
+--- a/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/avconfig.h	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,6 @@
++/* Generated by ffmpeg configure */
++#ifndef AVUTIL_AVCONFIG_H
++#define AVUTIL_AVCONFIG_H
++#define AV_HAVE_BIGENDIAN 0
++#define AV_HAVE_FAST_UNALIGNED 1
++#endif /* AVUTIL_AVCONFIG_H */
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/ffversion.h b/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/ffversion.h
+--- a/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/ffversion.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/ffmpeg/chromium/config/Chromium/linux/loong64/libavutil/ffversion.h	2000-01-01 00:00:00.000000000 +0800
+@@ -0,0 +1,5 @@
++/* Automatically generated by version.sh, do not manually edit! */
++#ifndef AVUTIL_FFVERSION_H
++#define AVUTIL_FFVERSION_H
++#define FFMPEG_VERSION "n5.0.1"
++#endif /* AVUTIL_FFVERSION_H */
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/ffmpeg/ffmpeg_generated.gni b/third_party/ffmpeg/ffmpeg_generated.gni
+--- a/third_party/ffmpeg/ffmpeg_generated.gni	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/ffmpeg/ffmpeg_generated.gni	2000-01-01 00:00:00.000000000 +0800
+@@ -258,6 +258,7 @@ if (((current_cpu == "arm64" || current_
+ if (((current_cpu == "arm64" || current_cpu == "arm64e") &&
+      ffmpeg_branding == "Chrome") ||
+     (current_cpu == "x64" && ffmpeg_branding == "Chrome") ||
++    (current_cpu == "loong64" && ffmpeg_branding == "Chrome") ||
+     (is_android && current_cpu == "arm" && arm_use_neon &&
+      ffmpeg_branding == "Chrome") ||
+     (is_android && current_cpu == "x86" && ffmpeg_branding == "Chrome") ||
+@@ -390,6 +391,19 @@ if (current_cpu == "arm64" || current_cp
+   ]
+ }
+ 
++if ((use_linux_config && current_cpu == "loong64")) {
++  ffmpeg_c_sources += [
++    "libavutil/loongarch/cpu.c",
++    "libavcodec/loongarch/vp8dsp_init_loongarch.c",
++    "libavcodec/loongarch/h264chroma_init_loongarch.c",
++    "libavcodec/loongarch/h264dsp_init_loongarch.c",
++    "libavcodec/loongarch/h264qpel_init_loongarch.c",
++    "libavcodec/loongarch/videodsp_init.c",
++    "libavcodec/loongarch/h264_intrapred_init_loongarch.c",
++    "libavcodec/loongarch/hpeldsp_init_loongarch.c",
++  ]
++}
++
+ if ((is_android && current_cpu == "arm" && arm_use_neon) ||
+     (use_linux_config && current_cpu == "arm" && arm_use_neon) ||
+     (use_linux_config && current_cpu == "arm")) {
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/skia/src/opts/SkOpts_SetTarget.h b/third_party/skia/src/opts/SkOpts_SetTarget.h
+--- a/third_party/skia/src/opts/SkOpts_SetTarget.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/skia/src/opts/SkOpts_SetTarget.h	2000-01-01 00:00:00.000000000 +0800
+@@ -136,9 +136,10 @@
+         #define SK_OPTS_NS lasx
+         // The intrinsic from lasxintrin.h is wrapped by the __loongarch_asx macro, so we need to define it.
+         #define __loongarch_asx
++        #define __loongarch_sx
+ 
+         #if defined(__clang__)
+-          #pragma clang attribute push(__attribute__((target("lasx"))), apply_to=function)
++          #pragma clang attribute push(__attribute__((target("lsx,lasx"))), apply_to=function)
+         #endif
+ 
+     #else
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/swiftshader/src/Reactor/BUILD.gn b/third_party/swiftshader/src/Reactor/BUILD.gn
+--- a/third_party/swiftshader/src/Reactor/BUILD.gn	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/swiftshader/src/Reactor/BUILD.gn	2000-01-01 00:00:00.000000000 +0800
+@@ -307,7 +307,11 @@ if (supports_subzero) {
+ 
+ if (supports_llvm) {
+   swiftshader_source_set("swiftshader_llvm_reactor") {
+-    llvm_dir = "../../third_party/llvm-10.0"
++    if (current_cpu == "loong64") {
++      llvm_dir = "../../third_party/llvm-16.0"
++    } else {
++      llvm_dir = "../../third_party/llvm-10.0"
++    }
+ 
+     deps = [
+       ":swiftshader_reactor_base",
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/swiftshader/third_party/llvm-16.0/configs/linux/include/llvm/Config/AsmParsers.def b/third_party/swiftshader/third_party/llvm-16.0/configs/linux/include/llvm/Config/AsmParsers.def
+--- a/third_party/swiftshader/third_party/llvm-16.0/configs/linux/include/llvm/Config/AsmParsers.def	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/swiftshader/third_party/llvm-16.0/configs/linux/include/llvm/Config/AsmParsers.def	2000-01-01 00:00:00.000000000 +0800
+@@ -45,6 +45,9 @@ LLVM_ASM_PARSER(PowerPC)
+ #if defined(__riscv)
+ LLVM_ASM_PARSER(RISCV)
+ #endif
++#if defined(__loongarch__)
++LLVM_ASM_PARSER(LoongArch)
++#endif
+ 
+ 
+ #undef LLVM_ASM_PARSER
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/swiftshader/third_party/llvm-16.0/configs/linux/include/llvm/Config/AsmPrinters.def b/third_party/swiftshader/third_party/llvm-16.0/configs/linux/include/llvm/Config/AsmPrinters.def
+--- a/third_party/swiftshader/third_party/llvm-16.0/configs/linux/include/llvm/Config/AsmPrinters.def	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/swiftshader/third_party/llvm-16.0/configs/linux/include/llvm/Config/AsmPrinters.def	2000-01-01 00:00:00.000000000 +0800
+@@ -45,6 +45,9 @@ LLVM_ASM_PRINTER(PowerPC)
+ #if defined(__riscv)
+ LLVM_ASM_PRINTER(RISCV)
+ #endif
++#if defined(__loongarch__)
++LLVM_ASM_PRINTER(LoongArch)
++#endif
+ 
+ 
+ #undef LLVM_ASM_PRINTER
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/swiftshader/third_party/llvm-16.0/configs/linux/include/llvm/Config/Disassemblers.def b/third_party/swiftshader/third_party/llvm-16.0/configs/linux/include/llvm/Config/Disassemblers.def
+--- a/third_party/swiftshader/third_party/llvm-16.0/configs/linux/include/llvm/Config/Disassemblers.def	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/swiftshader/third_party/llvm-16.0/configs/linux/include/llvm/Config/Disassemblers.def	2000-01-01 00:00:00.000000000 +0800
+@@ -45,6 +45,9 @@ LLVM_DISASSEMBLER(PowerPC)
+ #if defined(__riscv)
+ LLVM_DISASSEMBLER(RISCV)
+ #endif
++#if defined(__loongarch__)
++LLVM_DISASSEMBLER(LoongArch)
++#endif
+ 
+ 
+ #undef LLVM_DISASSEMBLER
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/swiftshader/third_party/llvm-16.0/configs/linux/include/llvm/Config/Targets.def b/third_party/swiftshader/third_party/llvm-16.0/configs/linux/include/llvm/Config/Targets.def
+--- a/third_party/swiftshader/third_party/llvm-16.0/configs/linux/include/llvm/Config/Targets.def	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/swiftshader/third_party/llvm-16.0/configs/linux/include/llvm/Config/Targets.def	2000-01-01 00:00:00.000000000 +0800
+@@ -44,6 +44,9 @@ LLVM_TARGET(PowerPC)
+ #if defined(__riscv)
+ LLVM_TARGET(RISCV)
+ #endif
++#if defined(__loongarch__)
++LLVM_TARGET(LoongArch)
++#endif
+ 
+ 
+ #undef LLVM_TARGET
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/swiftshader/third_party/llvm-16.0/configs/linux/include/llvm/Config/llvm-config.h b/third_party/swiftshader/third_party/llvm-16.0/configs/linux/include/llvm/Config/llvm-config.h
+--- a/third_party/swiftshader/third_party/llvm-16.0/configs/linux/include/llvm/Config/llvm-config.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/swiftshader/third_party/llvm-16.0/configs/linux/include/llvm/Config/llvm-config.h	2000-01-01 00:00:00.000000000 +0800
+@@ -47,6 +47,8 @@
+ #define LLVM_DEFAULT_TARGET_TRIPLE "powerpc64le-unknown-linux-gnu"
+ #elif defined(__riscv)
+ #define LLVM_DEFAULT_TARGET_TRIPLE "riscv64-unknown-linux-gnu"
++#elif defined(__loongarch__)
++#define LLVM_DEFAULT_TARGET_TRIPLE "loongarch64-unknown-linux-gnu"
+ #else
+ #error "unknown architecture"
+ #endif
+@@ -76,6 +78,8 @@
+ #define LLVM_HOST_TRIPLE "powerpc64le-unknown-linux-gnu"
+ #elif defined(__riscv)
+ #define LLVM_HOST_TRIPLE "riscv64-unknown-linux-gnu"
++#elif defined(__loongarch__)
++#define LLVM_HOST_TRIPLE "loongarch64-unknown-linux-gnu"
+ #else
+ #error "unknown architecture"
+ #endif
+@@ -95,6 +99,8 @@
+ #define LLVM_NATIVE_ARCH PowerPC
+ #elif defined(__riscv)
+ #define LLVM_NATIVE_ARCH RISCV
++#elif defined(__loongarch__)
++#define LLVM_NATIVE_ARCH LoongArch
+ #else
+ #error "unknown architecture"
+ #endif
+@@ -114,6 +120,8 @@
+ #define LLVM_NATIVE_ASMPARSER LLVMInitializePowerPCAsmParser
+ #elif defined(__riscv)
+ #define LLVM_NATIVE_ASMPARSER LLVMInitializeRISCVAsmParser
++#elif defined(__loongarch__)
++#define LLVM_NATIVE_ASMPARSER LLVMInitializeLoongArchAsmParser
+ #else
+ #error "unknown architecture"
+ #endif
+@@ -133,6 +141,8 @@
+ #define LLVM_NATIVE_ASMPRINTER LLVMInitializePowerPCAsmPrinter
+ #elif defined(__riscv)
+ #define LLVM_NATIVE_ASMPRINTER LLVMInitializeRISCVAsmPrinter
++#elif defined(__loongarch__)
++#define LLVM_NATIVE_ASMPRINTER LLVMInitializeLoongArchAsmPrinter
+ #else
+ #error "unknown architecture"
+ #endif
+@@ -152,6 +162,8 @@
+ #define LLVM_NATIVE_DISASSEMBLER LLVMInitializePowerPCDisassembler
+ #elif defined(__riscv)
+ #define LLVM_NATIVE_DISASSEMBLER LLVMInitializeRISCVDisassembler
++#elif defined(__loongarch__)
++#define LLVM_NATIVE_DISASSEMBLER LLVMInitializeLoongArchDisassembler
+ #else
+ #error "unknown architecture"
+ #endif
+@@ -171,6 +183,8 @@
+ #define LLVM_NATIVE_TARGET LLVMInitializePowerPCTarget
+ #elif defined(__riscv)
+ #define LLVM_NATIVE_TARGET LLVMInitializeRISCVTarget
++#elif defined(__loongarch__)
++#define LLVM_NATIVE_TARGET LLVMInitializeLoongArchTarget
+ #else
+ #error "unknown architecture"
+ #endif
+@@ -190,6 +204,8 @@
+ #define LLVM_NATIVE_TARGETINFO LLVMInitializePowerPCTargetInfo
+ #elif defined(__riscv)
+ #define LLVM_NATIVE_TARGETINFO LLVMInitializeRISCVTargetInfo
++#elif defined(__loongarch__)
++#define LLVM_NATIVE_TARGETINFO LLVMInitializeLoongArchTargetInfo
+ #else
+ #error "unknown architecture"
+ #endif
+@@ -209,6 +225,8 @@
+ #define LLVM_NATIVE_TARGETMC LLVMInitializePowerPCTargetMC
+ #elif defined(__riscv)
+ #define LLVM_NATIVE_TARGETMC LLVMInitializeRISCVTargetMC
++#elif defined(__loongarch__)
++#define LLVM_NATIVE_TARGETMC LLVMInitializeLoongArchTargetMC
+ #else
+ #error "unknown architecture"
+ #endif
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/swiftshader/third_party/llvm-16.0/llvm/include/llvm/Support/Error.h b/third_party/swiftshader/third_party/llvm-16.0/llvm/include/llvm/Support/Error.h
+--- a/third_party/swiftshader/third_party/llvm-16.0/llvm/include/llvm/Support/Error.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/swiftshader/third_party/llvm-16.0/llvm/include/llvm/Support/Error.h	2000-01-01 00:00:00.000000000 +0800
+@@ -18,7 +18,6 @@
+ #include "llvm/ADT/StringExtras.h"
+ #include "llvm/ADT/Twine.h"
+ #include "llvm/Config/abi-breaking.h"
+-#include "llvm/Support/AlignOf.h"
+ #include "llvm/Support/Compiler.h"
+ #include "llvm/Support/Debug.h"
+ #include "llvm/Support/ErrorHandling.h"
+@@ -669,22 +668,22 @@ private:
+ 
+   storage_type *getStorage() {
+     assert(!HasError && "Cannot get value when an error exists!");
+-    return reinterpret_cast<storage_type *>(&TStorage);
++    return &TStorage;
+   }
+ 
+   const storage_type *getStorage() const {
+     assert(!HasError && "Cannot get value when an error exists!");
+-    return reinterpret_cast<const storage_type *>(&TStorage);
++    return &TStorage;
+   }
+ 
+   error_type *getErrorStorage() {
+     assert(HasError && "Cannot get error when a value exists!");
+-    return reinterpret_cast<error_type *>(&ErrorStorage);
++    return &ErrorStorage;
+   }
+ 
+   const error_type *getErrorStorage() const {
+     assert(HasError && "Cannot get error when a value exists!");
+-    return reinterpret_cast<const error_type *>(&ErrorStorage);
++    return &ErrorStorage;
+   }
+ 
+   // Used by ExpectedAsOutParameter to reset the checked flag.
+@@ -716,8 +715,8 @@ private:
+   }
+ 
+   union {
+-    AlignedCharArrayUnion<storage_type> TStorage;
+-    AlignedCharArrayUnion<error_type> ErrorStorage;
++    storage_type TStorage;
++    error_type ErrorStorage;
+   };
+   bool HasError : 1;
+ #if LLVM_ENABLE_ABI_BREAKING_CHECKS
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/swiftshader/third_party/llvm-16.0/llvm/include/llvm/Support/ErrorOr.h b/third_party/swiftshader/third_party/llvm-16.0/llvm/include/llvm/Support/ErrorOr.h
+--- a/third_party/swiftshader/third_party/llvm-16.0/llvm/include/llvm/Support/ErrorOr.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/swiftshader/third_party/llvm-16.0/llvm/include/llvm/Support/ErrorOr.h	2000-01-01 00:00:00.000000000 +0800
+@@ -15,7 +15,6 @@
+ #ifndef LLVM_SUPPORT_ERROROR_H
+ #define LLVM_SUPPORT_ERROROR_H
+ 
+-#include "llvm/Support/AlignOf.h"
+ #include <cassert>
+ #include <system_error>
+ #include <type_traits>
+@@ -235,26 +234,27 @@ private:
+ 
+   storage_type *getStorage() {
+     assert(!HasError && "Cannot get value when an error exists!");
+-    return reinterpret_cast<storage_type *>(&TStorage);
++    return &TStorage;
+   }
+ 
+   const storage_type *getStorage() const {
+     assert(!HasError && "Cannot get value when an error exists!");
+-    return reinterpret_cast<const storage_type *>(&TStorage);
++    return &TStorage;
+   }
+ 
+   std::error_code *getErrorStorage() {
+     assert(HasError && "Cannot get error when a value exists!");
+-    return reinterpret_cast<std::error_code *>(&ErrorStorage);
++    return &ErrorStorage;
+   }
+ 
+   const std::error_code *getErrorStorage() const {
+-    return const_cast<ErrorOr<T> *>(this)->getErrorStorage();
++    assert(HasError && "Cannot get error when a value exists!");
++    return &ErrorStorage;
+   }
+ 
+   union {
+-    AlignedCharArrayUnion<storage_type> TStorage;
+-    AlignedCharArrayUnion<std::error_code> ErrorStorage;
++    storage_type TStorage;
++    std::error_code ErrorStorage;
+   };
+   bool HasError : 1;
+ };
+diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/third_party/swiftshader/third_party/llvm-16.0/llvm/include/llvm/Support/TrailingObjects.h b/third_party/swiftshader/third_party/llvm-16.0/llvm/include/llvm/Support/TrailingObjects.h
+--- a/third_party/swiftshader/third_party/llvm-16.0/llvm/include/llvm/Support/TrailingObjects.h	2000-01-01 00:00:00.000000000 +0800
++++ b/third_party/swiftshader/third_party/llvm-16.0/llvm/include/llvm/Support/TrailingObjects.h	2000-01-01 00:00:00.000000000 +0800
+@@ -46,7 +46,6 @@
+ #ifndef LLVM_SUPPORT_TRAILINGOBJECTS_H
+ #define LLVM_SUPPORT_TRAILINGOBJECTS_H
+ 
+-#include "llvm/Support/AlignOf.h"
+ #include "llvm/Support/Alignment.h"
+ #include "llvm/Support/Compiler.h"
+ #include "llvm/Support/MathExtras.h"

--- a/electron37/compiler-rt-adjust-paths-loong64.patch
+++ b/electron37/compiler-rt-adjust-paths-loong64.patch
@@ -1,0 +1,35 @@
+diff --git a/build/config/clang/BUILD.gn b/build/config/clang/BUILD.gn
+index 8c03235f5d141..c1f60044d4749 100644
+--- a/build/config/clang/BUILD.gn
++++ b/build/config/clang/BUILD.gn
+@@ -210,14 +210,18 @@ template("clang_lib") {
+       } else if (is_linux || is_chromeos) {
+         if (current_cpu == "x64") {
+           _dir = "x86_64-unknown-linux-gnu"
++          _suffix = "-x86_64"
+         } else if (current_cpu == "x86") {
+           _dir = "i386-unknown-linux-gnu"
++          _suffix = "-i386"
+         } else if (current_cpu == "arm") {
+           _dir = "armv7-unknown-linux-gnueabihf"
+         } else if (current_cpu == "arm64") {
+           _dir = "aarch64-unknown-linux-gnu"
++          _suffix = "-aarch64"
+         } else if (current_cpu == "loong64") {
+           _dir = "loongarch64-unknown-linux-gnu"
++          _suffix = "-loongarch64"
+         } else {
+           assert(false)  # Unhandled cpu type
+         }
+@@ -248,6 +252,11 @@ template("clang_lib") {
+         assert(false)  # Unhandled target platform
+       }
+ 
++      # Bit of a hack to make this find builtins from compiler-rt >= 16
++      if (is_linux || is_chromeos) {
++        _dir = "linux"
++      }
++
+       _lib_file = "${_prefix}clang_rt.${_libname}${_suffix}.${_ext}"
+       libs = [ "$_clang_lib_dir/$_dir/$_lib_file" ]
+ 

--- a/electron37/depot_tools-loong64-support.patch
+++ b/electron37/depot_tools-loong64-support.patch
@@ -1,0 +1,14 @@
+diff --git a/cipd b/cipd
+index 7f9cca27..3acbe4ad 100755
+--- a/cipd
++++ b/cipd
+@@ -80,6 +80,9 @@ if [ -z $ARCH ]; then
+     riscv64)
+       ARCH=riscv64
+       ;;
++    loongarch64)
++      ARCH=loong64
++      ;;
+     *)
+       >&2 echo "UNKNOWN Machine architecture: ${UNAME}"
+       exit 1

--- a/electron37/electron_runtime_api_dalagate-add-loongarch64-support.patch
+++ b/electron37/electron_runtime_api_dalagate-add-loongarch64-support.patch
@@ -1,0 +1,22 @@
+diff --git a/shell/browser/extensions/api/runtime/electron_runtime_api_delegate.cc b/shell/browser/extensions/api/runtime/electron_runtime_api_delegate.cc
+index b9ebc391e7..e1dc660f22 100644
+--- a/shell/browser/extensions/api/runtime/electron_runtime_api_delegate.cc
++++ b/shell/browser/extensions/api/runtime/electron_runtime_api_delegate.cc
+@@ -68,6 +68,8 @@ bool ElectronRuntimeAPIDelegate::GetPlatformInfo(PlatformInfo* info) {
+     info->arch = extensions::api::runtime::PlatformArch::kX86_32;
+   } else if (arch == "x64") {
+     info->arch = extensions::api::runtime::PlatformArch::kX86_64;
++  } else if (arch == "loong64") {
++    info->arch = extensions::api::runtime::PlatformArch::kLoongarch64;
+   } else {
+     NOTREACHED();
+   }
+@@ -80,6 +82,8 @@ bool ElectronRuntimeAPIDelegate::GetPlatformInfo(PlatformInfo* info) {
+     info->nacl_arch = extensions::api::runtime::PlatformNaclArch::kX86_32;
+   } else if (nacl_arch == "x86-64") {
+     info->nacl_arch = extensions::api::runtime::PlatformNaclArch::kX86_64;
++  } else if (nacl_arch == "loong64") {
++    info->nacl_arch = extensions::api::runtime::PlatformNaclArch::kLoongarch64;
+   } else {
+     NOTREACHED();
+   }

--- a/electron37/loong.patch
+++ b/electron37/loong.patch
@@ -1,0 +1,136 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 098c56b..2fb1fb0 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -434,6 +434,11 @@ prepare() {
+   sed -i "s|@ELECTRON@|${pkgname}|" electron.desktop
+   sed -i "s|@ELECTRON_NAME@|Electron ${_major_ver}|" electron.desktop
+ 
++  # Apply in advance to so that makepkg-source-roller.py will not throw error
++  patch -Np1 -d chromium-mirror_third_party_depot_tools -i "${srcdir}/depot_tools-loong64-support.patch"
++  # Get the binary from the npm package
++  npm install @esbuild/linux-loong64@0.24.0
++
+   cp -r chromium-mirror_third_party_depot_tools depot_tools
+   export PATH+=":$PWD/depot_tools" DEPOT_TOOLS_UPDATE=0
+   #export VPYTHON_BYPASS='manually managed python not supported by chrome operations'
+@@ -441,6 +446,14 @@ prepare() {
+   echo "Putting together electron sources"
+   # Generate gclient gn args file and prepare-electron-source-tree.sh
+   python makepkg-source-roller.py generate electron/DEPS $pkgname
++  # Do not use the script to fetch esbuild since google doesn't distribute it
++  # The esbuild is added manually
++  sed -i '/esbuild/d' prepare-electron-source-tree.sh
++  # Add esbuild binary manually
++  npm install @esbuild/linux-loong64@0.24.0
++  mkdir -p src/third_party/devtools-frontend/src/third_party/esbuild
++  mv node_modules/@esbuild/linux-loong64/bin/esbuild src/third_party/devtools-frontend/src/third_party/esbuild/esbuild
++  rm -r node_modules # Cleaning
+   rbash prepare-electron-source-tree.sh "$CARCH"
+   mv electron src/electron
+ 
+@@ -454,12 +467,48 @@ prepare() {
+     -s src/third_party/skia --header src/skia/ext/skia_commit_hash.h
+   src/build/util/lastchange.py \
+     -s src/third_party/dawn --revision src/gpu/webgpu/DAWN_VERSION
+-  src/tools/update_pgo_profiles.py --target=linux update \
+-    --gs-url-base=chromium-optimization-profiles/pgo_profiles
++  #src/tools/update_pgo_profiles.py --target=linux update \
++  #  --gs-url-base=chromium-optimization-profiles/pgo_profiles
++
++  # Link to system tools required by the build in advance
++  pushd src
++  mkdir -p third_party/node/linux/node-linux-x64/bin
++  ln -sfn /usr/bin/node third_party/node/linux/node-linux-x64/bin/
++  mkdir -p third_party/jdk/current/bin
++  ln -sfn /usr/bin/java third_party/jdk/current/bin/
++  ln -sfn /usr/bin/clang-format buildtools/linux64
++  popd
++
++  pushd src/third_party/node/
++  sed -i -e 's/@rollup/rollup/' -e "s/'wasm-node',//" node_modules.py
++  #local _rollup_ver="$(jq -r .dependencies.\"@rollup/wasm-node\" package.json)"
++  local _rollup_ver="4.32.0" # Known version that supports loong64
++  jq ".dependencies.rollup=\"$_rollup_ver\"" package.json > package.json.new
++  mv package.json{.new,}
++  popd
+ 
+   # https://gitlab.archlinux.org/archlinux/packaging/packages/electron32/-/issues/1
+   src/third_party/node/update_npm_deps
+ 
++  pushd src/third_party/devtools-frontend/src
++  sed -i -e 's/@rollup/rollup/' -e "s/'wasm-node',//" scripts/devtools_paths.py
++  #local _rollup_ver="$(jq -r .devDependencies.\"@rollup/wasm-node\" package.json)"
++  jq ".devDependencies.rollup=\"$_rollup_ver\" | .devDependencies.\"@rollup/rollup-linux-loongarch64-gnu\"=\"$_rollup_ver\""  package.json > package.json.new
++  mv package.json{.new,}
++  # Chromium hosts a custom registry at https://npm.skia.org/chrome-devtools/
++  # and rejects some packages:
++  # Package fs-extra with version 11.3.0 was created 108h0m0s time ago. This is less than 1 week and so failed the audit.
++  sed -i /registry/d .npmrc
++  # Replace direct invocation of wasm rollup
++  sed -i 's\@rollup/wasm-node\rollup\' \
++    inspector_overlay/BUILD.gn \
++    front_end/models/live-metrics/web-vitals-injected/BUILD.gn \
++    front_end/Images/BUILD.gn \
++    front_end/panels/recorder/injected/BUILD.gn \
++    scripts/build/ninja/bundle.gni
++  popd
++  python src/third_party/devtools-frontend/src/scripts/deps/manage_node_deps.py
++
+   src/electron/script/apply_all_patches.py \
+       src/electron/patches/config.json
+ 
+@@ -488,7 +537,9 @@ prepare() {
+   patch -Np1 -i ../chromium-138-nodejs-version-check.patch
+ 
+   # Allow libclang_rt.builtins from compiler-rt >= 16 to be used
+-  patch -Np1 -i ../compiler-rt-adjust-paths.patch
++  #patch -Np1 -i ../compiler-rt-adjust-paths.patch
++  # Use modified version for loong64 support
++  patch -Np1 -i ../compiler-rt-adjust-paths-loong64.patch
+ 
+   # Fixes for building with libstdc++ instead of libc++
+   patch -Np1 -i ../chromium-patches-*/chromium-138-compiler.patch
+@@ -505,6 +556,12 @@ prepare() {
+   patch -Np1 -i "${srcdir}/use-system-libraries-in-node.patch"
+   # patch -Np1 -i "${srcdir}/default_app-icon.patch"  # Icon from .desktop file
+ 
++  # Add loong64 support for chromium
++  patch -Np1 -i "${srcdir}/chromium-loong64-support.patch"
++  patch -Np1 -i "${srcdir}/allow-sched_getaffinity-in-seccomp-for-loong64.patch"
++  # Add loong64 support for electron
++  patch -Np1 -d electron -i "${srcdir}/electron_runtime_api_dalagate-add-loongarch64-support.patch"
++
+   # Allow building against system libraries in official builds
+   echo "Patching Chromium for using system libraries..."
+   sed -i 's/OFFICIAL_BUILD/GOOGLE_CHROME_BUILD/' \
+@@ -566,9 +623,12 @@ build() {
+     'clang_base_path="/usr"'
+     'clang_use_chrome_plugins=false'
+     "clang_version=\"$_clang_version\""
+-    'chrome_pgo_phase=2'
++    'chrome_pgo_phase=0'
+   )
+ 
++  # Disable xnnpack on loong64
++  _flags+=('build_tflite_with_xnnpack=false')
++
+   # Allow the use of nightly features with stable Rust compiler
+   # https://github.com/ungoogled-software/ungoogled-chromium/pull/2696#issuecomment-1918173198
+   export RUSTC_BOOTSTRAP=1
+@@ -635,3 +695,15 @@ package() {
+   install -Dm644 src/electron/default_app/icon.png \
+           "${pkgdir}/usr/share/pixmaps/${pkgname}.png"  # hicolor has no 1024x1024
+ }
++
++makedepends+=(jq)
++source+=("depot_tools-loong64-support.patch"
++         "compiler-rt-adjust-paths-loong64.patch"
++         "chromium-loong64-support.patch"
++         "electron_runtime_api_dalagate-add-loongarch64-support.patch"
++         "allow-sched_getaffinity-in-seccomp-for-loong64.patch")
++sha256sums+=('731ce1a98a181d0c22eb4a6f2e1dbb5417471a6ee17049603b3201ef5e931bd3'
++             '5eb62f142569bd6887396410ad174a4e9e932790361567df0fd9127003d6b2a0'
++             'f7ca729c50e16239de71e44c1b9c1f45a9801a46ec66be3f01aa254c56111057'
++             '516502491d2ed6d9bc8fbb40960a9f98cff4e7beadac4b7ac05a5579f9671733'
++             'b48d40e93f020b5e8861f1f320437984d8f7d62c568ad1995af78e49e88de7a9')


### PR DESCRIPTION
* Rebase to electron37/chromium138
* Switch to `std:string`'s comparing styles in `electron_runtime_api_delegate.cc` to fix build
* Disable xnnapck on loong64