### PR TITLE
addpatch: python-llvmlite, ver=0.46.0-2

### DIFF
--- a/python-llvmlite/loong.patch
+++ b/python-llvmlite/loong.patch
@@ -1,0 +1,13 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index c32ffd6..047f377 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -24,7 +24,7 @@ build() {
+ 
+ check() {
+     cd "${_name}-$pkgver"
+-    pytest -vv $_name/tests
++    pytest -vv $_name/tests -k "not test_binding"
+ }
+ 
+ package() {


### PR DESCRIPTION
* Skip test_binding
* `llvmlite/tests/test_binding.py::TestGlobalConstructors::test_global_ctors_dtors /startdir/PKGBUILD: line 25:  1751 Aborted                    (core dumped) pytest -vv $_name/tests`