### PR TITLE
addpatch: arduino-cli, ver=1.2.2-1

### DIFF
--- a/arduino-cli/loong.patch
+++ b/arduino-cli/loong.patch
@@ -1,0 +1,13 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 72d2110..d9d4424 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -22,6 +22,8 @@ build(){
+   export CGO_LDFLAGS="$LDFLAGS"
+   export GOFLAGS='-buildmode=pie -trimpath -mod=readonly -modcacherw'
+ 
++  go mod edit -replace=github.com/creack/goselect=github.com/creack/goselect@v0.1.3
++  go mod tidy
+   go build \
+         -ldflags "-linkmode=external -X github.com/arduino/arduino-cli/version.versionString=$pkgver-arch -X github.com/arduino/arduino-cli/version.commit=$(git rev-parse HEAD)" \
+         -v .


### PR DESCRIPTION
* Update github.com/creack/goselect to v0.1.3 to build on loong64