### PR TITLE
updpatch: rocm-llvm, ver=2:7.1.0-1

### DIFF
--- a/rocm-llvm/0001-rocm-llvm-define-nansq.patch
+++ b/rocm-llvm/0001-rocm-llvm-define-nansq.patch
@@ -1,0 +1,37 @@
+diff --git a/clang/include/clang/Basic/Builtins.td b/clang/include/clang/Basic/Builtins.td
+index 29939242596b..16a8a40cdbfa 100644
+--- a/clang/include/clang/Basic/Builtins.td
++++ b/clang/include/clang/Basic/Builtins.td
+@@ -314,7 +314,7 @@ def NanF16 : Builtin {
+ }
+
+ def NanF128 : Builtin {
+-  let Spellings = ["__builtin_nanf128"];
++  let Spellings = ["__builtin_nanf128", "__builtin_nansq"];
+   let Attributes = [FunctionWithBuiltinPrefix, NoThrow, Pure, Constexpr];
+   let Prototype = "__float128(char const*)";
+ }
+diff --git a/clang/lib/AST/ByteCode/InterpBuiltin.cpp b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+index e657dbd2f9c7..a32a0718377d 100644
+--- a/clang/lib/AST/ByteCode/InterpBuiltin.cpp
++++ b/clang/lib/AST/ByteCode/InterpBuiltin.cpp
+@@ -2097,6 +2097,7 @@ bool InterpretBuiltin(InterpState &S, CodePtr OpPC, const Function *F,
+     break;
+   case Builtin::BI__builtin_nans:
+   case Builtin::BI__builtin_nansf:
++  case Builtin::BI__builtin_nansq:
+   case Builtin::BI__builtin_nansl:
+   case Builtin::BI__builtin_nansf16:
+   case Builtin::BI__builtin_nansf128:
+diff --git a/clang/lib/AST/ExprConstant.cpp b/clang/lib/AST/ExprConstant.cpp
+index 0e41e3dbc8a3..7bd707edf578 100644
+--- a/clang/lib/AST/ExprConstant.cpp
++++ b/clang/lib/AST/ExprConstant.cpp
+@@ -15541,6 +15541,7 @@ bool FloatExprEvaluator::VisitCallExpr(const CallExpr *E) {
+
+   case Builtin::BI__builtin_nans:
+   case Builtin::BI__builtin_nansf:
++  case Builtin::BI__builtin_nansq:
+   case Builtin::BI__builtin_nansl:
+   case Builtin::BI__builtin_nansf16:
+   case Builtin::BI__builtin_nansf128:

--- a/rocm-llvm/0002-llvm-loongarch64-change-default-code-model.patch
+++ b/rocm-llvm/0002-llvm-loongarch64-change-default-code-model.patch
@@ -1,0 +1,24 @@
+From 2d876ed33ee38145ae7b44f3d82a8142a78fd5b8 Mon Sep 17 00:00:00 2001
+From: hev <wangrui@loongson.cn>
+Date: Fri, 21 Mar 2025 10:15:31 +0800
+Subject: [PATCH] [llvm][LoongArch] Changing the default code model from
+ `small` to `medium` for 64-bit (#132173)
+
+Link: https://discourse.llvm.org/t/rfc-changing-the-default-code-model-for-loongarch
+---
+ .../LoongArch/LoongArchTargetMachine.cpp      |   2 +-
+ 1 files changed, 1 insertions(+), 1 deletions(-)
+
+diff --git a/llvm/lib/Target/LoongArch/LoongArchTargetMachine.cpp b/llvm/lib/Target/LoongArch/LoongArchTargetMachine.cpp
+index 62b08be5435cd..692392dc2bae0 100644
+--- a/llvm/lib/Target/LoongArch/LoongArchTargetMachine.cpp
++++ b/llvm/lib/Target/LoongArch/LoongArchTargetMachine.cpp
+@@ -70,7 +70,7 @@ static CodeModel::Model
+ getEffectiveLoongArchCodeModel(const Triple &TT,
+                                std::optional<CodeModel::Model> CM) {
+   if (!CM)
+-    return CodeModel::Small;
++    return TT.isArch64Bit() ? CodeModel::Medium : CodeModel::Small;
+
+   switch (*CM) {
+   case CodeModel::Small:

--- a/rocm-llvm/0003-rocm-llvm-loongarch64-feature-support.patch
+++ b/rocm-llvm/0003-rocm-llvm-loongarch64-feature-support.patch
@@ -1,0 +1,317 @@
+diff --git a/clang/docs/LanguageExtensions.rst b/clang/docs/LanguageExtensions.rst
+index 4cfc574274da..ea2898dc8080 100644
+--- a/clang/docs/LanguageExtensions.rst
++++ b/clang/docs/LanguageExtensions.rst
+@@ -980,6 +980,7 @@ to ``float``; see below for more information on this emulation.
+   * SPIR (natively)
+   * X86 (if SSE2 is available; natively if AVX512-FP16 is also available)
+   * RISC-V (natively if Zfh or Zhinx is available)
++  * LoongArch (emulated)
+ 
+ * ``__bf16`` is supported on the following targets (currently never natively):
+ 
+@@ -987,6 +988,7 @@ to ``float``; see below for more information on this emulation.
+   * 64-bit ARM (AArch64)
+   * RISC-V
+   * X86 (when SSE2 is available)
++  * LoongArch
+ 
+ (For X86, SSE2 is available on 64-bit and all recent 32-bit processors.)
+ 
+diff --git a/clang/lib/Basic/Targets/LoongArch.h b/clang/lib/Basic/Targets/LoongArch.h
+index 5c34c84ff8d3..b68675417a5f 100644
+--- a/clang/lib/Basic/Targets/LoongArch.h
++++ b/clang/lib/Basic/Targets/LoongArch.h
+@@ -49,10 +49,14 @@ public:
+     HasFeatureLD_SEQ_SA = false;
+     HasFeatureDiv32 = false;
+     HasFeatureSCQ = false;
++    BFloat16Width = 16;
++    BFloat16Align = 16;
++    BFloat16Format = &llvm::APFloat::BFloat();
+     LongDoubleWidth = 128;
+     LongDoubleAlign = 128;
+     LongDoubleFormat = &llvm::APFloat::IEEEquad();
+     MCountName = "_mcount";
++    HasFloat16 = true;
+     SuitableAlign = 128;
+     WCharType = SignedInt;
+     WIntType = UnsignedInt;
+@@ -98,6 +102,10 @@ public:
+ 
+   bool hasBitIntType() const override { return true; }
+ 
++  bool hasBFloat16Type() const override { return true; }
++
++  bool useFP16ConversionIntrinsics() const override { return false; }
++
+   bool handleTargetFeatures(std::vector<std::string> &Features,
+                             DiagnosticsEngine &Diags) override;
+ 
+diff --git a/clang/lib/CodeGen/Targets/LoongArch.cpp b/clang/lib/CodeGen/Targets/LoongArch.cpp
+index 6c90e48a5ea4..4040f9d7e5c4 100644
+--- a/clang/lib/CodeGen/Targets/LoongArch.cpp
++++ b/clang/lib/CodeGen/Targets/LoongArch.cpp
+@@ -110,10 +110,9 @@ bool LoongArchABIInfo::detectFARsEligibleStructHelper(
+     uint64_t Size = getContext().getTypeSize(Ty);
+     if (IsInt && Size > GRLen)
+       return false;
+-    // Can't be eligible if larger than the FP registers. Half precision isn't
+-    // currently supported on LoongArch and the ABI hasn't been confirmed, so
+-    // default to the integer ABI in that case.
+-    if (IsFloat && (Size > FRLen || Size < 32))
++    // Can't be eligible if larger than the FP registers. Handling of half
++    // precision values has been specified in the ABI, so don't block those.
++    if (IsFloat && Size > FRLen)
+       return false;
+     // Can't be eligible if an integer type was already found (int+int pairs
+     // are not eligible).
+diff --git a/clang/test/CodeGen/LoongArch/abi-lp64d.c b/clang/test/CodeGen/LoongArch/abi-lp64d.c
+index fc7f1eada586..9f64cfd662e5 100644
+--- a/clang/test/CodeGen/LoongArch/abi-lp64d.c
++++ b/clang/test/CodeGen/LoongArch/abi-lp64d.c
+@@ -48,6 +48,9 @@ unsigned long check_ulong() { return 0; }
+ // CHECK-LABEL: define{{.*}} i64 @check_ulonglong()
+ unsigned long long check_ulonglong() { return 0; }
+ 
++// CHECK-LABEL: define{{.*}}  half @check_float16()
++_Float16 check_float16() { return 0; }
++
+ // CHECK-LABEL: define{{.*}} float @check_float()
+ float check_float() { return 0; }
+ 
+@@ -127,6 +130,14 @@ struct i16x4_s f_i16x4_s(struct i16x4_s x) {
+ /// available, the value is passed in a GAR; if no GAR is available, the value
+ /// is passed on the stack.
+ 
++struct f16x1_s {
++  __fp16 a;
++};
++
++struct float16x1_s {
++  _Float16 a;
++};
++
+ struct f32x1_s {
+   float a;
+ };
+@@ -135,6 +146,16 @@ struct f64x1_s {
+   double a;
+ };
+ 
++// CHECK-LABEL: define{{.*}} half @f_f16x1_s(half %0)
++struct f16x1_s f_f16x1_s(struct f16x1_s x) {
++  return x;
++}
++
++// CHECK-LABEL: define{{.*}} half @f_float16x1_s(half %0)
++struct float16x1_s f_float16x1_s(struct float16x1_s x) {
++  return x;
++}
++
+ // CHECK-LABEL: define{{.*}} float @f_f32x1_s(float %0)
+ struct f32x1_s f_f32x1_s(struct f32x1_s x) {
+   return x;
+@@ -151,10 +172,20 @@ struct f64x1_s f_f64x1_s(struct f64x1_s x) {
+ /// number of available FAR is less than 2, it’s passed in a GAR, and passed on
+ /// the stack if no GAR is available.
+ 
++struct f16x2_s {
++  __fp16 a;
++  _Float16 b;
++};
++
+ struct f32x2_s {
+   float a, b;
+ };
+ 
++// CHECK-LABEL: define{{.*}} { half, half } @f_f16x2_s(half %0, half %1)
++struct f16x2_s f_f16x2_s(struct f16x2_s x) {
++  return x;
++}
++
+ // CHECK-LABEL: define{{.*}} { float, float } @f_f32x2_s(float %0, float %1)
+ struct f32x2_s f_f32x2_s(struct f32x2_s x) {
+   return x;
+@@ -165,11 +196,21 @@ struct f32x2_s f_f32x2_s(struct f32x2_s x) {
+ /// i. Multiple fixed-point members. If there are available GAR, the structure
+ /// is passed in a GAR, and passed on the stack if no GAR is available.
+ 
++struct f16x1_i16x2_s {
++  _Float16 a;
++  int16_t b, c;
++};
++
+ struct f32x1_i16x2_s {
+   float a;
+   int16_t b, c;
+ };
+ 
++// CHECK-LABEL: define{{.*}} i64 @f_f16x1_i16x2_s(i64 %x.coerce)
++struct f16x1_i16x2_s f_f16x1_i16x2_s(struct f16x1_i16x2_s x) {
++  return x;
++}
++
+ // CHECK-LABEL: define{{.*}} i64 @f_f32x1_i16x2_s(i64 %x.coerce)
+ struct f32x1_i16x2_s f_f32x1_i16x2_s(struct f32x1_i16x2_s x) {
+   return x;
+@@ -181,11 +222,21 @@ struct f32x1_i16x2_s f_f32x1_i16x2_s(struct f32x1_i16x2_s x) {
+ /// but one GAR is available, it’s passed in GAR; If no GAR is available, it’s
+ /// passed on the stack.
+ 
++struct f16x1_i32x1_s {
++  _Float16 a;
++  int32_t b;
++};
++
+ struct f32x1_i32x1_s {
+   float a;
+   int32_t b;
+ };
+ 
++// CHECK-LABEL: define{{.*}} { half, i32 } @f_f16x1_i32x1_s(half %0, i32 %1)
++struct f16x1_i32x1_s f_f16x1_i32x1_s(struct f16x1_i32x1_s x) {
++  return x;
++}
++
+ // CHECK-LABEL: define{{.*}} { float, i32 } @f_f32x1_i32x1_s(float %0, i32 %1)
+ struct f32x1_i32x1_s f_f32x1_i32x1_s(struct f32x1_i32x1_s x) {
+   return x;
+@@ -253,6 +304,16 @@ struct f32x4_s f_f32x4_s(struct f32x4_s x) {
+   return x;
+ }
+ 
++struct f16x5_s {
++  _Float16 a, b, c, d;
++  __fp16 e;
++};
++
++// CHECK-LABEL: define{{.*}} [2 x i64] @f_f16x5_s([2 x i64] %x.coerce)
++struct f16x5_s f_f16x5_s(struct f16x5_s x) {
++  return x;
++}
++
+ /// ii. The structure with two double members is passed in a pair of available
+ /// FARs. If no a pair of available FARs, it’s passed in GARs. A structure with
+ /// one double member and one float member is same.
+@@ -312,6 +373,16 @@ struct f32x2_i32x2_s f_f32x2_i32x2_s(struct f32x2_i32x2_s x) {
+   return x;
+ }
+ 
++struct f16x4_i32x2_s {
++  _Float16 a, b, c, d;
++  int32_t e, f;
++};
++
++// CHECK-LABEL: define{{.*}} [2 x i64] @f_f16x4_i32x2_s([2 x i64] %x.coerce)
++struct f16x4_i32x2_s f_f16x4_i32x2_s(struct f16x4_i32x2_s x) {
++  return x;
++}
++
+ /// 3. WOA > 2 × GRLEN
+ /// a. It’s passed by reference and are replaced in the argument list with the
+ /// address. If there is an available GAR, the reference is passed in the GAR,
+diff --git a/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp b/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
+index 2282dc895561..e63769939ecd 100644
+--- a/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
++++ b/llvm/lib/Target/LoongArch/LoongArchISelLowering.cpp
+@@ -169,6 +169,8 @@ LoongArchTargetLowering::LoongArchTargetLowering(const TargetMachine &TM,
+   if (Subtarget.hasBasicF()) {
+     setLoadExtAction(ISD::EXTLOAD, MVT::f32, MVT::f16, Expand);
+     setTruncStoreAction(MVT::f32, MVT::f16, Expand);
++    setLoadExtAction(ISD::EXTLOAD, MVT::f32, MVT::bf16, Expand);
++    setTruncStoreAction(MVT::f32, MVT::bf16, Expand);
+     setCondCodeAction(FPCCToExpand, MVT::f32, Expand);
+ 
+     setOperationAction(ISD::SELECT_CC, MVT::f32, Expand);
+@@ -186,6 +188,9 @@ LoongArchTargetLowering::LoongArchTargetLowering(const TargetMachine &TM,
+     setOperationAction(ISD::FREM, MVT::f32, Expand);
+     setOperationAction(ISD::FP16_TO_FP, MVT::f32, Expand);
+     setOperationAction(ISD::FP_TO_FP16, MVT::f32, Expand);
++    setOperationAction(ISD::BF16_TO_FP, MVT::f32, Custom);
++    setOperationAction(ISD::FP_TO_BF16, MVT::f32,
++                       Subtarget.isSoftFPABI() ? LibCall : Custom);
+ 
+     if (Subtarget.is64Bit())
+       setOperationAction(ISD::FRINT, MVT::f32, Legal);
+@@ -204,6 +209,8 @@ LoongArchTargetLowering::LoongArchTargetLowering(const TargetMachine &TM,
+   if (Subtarget.hasBasicD()) {
+     setLoadExtAction(ISD::EXTLOAD, MVT::f64, MVT::f16, Expand);
+     setLoadExtAction(ISD::EXTLOAD, MVT::f64, MVT::f32, Expand);
++    setLoadExtAction(ISD::EXTLOAD, MVT::f64, MVT::bf16, Expand);
++    setTruncStoreAction(MVT::f64, MVT::bf16, Expand);
+     setTruncStoreAction(MVT::f64, MVT::f16, Expand);
+     setTruncStoreAction(MVT::f64, MVT::f32, Expand);
+     setCondCodeAction(FPCCToExpand, MVT::f64, Expand);
+@@ -223,7 +230,9 @@ LoongArchTargetLowering::LoongArchTargetLowering(const TargetMachine &TM,
+     setOperationAction(ISD::FREM, MVT::f64, Expand);
+     setOperationAction(ISD::FP16_TO_FP, MVT::f64, Expand);
+     setOperationAction(ISD::FP_TO_FP16, MVT::f64, Expand);
+-
++    setOperationAction(ISD::BF16_TO_FP, MVT::f64, Custom);
++    setOperationAction(ISD::FP_TO_BF16, MVT::f64,
++                       Subtarget.isSoftFPABI() ? LibCall : Custom);
+     if (Subtarget.is64Bit())
+       setOperationAction(ISD::FRINT, MVT::f64, Legal);
+   }
+@@ -459,6 +468,10 @@ SDValue LoongArchTargetLowering::LowerOperation(SDValue Op,
+     return lowerBITREVERSE(Op, DAG);
+   case ISD::SCALAR_TO_VECTOR:
+     return lowerSCALAR_TO_VECTOR(Op, DAG);
++  case ISD::FP_TO_BF16:
++    return lowerFP_TO_BF16(Op, DAG);
++  case ISD::BF16_TO_FP:
++    return lowerBF16_TO_FP(Op, DAG);
+   }
+   return SDValue();
+ }
+@@ -1442,6 +1455,36 @@ SDValue LoongArchTargetLowering::lowerVECTOR_SHUFFLE(SDValue Op,
+   return SDValue();
+ }
+ 
++SDValue LoongArchTargetLowering::lowerFP_TO_BF16(SDValue Op,
++                                                 SelectionDAG &DAG) const {
++  assert(Subtarget.hasBasicF() && "Unexpected custom legalization");
++  SDLoc DL(Op);
++  MakeLibCallOptions CallOptions;
++  RTLIB::Libcall LC =
++      RTLIB::getFPROUND(Op.getOperand(0).getValueType(), MVT::bf16);
++  SDValue Res =
++      makeLibCall(DAG, LC, MVT::f32, Op.getOperand(0), CallOptions, DL).first;
++  if (Subtarget.is64Bit())
++    return DAG.getNode(LoongArchISD::MOVFR2GR_S_LA64, DL, MVT::i64, Res);
++  return DAG.getBitcast(MVT::i32, Res);
++}
++
++SDValue LoongArchTargetLowering::lowerBF16_TO_FP(SDValue Op,
++                                                 SelectionDAG &DAG) const {
++  assert(Subtarget.hasBasicF() && "Unexpected custom legalization");
++  MVT VT = Op.getSimpleValueType();
++  SDLoc DL(Op);
++  Op = DAG.getNode(
++      ISD::SHL, DL, Op.getOperand(0).getValueType(), Op.getOperand(0),
++      DAG.getShiftAmountConstant(16, Op.getOperand(0).getValueType(), DL));
++  SDValue Res = Subtarget.is64Bit() ? DAG.getNode(LoongArchISD::MOVGR2FR_W_LA64,
++                                                  DL, MVT::f32, Op)
++                                    : DAG.getBitcast(MVT::f32, Op);
++  if (VT != MVT::f32)
++    return DAG.getNode(ISD::FP_EXTEND, DL, VT, Res);
++  return Res;
++}
++
+ static bool isConstantOrUndef(const SDValue Op) {
+   if (Op->isUndef())
+     return true;
+diff --git a/llvm/lib/Target/LoongArch/LoongArchISelLowering.h b/llvm/lib/Target/LoongArch/LoongArchISelLowering.h
+index a215ab523874..57b722f6cc8a 100644
+--- a/llvm/lib/Target/LoongArch/LoongArchISelLowering.h
++++ b/llvm/lib/Target/LoongArch/LoongArchISelLowering.h
+@@ -337,6 +337,8 @@ private:
+   SDValue lowerVECTOR_SHUFFLE(SDValue Op, SelectionDAG &DAG) const;
+   SDValue lowerBITREVERSE(SDValue Op, SelectionDAG &DAG) const;
+   SDValue lowerSCALAR_TO_VECTOR(SDValue Op, SelectionDAG &DAG) const;
++  SDValue lowerFP_TO_BF16(SDValue Op, SelectionDAG &DAG) const;
++  SDValue lowerBF16_TO_FP(SDValue Op, SelectionDAG &DAG) const;
+ 
+   bool isFPImmLegal(const APFloat &Imm, EVT VT,
+                     bool ForCodeSize) const override;

--- a/rocm-llvm/0004-flang-ignore-lto-arg.patch
+++ b/rocm-llvm/0004-flang-ignore-lto-arg.patch
@@ -1,0 +1,13 @@
+diff --git a/clang/lib/Driver/Driver.cpp b/clang/lib/Driver/Driver.cpp
+index 38cad6017562..7b816ec4f60d 100644
+--- a/clang/lib/Driver/Driver.cpp
++++ b/clang/lib/Driver/Driver.cpp
+@@ -352,6 +352,8 @@ InputArgList Driver::ParseArgStrings(ArrayRef<const char *> ArgStrings,
+     unsigned DiagID;
+     auto ArgString = A->getAsString(Args);
+     std::string Nearest;
++    if (ArgString == "-fuse-linker-plugin")
++      continue;
+     if (getOpts().findNearest(ArgString, Nearest, VisibilityMask) > 1) {
+       if (!IsCLMode() &&
+           getOpts().findExact(ArgString, Nearest,

--- a/rocm-llvm/loong.patch
+++ b/rocm-llvm/loong.patch
@@ -1,26 +1,36 @@
-diff --git a/PKGBUILD b/PKGBUILD
-index ff5b5c5..843e537 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -37,6 +37,12 @@ prepare() {
-   # Add fix for missing function overload (openat)
-   # https://github.com/llvm/llvm-project/issues/100754
-   git cherry-pick -n 155b7a12820ec45095988b6aa6e057afaf2bc892
+@@ -44,6 +44,11 @@ prepare() {
+ 
+   # Fix build with glibc 2.42: https://github.com/llvm/llvm-project/issues/137321
+   patch -Np1 < ../rocm-llvm-6.4-fix-glibc-2.42-termio-removal.patch
 +
-+  # Fix llvm-mc abi
-+  git cherry-pick -n 3acb0e9e600cbe3668b7db3956238a592ebadc0a
-+
-+  # Fix libraries_sha.inc:1:42: error: narrowing conversion of ‘-30’ from ‘int’ to ‘char’
-+  git cherry-pick -n 74c3df6cb5540c937ad8b58f95275901efae8669
++  patch -Np1 < ../0001-rocm-llvm-define-nansq.patch
++  patch -Np1 < ../0002-llvm-loongarch64-change-default-code-model.patch
++  patch -Np1 < ../0003-rocm-llvm-loongarch64-feature-support.patch
++  patch -Np1 < ../0004-flang-ignore-lto-arg.patch
  }
  
  build() {
-@@ -65,7 +71,7 @@ build() {
+@@ -73,7 +78,7 @@ build() {
          -D LIBCXXABI_ENABLE_SHARED=OFF
          -D LIBCXXABI_ENABLE_STATIC=ON
          -D LIBCXXABI_INSTALL_STATIC_LIBRARY=OFF
 -        -D LLVM_TARGETS_TO_BUILD='AMDGPU;NVPTX;X86'
 +        -D LLVM_TARGETS_TO_BUILD='AMDGPU;NVPTX;LoongArch'
          -D CLANG_DEFAULT_LINKER=lld
+         -D ENABLE_LINKER_BUILD_ID=ON
          -D CLANG_DEFAULT_RTLIB=compiler-rt
-         -D CLANG_DEFAULT_UNWINDLIB=libgcc
+@@ -179,3 +184,12 @@ package_comgr() {
+     cd "$pkgbase/amd/comgr"
+     install -Dm644 LICENSE.txt "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+ }
++
++source+=('0001-rocm-llvm-define-nansq.patch'
++         '0002-llvm-loongarch64-change-default-code-model.patch'
++         '0003-rocm-llvm-loongarch64-feature-support.patch'
++         '0004-flang-ignore-lto-arg.patch')
++sha256sums+=('96f95ef214574db1f060c11a7949efcff8bd7221724d7b29e3637cf94ced2bec'
++             '33f23266f846064f863ff8f3688e41e894bb3010c6601963caa9dfe445a07d9c'
++             '51dc94776a1c93b0f571bc27f43828b2867e18386f7e1faee7950cb4cfda8308'
++             'f5d909684bfb7a4e83ef2b01871fb124cd32c3d41f44e13dedb100ecf7751dc7')


### PR DESCRIPTION
* use patches from AOSC(0001, 0002, 0004)
* backport patch from upstream. commit id: 8c65f68330c77c27aae2ff58e883802760891cbb 0ed5d9aff6e72bdaf3f12bc71dbf83a5c116e8fd