### PR TITLE
updpatch: gcc, ver=15.2.1+r22+gc4e96a094636-1.1

### DIFF
--- a/gcc/loong.patch
+++ b/gcc/loong.patch
@@ -1,3 +1,5 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 169e651..23e2d34 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
 @@ -21,8 +21,6 @@ makedepends=(
@@ -9,18 +11,20 @@
    libisl
    libmpc
    python
-@@ -68,6 +66,10 @@ prepare() {
+@@ -68,6 +66,12 @@ prepare() {
    # Reproducible gcc-ada
    patch -Np0 < "$srcdir/gcc-ada-repro.patch"
  
 +  # Patches for loong64
 +  # Fix libdir
 +  patch -Np1 -i "$srcdir/gcc-lib64-lib.patch"
++  # Apply upstream fix for LoongArch ICE in highway-1.3.0 testsuite
++  git cherry-pick -n 1276b391b4b068655b1d4511d51421302c1a7849
 +
    mkdir -p "$srcdir/gcc-build"
    mkdir -p "$srcdir/libgccjit-build"
  }
-@@ -95,7 +97,8 @@ build() {
+@@ -95,7 +99,8 @@ build() {
        --enable-link-serialization=1
        --enable-linker-build-id
        --enable-lto
@@ -30,7 +34,7 @@
        --enable-plugin
        --enable-shared
        --enable-threads=posix
-@@ -113,7 +116,7 @@ build() {
+@@ -113,7 +118,7 @@ build() {
    CXXFLAGS=${CXXFLAGS/-Werror=format-security/}
  
    "$srcdir/gcc/configure" \
@@ -39,7 +43,7 @@
      --enable-bootstrap \
      "${_confflags[@]:?_confflags unset}"
  
-@@ -162,7 +165,7 @@ package_gcc-libs() {
+@@ -162,7 +167,7 @@ package_gcc-libs() {
    pkgdesc='Runtime libraries shipped by GCC'
    depends=('glibc>=2.27')
    options=(!emptydirs !strip)
@@ -48,7 +52,7 @@
              libubsan.so libasan.so libtsan.so liblsan.so)
    replaces=($pkgname-multilib libgphobos)
  
-@@ -172,7 +175,6 @@ package_gcc-libs() {
+@@ -172,7 +177,6 @@ package_gcc-libs() {
  
    for lib in libatomic \
               libgfortran \
@@ -56,7 +60,7 @@
               libgomp \
               libitm \
               libquadmath \
-@@ -220,22 +222,18 @@ package_gcc() {
+@@ -220,22 +224,18 @@ package_gcc() {
    install -m755 -t "$pkgdir/${_libdir}/" gcc/{cc1,cc1plus,collect2,lto1}
  
    make -C $CHOST/libgcc DESTDIR="$pkgdir" install
@@ -80,7 +84,7 @@
  
    make DESTDIR="$pkgdir" install-fixincludes
    make -C gcc DESTDIR="$pkgdir" install-mkheaders
-@@ -252,15 +250,11 @@ package_gcc() {
+@@ -252,15 +252,11 @@ package_gcc() {
    make -C $CHOST/libsanitizer/asan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
    make -C $CHOST/libsanitizer/tsan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
    make -C $CHOST/libsanitizer/lsan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
@@ -99,7 +103,7 @@
  
    make -C libcpp DESTDIR="$pkgdir" install
    make -C gcc DESTDIR="$pkgdir" install-po
-@@ -271,7 +265,7 @@ package_gcc() {
+@@ -271,7 +267,7 @@ package_gcc() {
    # create cc-rs compatible symlinks
    # https://github.com/rust-lang/cc-rs/blob/1.0.73/src/lib.rs#L2578-L2581
    for binary in {c++,g++,gcc,gcc-ar,gcc-nm,gcc-ranlib}; do
@@ -108,7 +112,7 @@
    done
  
    # POSIX conformance launcher scripts for c89 and c99
-@@ -303,8 +297,6 @@ package_gcc-fortran() {
+@@ -303,8 +299,6 @@ package_gcc-fortran() {
    cd gcc-build
    make -C $CHOST/libgfortran DESTDIR="$pkgdir" install-cafexeclibLTLIBRARIES \
      install-{toolexeclibDATA,nodist_fincludeHEADERS,gfor_cHEADERS}
@@ -117,7 +121,7 @@
    make -C $CHOST/libgomp DESTDIR="$pkgdir" install-nodist_fincludeHEADERS
    make -C gcc DESTDIR="$pkgdir" fortran.install-{common,man,info}
    install -Dm755 gcc/f951 "$pkgdir/${_libdir}/f951"
-@@ -349,10 +341,6 @@ package_gcc-ada() {
+@@ -349,10 +343,6 @@ package_gcc-ada() {
    make DESTDIR="${pkgdir}" INSTALL="install" \
      INSTALL_DATA="install -m644" install-libada
  
@@ -128,7 +132,7 @@
    ln -s gcc "$pkgdir/usr/bin/gnatgcc"
  
    # insist on dynamic linking, but keep static libraries because gnatmake complains
-@@ -361,12 +349,6 @@ package_gcc-ada() {
+@@ -361,12 +351,6 @@ package_gcc-ada() {
    ln -s libgnat-${pkgver%%.*}.so "$pkgdir/usr/lib/libgnat.so"
    rm -f "$pkgdir"/${_libdir}/adalib/libgna{rl,t}.so
  
@@ -141,7 +145,7 @@
    # Install Runtime Library Exception
    install -d "$pkgdir/usr/share/licenses/$pkgname/"
    ln -s /usr/share/licenses/gcc-libs/RUNTIME.LIBRARY.EXCEPTION \
-@@ -528,3 +510,9 @@ package_libgccjit() {
+@@ -528,3 +512,9 @@ package_libgccjit() {
    ln -s /usr/share/licenses/gcc-libs/RUNTIME.LIBRARY.EXCEPTION \
      "$pkgdir/usr/share/licenses/$pkgname/"
  }


### PR DESCRIPTION
* Apply upstream fix for LoongArch ICE with LSX reported in highway-1.3.0 testsuite