### PR TITLE
updpatch: docker, ver=1:28.5.0-1.1

### DIFF
--- a/docker/loong.patch
+++ b/docker/loong.patch
@@ -1,8 +1,8 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index e43b0ec..d00689f 100644
+index 3f1bcb5..31b5ab5 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -74,6 +74,7 @@ build() {
+@@ -73,6 +73,7 @@ build() {
    export LDFLAGS=''
    export GOFLAGS='-buildmode=pie -trimpath -mod=readonly -modcacherw -ldflags=-linkmode=external -ldflags=-compressdwarf=false -ldflags=-B=gobuildid'
    export GO111MODULE=off
@@ -10,3 +10,16 @@ index e43b0ec..d00689f 100644
    export DISABLE_WARN_OUTSIDE_CONTAINER=1
  
    ### cli
+@@ -126,4 +127,12 @@ package() {
+   cp -r man/man* "$pkgdir/usr/share/man"
+ }
+ 
++prepare() {
++  patch -Np1 -d moby -i "${srcdir}/moby-add-support-for-loong64-seccomp.patch"
++}
++
++# https://github.com/moby/moby/pull/45302
++source+=("moby-add-support-for-loong64-seccomp.patch")
++sha256sums+=('b23660637531b49842cf0955c24ffe8c3042dcd5f563299beefb48ef62e48eab')
++
+ # vim:set ts=2 sw=2 et:

--- a/docker/moby-add-support-for-loong64-seccomp.patch
+++ b/docker/moby-add-support-for-loong64-seccomp.patch
@@ -1,0 +1,57 @@
+diff --git a/vendor/github.com/moby/profiles/seccomp/default.json b/vendor/github.com/moby/profiles/seccomp/default.json
+index dafe5cf6a6a3e..45a9a276dc2d3 100644
+--- a/vendor/github.com/moby/profiles/seccomp/default.json
++++ b/vendor/github.com/moby/profiles/seccomp/default.json
+@@ -52,6 +52,10 @@
+ 		{
+ 			"architecture": "SCMP_ARCH_RISCV64",
+ 			"subArchitectures": null
++		},
++		{
++			"architecture": "SCMP_ARCH_LOONGARCH64",
++			"subArchitectures": null
+ 		}
+ 	],
+ 	"syscalls": [
+@@ -842,4 +846,4 @@
+ 			}
+ 		}
+ 	]
+-}
+\ No newline at end of file
++}
+diff --git a/vendor/github.com/moby/profiles/seccomp/default_linux.go b/vendor/github.com/moby/profiles/seccomp/default_linux.go
+index 26c50c342e7d3..93b57962fc8b6 100644
+--- a/vendor/github.com/moby/profiles/seccomp/default_linux.go
++++ b/vendor/github.com/moby/profiles/seccomp/default_linux.go
+@@ -39,6 +39,10 @@ func arches() []Architecture {
+ 			Arch:      specs.ArchRISCV64,
+ 			SubArches: nil,
+ 		},
++		{
++			Arch:      specs.ArchLOONGARCH64,
++			SubArches: nil,
++		},
+ 	}
+ }
+ 
+diff --git a/vendor/github.com/moby/profiles/seccomp/seccomp_linux.go b/vendor/github.com/moby/profiles/seccomp/seccomp_linux.go
+index 92d4c188ba784..04da61278f6e9 100644
+--- a/vendor/github.com/moby/profiles/seccomp/seccomp_linux.go
++++ b/vendor/github.com/moby/profiles/seccomp/seccomp_linux.go
+@@ -42,6 +42,7 @@ var nativeToSeccomp = map[string]specs.Arch{
+ 	"riscv64":     specs.ArchRISCV64,
+ 	"s390":        specs.ArchS390,
+ 	"s390x":       specs.ArchS390X,
++	"loong64":     specs.ArchLOONGARCH64,
+ }
+ 
+ // GOARCH => libseccomp string
+@@ -61,6 +62,7 @@ var goToNative = map[string]string{
+ 	"riscv64":     "riscv64",
+ 	"s390":        "s390",
+ 	"s390x":       "s390x",
++	"loong64":     "loong64",
+ }
+ 
+ // inSlice tests whether a string is contained in a slice of strings or not.


### PR DESCRIPTION
* Add seccomp support for LoongArch64 in moby
* Backport https://github.com/moby/moby/pull/45302