### PR TITLE
updpatch: librustls, ver=0.15.0-2

### DIFF
--- a/librustls/loong.patch
+++ b/librustls/loong.patch
@@ -1,5 +1,5 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 5769a94..7a8f164 100644
+index b396db3..6840f61 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
 @@ -15,6 +15,8 @@ makedepends=(
@@ -9,5 +9,35 @@ index 5769a94..7a8f164 100644
 +  cmake
 +  clang
  )
- provides=('librustls.so')
- options=(!lto)
+ provides=(
+   librustls.so
+@@ -27,16 +29,29 @@ b2sums=('1b45c492fdbb79527d97e8a84143e4435198af095117ba5bdabe8d72d77adf65ba3b599
+ 
+ prepare() {
+   cd rustls-ffi-${pkgver}
++  cat > cmake-wrapper << "EOF"
++#!/bin/bash
++_extra_args='-DCMAKE_POLICY_VERSION_MINIMUM=3.5'
++if [[ "$1" != "--version" ]] && [[ "$1" != "--build" ]]; then
++    cmake $_extra_args  "$@"
++else
++    cmake "$@"
++fi
++EOF
++
++  chmod u+x cmake-wrapper
+   cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+ }
+ 
+ build() {
+   cd rustls-ffi-${pkgver}
++  export CMAKE="$PWD/cmake-wrapper"
+   cargo cbuild --release --frozen --prefix=/usr
+ }
+ 
+ package() {
+   cd rustls-ffi-${pkgver}
++  export CMAKE="$PWD/cmake-wrapper"
+   cargo cinstall --release --frozen --prefix /usr --destdir "${pkgdir}"
+   install -Dm644 -t "${pkgdir}/usr/share/licenses/${pkgname}" LICENSE-*
+ }


### PR DESCRIPTION
* Fix build with new cmake
* See: https://github.com/felixonmars/archriscv-packages/commit/b720be045b1246c3ad1c7eae894dd9c7c004d3ed