### PR TITLE
updpatch: chromium, ver=141.0.7390.76-1

### DIFF
--- a/chromium/chromium-loong64-support.patch
+++ b/chromium/chromium-loong64-support.patch
@@ -668,15 +668,15 @@ diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sa
 diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/services/credentials.cc b/sandbox/linux/services/credentials.cc
 --- a/sandbox/linux/services/credentials.cc	2000-01-01 00:00:00.000000000 +0800
 +++ b/sandbox/linux/services/credentials.cc	2000-01-01 00:00:00.000000000 +0800
-@@ -90,7 +90,7 @@ bool ChrootToSafeEmptyDir() {
-   alignas(16) char stack_buf[PTHREAD_STACK_MIN_CONST];
+@@ -85,7 +85,7 @@
+   alignas(16) std::array<char, PTHREAD_STACK_MIN_CONST> stack_buf;
  
  #if defined(ARCH_CPU_X86_FAMILY) || defined(ARCH_CPU_ARM_FAMILY) || \
 -    defined(ARCH_CPU_MIPS_FAMILY)
 +    defined(ARCH_CPU_MIPS_FAMILY) || defined(ARCH_CPU_LOONGARCH_FAMILY)
-   // The stack grows downward.
-   void* stack = stack_buf + sizeof(stack_buf);
- #else
+   // SAFETY: This is the `stack` argument of `clone(2)`. Because the stack grows
+   // downward on these architectures, this is the topmost address of the memory
+   // space for the stack, and the address will not be dereferenced.
 diff '--color=auto' -p -X ../chromium-loongarch64/chromium/exclude -N -u -r a/sandbox/linux/services/syscall_wrappers.cc b/sandbox/linux/services/syscall_wrappers.cc
 --- a/sandbox/linux/services/syscall_wrappers.cc	2000-01-01 00:00:00.000000000 +0800
 +++ b/sandbox/linux/services/syscall_wrappers.cc	2000-01-01 00:00:00.000000000 +0800

--- a/chromium/compiler-rt-adjust-paths-loong64.patch
+++ b/chromium/compiler-rt-adjust-paths-loong64.patch
@@ -1,0 +1,34 @@
+--- a/build/config/clang/BUILD.gn
++++ b/build/config/clang/BUILD.gn
+@@ -170,17 +170,17 @@
+         _dir = "darwin"
+       } else if (is_linux || is_chromeos) {
+         if (current_cpu == "x64") {
+-          _dir = "x86_64-unknown-linux-gnu"
++          _suffix = "-x86_64"
+         } else if (current_cpu == "x86") {
+-          _dir = "i386-unknown-linux-gnu"
++          _suffix = "-i386"
+         } else if (current_cpu == "arm") {
+           _dir = "armv7-unknown-linux-gnueabihf"
+         } else if (current_cpu == "arm64") {
+-          _dir = "aarch64-unknown-linux-gnu"
++          _suffix = "-aarch64"
+         } else if (current_cpu == "loong64") {
+-          _dir = "loongarch64-unknown-linux-gnu"
++          _suffix = "-loongarch64"
+         } else if (current_cpu == "riscv64") {
+-          _dir = "riscv64-unknown-linux-gnu"
++          _suffix = "-riscv64"
+         } else if (current_cpu == "ppc64") {
+           _dir = "ppc64le-unknown-linux-gnu"
+         } else if (current_cpu == "s390x") {
+@@ -188,6 +188,8 @@
+         } else {
+           assert(false)  # Unhandled cpu type
+         }
++
++        _dir = "linux"
+       } else if (is_fuchsia) {
+         if (current_cpu == "x64") {
+           _dir = "x86_64-unknown-fuchsia"

--- a/chromium/loong.patch
+++ b/chromium/loong.patch
@@ -1,5 +1,5 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 632c907..e336c8b 100644
+index 33ab151..73baef9 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
 @@ -27,6 +27,7 @@ optdepends=('pipewire: WebRTC desktop sharing under Wayland'
@@ -10,7 +10,7 @@ index 632c907..e336c8b 100644
  source=(https://commondatastorage.googleapis.com/chromium-browser-official/chromium-$pkgver-lite.tar.xz
          https://github.com/foutrelis/chromium-launcher/archive/v$_launcher_ver/chromium-launcher-$_launcher_ver.tar.gz
          chromium-138-nodejs-version-check.patch
-@@ -47,6 +48,8 @@ sha256sums=('02a0d17f811bb780e5b81bb457200bf1c95a49a78ce7e023d0367c30c38fda7c'
+@@ -47,6 +48,8 @@ sha256sums=('720a1196410080056cd97a1f5ec34d68ba216a281d9b5157b7ea81ea018ec661'
  if (( _manual_clone )); then
    source[0]=fetch-chromium-release
    makedepends+=('python-httplib2' 'python-pyparsing' 'python-six' 'npm' 'rsync')
@@ -19,18 +19,22 @@ index 632c907..e336c8b 100644
  fi
  
  # Possible replacements are listed in build/linux/unbundle/replace_gn_files.py
-@@ -122,6 +125,10 @@ prepare() {
-   # Allow libclang_rt.builtins from compiler-rt >= 16 to be used
-   patch -Np1 -i ../compiler-rt-adjust-paths.patch
+@@ -120,7 +123,13 @@ prepare() {
+   patch -Np1 -i ../chromium-138-rust-1.86-mismatched_lifetime_syntaxes.patch
  
+   # Allow libclang_rt.builtins from compiler-rt >= 16 to be used
+-  patch -Np1 -i ../compiler-rt-adjust-paths.patch
++  #patch -Np1 -i ../compiler-rt-adjust-paths.patch
++  # Arch Linux upstream's patch failed on loong64
++  patch -Np1 -i ../compiler-rt-adjust-paths-loong64.patch
++
 +  # Patches for loong64
 +  patch -Np1 -i "${srcdir}/chromium-loong64-support.patch"
 +  patch -Np1 -i "${srcdir}/allow-sched_getaffinity-in-seccomp-for-loong64.patch"
-+
+ 
    # Increase _FORTIFY_SOURCE level to match Arch's default flags
    patch -Np1 -i ../increase-fortify-level.patch
- 
-@@ -256,6 +263,9 @@ build() {
+@@ -256,6 +265,9 @@ build() {
    # https://crbug.com/957519#c122
    CXXFLAGS=${CXXFLAGS/-Wp,-D_GLIBCXX_ASSERTIONS}
  
@@ -40,13 +44,15 @@ index 632c907..e336c8b 100644
    gn gen out/Release --args="${_flags[*]}"
    ninja -C out/Release chrome chrome_sandbox chromedriver.unstripped
  }
-@@ -331,4 +341,9 @@ package() {
+@@ -331,4 +343,11 @@ package() {
    install -Dm644 LICENSE "$pkgdir/usr/share/licenses/chromium/LICENSE"
  }
  
 +source+=("chromium-loong64-support.patch"
-+         "allow-sched_getaffinity-in-seccomp-for-loong64.patch")
-+sha256sums+=('25756af6b3d96f5b2a74e1b53fd79d4e6afe1a855050aee3987cf5118e8c13ea'
-+             'b48d40e93f020b5e8861f1f320437984d8f7d62c568ad1995af78e49e88de7a9')
++         "allow-sched_getaffinity-in-seccomp-for-loong64.patch"
++         "compiler-rt-adjust-paths-loong64.patch")
++sha256sums+=('66347afbeb8cab166adec404b7671ddba566cfa589670e51db3d027a18dd8c25'
++             'b48d40e93f020b5e8861f1f320437984d8f7d62c568ad1995af78e49e88de7a9'
++             '71f996db9d83c851b64db968e7883af46102d0cd7593db7d3fdf037a2c010c8b')
 +
  # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
* Rebase to chromium 141
* Re-introduce our compiler-rt-adjust-paths-loong64.patch since upstrean compiler-rt-adjust-paths.patch failed on loong64