### PR TITLE
updpatch: qt6-webengine, ver=6.10.0-1

### DIFF
--- a/qt6-webengine/add-loong64-support.patch
+++ b/qt6-webengine/add-loong64-support.patch
@@ -74,13 +74,13 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
 --- a/qtwebengine/src/3rdparty/chromium/extensions/browser/api/declarative_net_request/BUILD.gn	2000-01-01 00:00:00.000000000 +0800
 +++ b/qtwebengine/src/3rdparty/chromium/extensions/browser/api/declarative_net_request/BUILD.gn	2000-01-01 00:00:00.000000000 +0800
 @@ -19,6 +19,7 @@ source_set("declarative_net_request") {
-   deps = [
+   public_deps = [
      "//base",
      "//content/public/browser",
 +    "//components/web_cache/public/mojom",
+     "//extensions/browser:browser_sources",
      "//extensions/common",
      "//extensions/common/api",
-     "//services/preferences/public/cpp",
 diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/sandbox/features.gni b/qtwebengine/src/3rdparty/chromium/sandbox/features.gni
 --- a/qtwebengine/src/3rdparty/chromium/sandbox/features.gni	2000-01-01 00:00:00.000000000 +0800
 +++ b/qtwebengine/src/3rdparty/chromium/sandbox/features.gni	2000-01-01 00:00:00.000000000 +0800
@@ -3401,9 +3401,9 @@ diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r
  #else
  #error Port
  #endif
-diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/rollup.config.js b/qtwebengine/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/rollup.config.js
---- a/qtwebengine/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/rollup.config.js	2000-01-01 00:00:00.000000000 +0800
-+++ b/qtwebengine/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/rollup.config.js	2000-01-01 00:00:00.000000000 +0800
+diff '--color=auto' -p -X ../chromium-loongarch64/qt6-webengine/exclude -N -u -r a/qtwebengine/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/rollup.config.,js b/qtwebengine/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/rollup.config.mjs
+--- a/qtwebengine/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/rollup.config.mjs	2000-01-01 00:00:00.000000000 +0800
++++ b/qtwebengine/src/3rdparty/chromium/third_party/devtools-frontend/src/scripts/build/rollup.config.mjs	2000-01-01 00:00:00.000000000 +0800
 @@ -19,7 +19,7 @@ export default commandLineArgs => ({
      sourcemap: Boolean(commandLineArgs.configSourcemaps),
    }],

--- a/qt6-webengine/loong.patch
+++ b/qt6-webengine/loong.patch
@@ -1,8 +1,8 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index e4826ef..e439fe8 100644
+index f3d6cc8..f7a95d9 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -98,6 +98,12 @@ prepare() {
+@@ -95,6 +95,12 @@ prepare() {
    # Bump chromium to head of stable branch
    cd src/3rdparty
    [[ -n $_chromium ]] && git checkout $_chromium || true
@@ -15,12 +15,14 @@ index e4826ef..e439fe8 100644
  }
  
  build() {
-@@ -119,3 +125,8 @@ package() {
+@@ -116,3 +122,10 @@ package() {
  
    install -Dm644 "$srcdir"/${_pkgfn}/src/3rdparty/chromium/LICENSE "$pkgdir"/usr/share/licenses/${pkgname}/LICENSE.chromium
  }
 +
 +source+=("add-loong64-support.patch")
-+sha256sums+=('1dcdb5421df854cfc1dbbd977ae718ddfe58a5375fe20223b9a0f900682b52bf')
++sha256sums+=('7f1941b42851e568900a261eab8f15c1a743b987965e98c168d6298ef3b97a92')
 +# Temporarily switch to mold to workaround with binutils's bfd's bug
 +makedepends+=(mold)
++# Switch to LTS nodejs to build
++makedepends+=(nodejs-lts-jod)


### PR DESCRIPTION
* Rebase to Qt 6.10 and chromium 134
* Use nodejs-lts-jod to build to avoid compile-time error:
```
TypeError: Cannot read properties of undefined (reading 'kind')
```