### PR TITLE
addpatch: anari-sdk, ver=0.13.1-1

### DIFF
--- a/anari-sdk/loong.patch
+++ b/anari-sdk/loong.patch
@@ -1,0 +1,12 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 43888a1..eb0b9d2 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -17,6 +17,7 @@ sha256sums=('cbcbe8a3ead5fb88b9a91d629316d334f284fb7efdf9c83b1b09bfde3738f419')
+ 
+ build() {
+   cmake -B build -S ANARI-SDK \
++    -DBUILD_HELIDE_DEVICE=OFF \
+     -DCMAKE_INSTALL_PREFIX=/usr
+   cmake --build build
+ }


### PR DESCRIPTION
Refer to archriscv: https://github.com/felixonmars/archriscv-packages/commit/6666a2aa0aab9dd0ec4fd6bf7e2544c67b386638

> Disable BUILD_HELIDE_DEVICE because it depends on embree which we
> haven't ported yet (and which seems to require ispc).
>
> This package is an opt&make dependency for vtk