### PR TITLE
addpatch: ghc, ver=9.6.6-1

### DIFF
--- a/ghc/hadrian-enable-interpreter.patch
+++ b/ghc/hadrian-enable-interpreter.patch
@@ -1,0 +1,39 @@
+Description: Enable GHCi on all platforms in Debian
+Author: Ilias Tsitsimpis <iliastsi@debian.org>
+Bug: https://gitlab.haskell.org/ghc/ghc/-/issues/24098
+
+Index: b/hadrian/src/Oracles/Setting.hs
+===================================================================
+--- a/hadrian/src/Oracles/Setting.hs
++++ b/hadrian/src/Oracles/Setting.hs
+@@ -292,13 +292,8 @@ hostSupportsRPaths = anyHostOs ["linux",
+ -- | Check whether the target supports GHCi.
+ ghcWithInterpreter :: Action Bool
+ ghcWithInterpreter = do
+-    goodOs <- anyTargetOs [ "mingw32", "cygwin32", "linux", "solaris2"
+-                          , "freebsd", "dragonfly", "netbsd", "openbsd"
+-                          , "darwin", "kfreebsdgnu" ]
+-    goodArch <- anyTargetArch [ "i386", "x86_64", "powerpc"
+-                              , "arm", "aarch64", "s390x"
+-                              , "powerpc64", "powerpc64le" ]
+-    return $ goodOs && goodArch
++    -- Enable GHCi on all platforms for Debian
++    return True
+ 
+ -- | Variants of the ARM architecture.
+ data ArmVersion = ARMv5 | ARMv6 | ARMv7
+Index: b/hadrian/bindist/config.mk.in
+===================================================================
+--- a/hadrian/bindist/config.mk.in
++++ b/hadrian/bindist/config.mk.in
+@@ -140,8 +140,8 @@ GhcWithSMP := $(strip $(if $(filter YESN
+ 
+ # Whether to include GHCi in the compiler.  Depends on whether the RTS linker
+ # has support for this OS/ARCH combination.
+-OsSupportsGHCi=$(strip $(patsubst $(TargetOS_CPP), YES, $(findstring $(TargetOS_CPP), mingw32 linux solaris2 freebsd dragonfly netbsd openbsd darwin kfreebsdgnu)))
+-ArchSupportsGHCi=$(strip $(patsubst $(TargetArch_CPP), YES, $(findstring $(TargetArch_CPP), i386 x86_64 powerpc powerpc64 powerpc64le sparc sparc64 arm aarch64)))
++OsSupportsGHCi=YES
++ArchSupportsGHCi=YES
+ 
+ ifeq "$(OsSupportsGHCi)$(ArchSupportsGHCi)" "YESYES"
+ GhcWithInterpreter=YES

--- a/ghc/llvm-new-pass-manager.patch
+++ b/ghc/llvm-new-pass-manager.patch
@@ -1,0 +1,77 @@
+commit 77db84aba1ba00f6d146e9107b24c6203798e796
+Author: Ben Gamari <bgamari.foss@gmail.com>
+Date:   Wed Jan 31 08:58:58 2024 -0500
+
+    llvmGen: Adapt to allow use of new pass manager.
+    
+    We now must use `-passes` in place of `-O<n>` due to #21936.
+    
+    Closes #21936.
+
+Index: b/compiler/GHC/Driver/Session.hs
+===================================================================
+--- a/compiler/GHC/Driver/Session.hs
++++ b/compiler/GHC/Driver/Session.hs
+@@ -3430,7 +3430,6 @@ fFlagsDeps = [
+   flagSpec "late-dmd-anal"                    Opt_LateDmdAnal,
+   flagSpec "late-specialise"                  Opt_LateSpecialise,
+   flagSpec "liberate-case"                    Opt_LiberateCase,
+-  flagHiddenSpec "llvm-tbaa"                  Opt_LlvmTBAA,
+   flagHiddenSpec "llvm-fill-undef-with-garbage" Opt_LlvmFillUndefWithGarbage,
+   flagSpec "loopification"                    Opt_Loopification,
+   flagSpec "block-layout-cfg"                 Opt_CfgBlocklayout,
+@@ -3989,7 +3988,6 @@ optLevelFlags :: [([Int], GeneralFlag)]
+ optLevelFlags -- see Note [Documenting optimisation flags]
+   = [ ([0,1,2], Opt_DoLambdaEtaExpansion)
+     , ([0,1,2], Opt_DoEtaReduction)       -- See Note [Eta-reduction in -O0]
+-    , ([0,1,2], Opt_LlvmTBAA)
+     , ([0,1,2], Opt_ProfManualCcs )
+     , ([2], Opt_DictsStrict)
+ 
+Index: b/compiler/GHC/Driver/Flags.hs
+===================================================================
+--- a/compiler/GHC/Driver/Flags.hs
++++ b/compiler/GHC/Driver/Flags.hs
+@@ -273,7 +273,6 @@ data GeneralFlag
+    | Opt_RegsGraph                      -- do graph coloring register allocation
+    | Opt_RegsIterative                  -- do iterative coalescing graph coloring register allocation
+    | Opt_PedanticBottoms                -- Be picky about how we treat bottom
+-   | Opt_LlvmTBAA                       -- Use LLVM TBAA infrastructure for improving AA (hidden flag)
+    | Opt_LlvmFillUndefWithGarbage       -- Testing for undef bugs (hidden flag)
+    | Opt_IrrefutableTuples
+    | Opt_CmmSink
+@@ -508,7 +507,6 @@ optimisationFlags = EnumSet.fromList
+    , Opt_EnableRewriteRules
+    , Opt_RegsGraph
+    , Opt_RegsIterative
+-   , Opt_LlvmTBAA
+    , Opt_IrrefutableTuples
+    , Opt_CmmSink
+    , Opt_CmmElimCommonBlocks
+Index: b/compiler/GHC/Driver/Pipeline/Execute.hs
+===================================================================
+--- a/compiler/GHC/Driver/Pipeline/Execute.hs
++++ b/compiler/GHC/Driver/Pipeline/Execute.hs
+@@ -989,8 +989,7 @@ llvmOptions :: LlvmConfig
+             -> DynFlags
+             -> [(String, String)]  -- ^ pairs of (opt, llc) arguments
+ llvmOptions llvm_config dflags =
+-       [("-enable-tbaa -tbaa",  "-enable-tbaa") | gopt Opt_LlvmTBAA dflags ]
+-    ++ [("-relocation-model=" ++ rmodel
++       [("-relocation-model=" ++ rmodel
+         ,"-relocation-model=" ++ rmodel) | not (null rmodel)]
+     ++ [("-stack-alignment=" ++ (show align)
+         ,"-stack-alignment=" ++ (show align)) | align > 0 ]
+Index: b/llvm-passes
+===================================================================
+--- a/llvm-passes
++++ b/llvm-passes
+@@ -1,5 +1,5 @@
+ [
+-(0, "-enable-new-pm=0 -mem2reg -globalopt -lower-expect"),
+-(1, "-enable-new-pm=0 -O1 -globalopt"),
+-(2, "-enable-new-pm=0 -O2")
++(0, "-passes=function(require<tbaa>),function(mem2reg),globalopt,function(lower-expect)"),
++(1, "-passes=default<O1>"),
++(2, "-passes=default<O2>")
+ ]

--- a/ghc/loong.patch
+++ b/ghc/loong.patch
@@ -1,0 +1,57 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 69700b6..967eaf8 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -40,6 +40,13 @@ prepare() {
+ 
+   # detects GCC correctly
+   sed -i 's/grep -q gcc/grep -qi gcc/' m4/fp_gcc_version.m4
++
++  # Bump max LLVM version
++  patch -Np1 -i "${srcdir}/llvm-new-pass-manager.patch"
++  sed -i 's/LlvmMaxVersion=[0-9]\+ \(# not inclusive\)/LlvmMaxVersion=19 \1/' configure.ac
++  # Enable GHCi on all platforms
++  patch -Np1 -i "${srcdir}/hadrian-enable-interpreter.patch"
++  autoreconf -fiv
+ }
+ 
+ build() {
+@@ -79,7 +86,7 @@ package_ghc-static() {
+ 
+ package_ghc() {
+   pkgdesc='The Glasgow Haskell Compiler'
+-  depends=('gcc' 'ghc-libs')
++  depends=('gcc' 'ghc-libs' 'llvm18')
+   provides=('haskell-haddock=2.29.2'
+             'haskell-hp2ps=0.1'
+             'haskell-hpc-bin=0.68'
+@@ -102,7 +109,7 @@ package_ghc() {
+   rm "$pkgdir"/usr/lib/ghc-$pkgver/bin/ghc-pkg*
+   rm "$pkgdir"/usr/bin/ghc-pkg*
+   (cd "$pkgdir"/usr/lib/ghc-$pkgver/lib; rm -r package.conf.d)
+-  (cd "$pkgdir"/usr/lib/ghc-$pkgver/lib/$CARCH-linux-ghc-$pkgver; rm -r !(ghc-$pkgver|libHSghc-$pkgver-ghc$pkgver.so))
++  (cd "$pkgdir"/usr/lib/ghc-$pkgver/lib/$(uname -m)-linux-ghc-$pkgver; rm -r !(ghc-$pkgver|libHSghc-$pkgver-ghc$pkgver.so))
+ 
+   # docs moved to ghc-static
+   rm -r "$pkgdir"/usr/share/doc
+@@ -195,9 +202,9 @@ package_ghc-libs() {
+   find "$pkgdir"/usr/lib \( -name "*.a" -o -name "*.o" -o -name "*.p_o" -o -name "*.p_hi" -o -name "*.hi" \) -delete
+ 
+   # ghc library, headers, and other exes are in the ghc package
+-  rm -r "$pkgdir"/usr/lib/ghc-$pkgver/lib/$CARCH-linux-ghc-$pkgver/{ghc-$pkgver,libHSghc-$pkgver-ghc$pkgver.so}
++  rm -r "$pkgdir"/usr/lib/ghc-$pkgver/lib/$(uname -m)-linux-ghc-$pkgver/{ghc-$pkgver,libHSghc-$pkgver-ghc$pkgver.so}
+   (cd "$pkgdir"/usr/lib/ghc-$pkgver/bin; rm !(ghc-pkg*))
+-  (cd "$pkgdir"/usr/lib/ghc-$pkgver/lib; rm -r !(package.conf.d|$CARCH-linux-ghc-$pkgver))
++  (cd "$pkgdir"/usr/lib/ghc-$pkgver/lib; rm -r !(package.conf.d|$(uname -m)-linux-ghc-$pkgver))
+   rm "$pkgdir"/usr/lib/ghc-$pkgver/lib/package.conf.d/*.copy
+   (cd "$pkgdir"/usr/bin; rm !(ghc-pkg*))
+ 
+@@ -211,3 +218,8 @@ package_ghc-libs() {
+ 
+   install -Dm644 LICENSE "$pkgdir"/usr/share/licenses/$pkgname/LICENSE
+ }
++
++source+=("llvm-new-pass-manager.patch"
++         "hadrian-enable-interpreter.patch")
++sha512sums+=('4d749221c73884669d71eb68e30da93da7e8238accdba372b0d5df9f60e916aed755aef77e9b14303dd9e6b944b8f26630c4f12d56ab5de0303ec8caf8bef478'
++             '6e7c9d3e4844bfd63ec3b28efce6d99c753edf3ffd84023bb15fe3374fc3ccae99bb8999ac3980f234ae1bc5072f8f81a3ca215c2daa19ac3eae1da6d34eebb7')


### PR DESCRIPTION
* Force to use LLVM18 backend and adapt GHC for LLVM 18 pass manager
  * Upstream GHC 9.6 only supports up to LLVM15, which doesn't have LoongArch64 support
  * LLVM18 is the closest version in our repo
  * llvm-new-pass-manager.patch
  * Reference: https://sources.debian.org/src/ghc/9.6.6-4/debian/patches/llvm-new-pass-manager
* Enable GHCi on all platforms
  * hadrian-enable-interpreter.patch
  * Reference: https://gitlab.haskell.org/ghc/ghc/-/issues/24098
  * Reference: https://sources.debian.org/src/ghc/9.6.6-4/debian/patches/hadrian-enable-interpreter
* Fix dynamic architecture detection replacing `$CARCH` with `$(uname -m)`