### PR TITLE
addpatch: elvish, ver=0.21.0-1

### DIFF
--- a/elvish/loong.patch
+++ b/elvish/loong.patch
@@ -1,0 +1,13 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index d3f589b..9ac584e 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -53,7 +53,7 @@ build() {
+ check() {
+   cd "$pkgname"
+   build/elvish --version | grep -Fqx "$pkgver+$_variant"
+-  go test -v -race ./...
++  go test -v ./...
+ }
+ 
+ package() {


### PR DESCRIPTION
* Disable `-race` in go test args that doesn't support loong64