### PR TITLE
addpatch: python-setuptools-scm, ver=9.2.2-1

### DIFF
--- a/python-setuptools-scm/loong.patch
+++ b/python-setuptools-scm/loong.patch
@@ -1,0 +1,10 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 4c70395..3836bf3 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -60,3 +60,5 @@ package() {
+   cd $_name
+   python -m installer --destdir="$pkgdir" dist/*.whl
+ }
++
++checkdepends+=(libxml2 libxslt)


### PR DESCRIPTION
* Add libxml2 and libxslt to checkdepends
* Fix: `Error: Please make sure the libxml2 and libxslt development packages are installed.`