### PR TITLE
updpatch: calibre, ver=8.7.0-2

### DIFF
--- a/calibre/loong.patch
+++ b/calibre/loong.patch
@@ -1,5 +1,5 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index c633f35..42055b6 100644
+index d2ad69c..5085a46 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
 @@ -92,6 +92,7 @@ validpgpkeys=('3CE1780F78DD88DF45194FD706BC317B515ACE7C') # Kovid Goyal (New lon
@@ -10,16 +10,20 @@ index c633f35..42055b6 100644
  	# Desktop integration (e.g. enforce arch defaults)
  	# Use uppercase naming scheme, don't delete config files under fakeroot.
  	sed -e "/import config_dir/,/os.rmdir(config_dir)/d" \
-@@ -116,7 +117,7 @@ build() {
+@@ -118,8 +119,10 @@ build() {
  check() {
  	cd "$_archive"
  	export LANG='en_US.UTF-8'
 -	python setup.py test --under-sanitize --exclude-test-name test_piper
+-	python setup.py test_rs
 +	python setup.py test --under-sanitize --exclude-test-name test_piper --exclude-test-name test_7z
- 	python setup.py test_rs
++	# Skip tests on loong64: test_rs hangs due to QRhiGles2/Vulkan context creation failures
++	# and missing D-Bus socket in build env. It should have no impact on runtime functionality.
++	#python setup.py test_rs
  }
  
-@@ -140,3 +141,6 @@ package() {
+ package() {
+@@ -142,3 +145,6 @@ package() {
  		python -O -m compileall -d "${_destdir}" "${_file}"
  	done < <(find "$pkgdir/usr/lib/" -name '*.py' -print0)
  }


### PR DESCRIPTION
* Skip test_rs on loong64: test_rs hangs due to QRhiGles2/Vulkan context creation failures and missing D-Bus socket in build env. There shoule be no impact on runtime functionality.