### PR TITLE
addpatch: cockpit, ver=352-1.1

### DIFF
--- a/cockpit/loong.patch
+++ b/cockpit/loong.patch
@@ -1,0 +1,20 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 80f9d54..5a95103 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -23,6 +23,8 @@ prepare() {
+   cd cockpit-$pkgver
+   # disable buggy package-lock check
+   sed -r '/^cmd_make_package_lock_json\b/ a exit 0' -i tools/node-modules
++  # Add "Model Name:" fallback to fix CPU model display on LoongArch.
++  patch -Np1 -i "${srcdir}/handle-CPU-model-names-parsing-on-LoongArch.patch"
+ }
+ 
+ build() {
+@@ -117,3 +119,6 @@ package_cockpit-packagekit() {
+   _do_package_component
+   _do_package_component apps
+ }
++
++source+=("handle-CPU-model-names-parsing-on-LoongArch.patch::https://github.com/cockpit-project/cockpit/commit/0fc9b27203b1eb8fa14bbfa12ba949b1c629e59f.diff")
++sha256sums+=('697045ca1993107b564bbc1001b8f8d33fdfbc68618b58e3782fe4e160cd9f11')


### PR DESCRIPTION
* handle CPU model names parsing on LoongArch