### PR TITLE
updpatch: arduino-cli, ver=1.4.0-1

### DIFF
--- a/arduino-cli/loong.patch
+++ b/arduino-cli/loong.patch
@@ -1,13 +1,23 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 72d2110..d9d4424 100644
+index f30385b..c41cbda 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -22,6 +22,8 @@ build(){
-   export CGO_LDFLAGS="$LDFLAGS"
-   export GOFLAGS='-buildmode=pie -trimpath -mod=readonly -modcacherw'
- 
+@@ -37,6 +37,9 @@ build(){
+     -compressdwarf=false \
+     -linkmode=external \
+   "
 +  go mod edit -replace=github.com/creack/goselect=github.com/creack/goselect@v0.1.3
 +  go mod tidy
-   go build \
-         -ldflags "-linkmode=external -X github.com/arduino/arduino-cli/version.versionString=$pkgver-arch -X github.com/arduino/arduino-cli/version.commit=$(git rev-parse HEAD)" \
-         -v .
++  go mod vendor
+   go build -v -ldflags "$ld_flags" -o build/
+ }
+ 
+@@ -47,6 +50,8 @@ check() {
+       | grep -v github.com/arduino/arduino-cli/internal/arduino/monitor \
+       | grep -v github.com/arduino/arduino-cli/internal/integrationtest \
+       | grep -v github.com/arduino/arduino-cli/internal/version \
++      | grep -v github.com/arduino/arduino-cli/internal/arduino/cores/packagemanager \
++      | grep -v github.com/arduino/arduino-cli/internal/cli/arguments \
+   )
+   # shellcheck disable=SC2086
+   go test -v $unit_tests


### PR DESCRIPTION
* Skip tests that need to download pre-built binaries