### PR TITLE
updpatch: nodejs, ver=25.0.0-1

### DIFF
--- a/nodejs/loong.patch
+++ b/nodejs/loong.patch
@@ -1,31 +1,30 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 0f1d08c..b0d34d1 100644
+index 3f3a81e..b43f2fb 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
 @@ -58,6 +58,8 @@ build() {
    _set_flags
    cd node
  
-+  patch -Np1 -d deps/v8 -i "${srcdir}/v8-use-a-zone-to-track-unresolved-branches.patch"
++  patch -Np1 -i "${srcdir}/v8-loong64-codetype-fix.patch"
 +
    ./configure \
      --prefix=/usr \
      --without-npm \
-@@ -93,6 +95,9 @@ check() {
-   rm test/parallel/test-http2-max-invalid-frames.js
-   rm test/parallel/test-http2-misbehaving-flow-control-paused.js
-   rm test/client-proxy/test-http-proxy-request-no-proxy-port-specific.mjs
-+  # Ignore tests failed on loong64
+@@ -92,6 +94,8 @@ check() {
+   rm test/parallel/test-http2-priority-event.js
+   rm test/parallel/test-http2-reset-flood.js
+   rm test/parallel/test-tls-ocsp-callback.js
 +  rm -f test/parallel/test-dgram-send-cb-quelches-error.js
 +  rm -f test/parallel/test-net-autoselectfamily.js
    make test-only
  }
  
-@@ -103,4 +108,7 @@ package() {
+@@ -102,4 +106,7 @@ package() {
    install -Dm644 LICENSE -t "$pkgdir"/usr/share/licenses/nodejs/
  }
  
-+source+=("v8-use-a-zone-to-track-unresolved-branches.patch::https://github.com/v8/v8/commit/144ebfdb3e25331a67aee40f58970bf0050b7b2d.diff")
-+sha512sums+=('76b9a065ba2c82dee0eeb4b6f45b841804d3ea47a0b0a05de27b09272e7e10ef6dc7ae837e874145ab3c14f555af9fb180edd0a695a99a1f3ce5ccdd03de61c1')
++source+=(v8-loong64-codetype-fix.patch)
++sha512sums+=('26c84d44083eb7e6cf82add949d29a0b00eba1d196284e84ef05cde5e7434d6270cb9a954c4e0fa9c6785156cee4ea02c266f6f0225168aaaafd791a0a6358c0')
 +
  # vim:set ts=2 sw=2 et:

--- a/nodejs/v8-loong64-codetype-fix.patch
+++ b/nodejs/v8-loong64-codetype-fix.patch
@@ -1,0 +1,11 @@
+--- a/deps/v8/src/builtins/loong64/builtins-loong64.cc
++++ b/deps/v8/src/builtins/loong64/builtins-loong64.cc
+@@ -328,7 +328,7 @@
+     if (v8_flags.debug_code) {
+       Label not_baseline;
+       __ GetObjectType(data, scratch1, scratch1);
+-      __ Branch(&not_baseline, ne, scratch1, Operand(CODETYPE));
++      __ Branch(&not_baseline, ne, scratch1, Operand(CODE_TYPE));
+       AssertCodeIsBaseline(masm, data, scratch1);
+       __ Branch(is_baseline);
+       __ bind(&not_baseline);


### PR DESCRIPTION
* Upstream has included v8-use-a-zone-to-track-unresolved-branches.patch so we don't need this patch anymore
* Fix builtins-loong64.cc that were not synchronized to use CODE_TYPE instead of CODETYPE
* Disable some failed tests of low risk