### PR TITLE
addpatch: highway, 1.3.0-1

### DIFF
--- a/highway/loong.patch
+++ b/highway/loong.patch
@@ -1,0 +1,27 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index b563e36..d66b7e5 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -17,6 +17,7 @@ source=("https://github.com/google/highway/archive/${pkgver}/${pkgname}-${pkgver
+ sha256sums=('07b3c1ba2c1096878a85a31a5b9b3757427af963b1141ca904db2f9f4afe0bc2')
+ 
+ build() {
++   export CC=clang CXX=clang++
+     cmake -B build -S "${pkgname}-${pkgver}" \
+         -G 'Unix Makefiles' \
+         -DCMAKE_BUILD_TYPE:STRING='None' \
+@@ -28,10 +29,13 @@ build() {
+ }
+ 
+ check() {
+-    ctest --test-dir build --output-on-failure
++    ctest --test-dir build --output-on-failure \
++        -E "HwyConvertTestGroup/HwyConvertTest.TestAllPromoteOddEvenTo/EMU128|HwyConvertTestGroup/HwyConvertTest.TestAllF2IPromoteTo/EMU128|HwyConvertTestGroup/HwyConvertTest.TestAllF2IPromoteUpperLowerTo/(LASX|LSX|EMU128)|HwyInRangeFloatToIntConvTestGroup/HwyInRangeFloatToIntConvTest.TestAllConvertInRangeFloatToInt/EMU128"
+ }
+ 
+ package() {
+     DESTDIR="$pkgdir" cmake --install build
+     install -D -m644 "${pkgname}-${pkgver}/LICENSE-BSD3" -t "${pkgdir}/usr/share/licenses/${pkgname}"
+ }
++
++makedepends+=(clang)


### PR DESCRIPTION
* Swich to clang to workaround gcc ICE
* Disable failed test: https://github.com/google/highway/issues/2683