### PR TITLE
feat: enhance patch-check.sh for source verification

### DIFF
--- a/patch-check.sh
+++ b/patch-check.sh
@@ -10,8 +10,17 @@ fi
 ORIGDIR=$PWD
 for _dir in $(git diff --merge-base --name-only upstream/master | cut -d / -f 1 | uniq); do
   if [[ ! -e "$_dir"/loong.patch ]]; then
-    echo "Skipping $_dir..."
-    continue
+    # Check if PKGBUILD exists for direct checksum verification
+    if [[ -e "$_dir"/PKGBUILD ]]; then
+      echo "No loong.patch found but PKGBUILD exists, checking checksums for $_dir..."
+      pushd $_dir
+      sudo -u nobody makepkg --verifysource --skippgpcheck || exit 1
+      popd
+      continue
+    else
+      echo "Skipping $_dir..."
+      continue
+    fi
   fi
 
   echo "Trying to apply patch for $_dir..."


### PR DESCRIPTION
* check PKGBUILD existence when loong.patch is missing
* run `makepkg --verifysource` to validate sources early
* avoid skipping packages that may require source integrity check