### PR TITLE
updpatch: openmpi, ver=5.0.8-2

### DIFF
--- a/openmpi/loong.patch
+++ b/openmpi/loong.patch
@@ -1,5 +1,5 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index fe00ace..e4ad2a0 100644
+index c1c08b5..d216d51 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
 @@ -16,18 +16,14 @@ arch=(x86_64)
@@ -21,17 +21,18 @@ index fe00ace..e4ad2a0 100644
    openucx
    prrte
    valgrind
-@@ -70,13 +66,7 @@ build() {
+@@ -71,13 +67,7 @@ build() {
      --with-pmix=external
      --with-prrte=external
      --with-valgrind
 -    --with-ucc=/usr
-     --with-ucx=/usr
+-    --with-ucx=/usr
 -    --with-cuda=/opt/cuda
 -    # this tricks the configure script to look for /usr/lib/pkgconfig/cuda.pc
 -    # instead of /opt/cuda/lib/pkgconfig/cuda.pc
 -    --with-cuda-libdir=/usr/lib
 -    --with-rocm=/opt/rocm
++    #--with-ucx=/usr
      # all components that link to libraries provided by optdepends must be run-time loadable
      --enable-mca-dso=accelerator_cuda,accelerator_rocm,btl_smcuda,rcache_gpusm,rcache_rgpusm,coll_ucc,scoll_ucc
      # mpirun should not warn on MCA component load failures by default - usually caused by missing optdepends, which is ok


### PR DESCRIPTION
* Disable to build with openucx since it's broken on loong64