### PR TITLE
addpatch: gemini-cli, ver=1:0.16.0-1

### DIFF
--- a/gemini-cli/loong.patch
+++ b/gemini-cli/loong.patch
@@ -1,0 +1,10 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 7a026ca..f055f12 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -30,3 +30,5 @@ package() {
+   rm "$pkgdir/usr/lib/node_modules/@google/gemini-cli/node_modules/shell-quote/print.py"
+   rm "$pkgdir/usr/lib/node_modules/@google/gemini-cli/node_modules/open/xdg-open"
+ }
++
++makedepends+=(python)


### PR DESCRIPTION
* No prebuilt tree-sitter-bash for loong64 and requires python to build