### PR TITLE
addpatch: brotli, ver=1.2.0-1

### DIFF
--- a/brotli/loong.patch
+++ b/brotli/loong.patch
@@ -1,0 +1,21 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 11360eb..8c10bd1 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -31,6 +31,7 @@ pkgver() {
+ 
+ build() {
+   cd ${pkgbase}
++  git cherry-pick -n e230f474b87134e8c6c85b630084c612057f253e
+   python -m build --wheel --no-isolation
+   cmake -S . -B build \
+     -DCMAKE_BUILD_TYPE=Release \
+@@ -43,7 +44,7 @@ build() {
+ check() {
+   cd ${pkgbase}
+   local python_version=$(python -c 'import sys; print("".join(map(str, sys.version_info[:2])))')
+-  PYTHONPATH="$PWD/bin/lib.linux-$CARCH-cpython-${python_version}" python -m unittest discover python "*_test.py"
++  PYTHONPATH="$PWD/bin/lib.linux-$(uname -m)-cpython-${python_version}" python -m unittest discover python "*_test.py"
+   cd build
+   ctest --output-on-failure --stop-on-failure -j$(nproc)
+ }


### PR DESCRIPTION
* Backport fix to disable BROTLI_MODEL macro for some targets including loongarch64
* Fix PYTHONPATH (`$CARCH` to `$(uname -m)`)