### PR TITLE
updpatch: gcc, ver=15.2.1+r604+g0b99615a8aef-1.1

### DIFF
--- a/gcc/loong.patch
+++ b/gcc/loong.patch
@@ -1,6 +1,8 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 5164872..a7c5c5a 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -101,6 +101,12 @@ prepare() {
+@@ -101,6 +101,14 @@ prepare() {
    # Reproducible gcc-ada
    patch -Np0 < "$srcdir/gcc-ada-repro.patch"
  
@@ -9,11 +11,13 @@
 +  patch -Np1 -i "$srcdir/gcc-lib64-lib.patch"
 +  # Apply upstream fix for LoongArch ICE in highway-1.3.0 testsuite
 +  git cherry-pick -n 1276b391b4b068655b1d4511d51421302c1a7849
++  # Apply upstream fix to extend the narrower shift amount before broadcasting it
++  git cherry-pick -n 1139fdadc85a0b602a2833e6b7f2cfe2a8a90cdb
 +
    mkdir -p "$srcdir/gcc-build"
    mkdir -p "$srcdir/libgccjit-build"
  }
-@@ -128,7 +134,8 @@ build() {
+@@ -128,7 +136,8 @@ build() {
        --enable-link-serialization=1
        --enable-linker-build-id
        --enable-lto
@@ -23,7 +27,7 @@
        --enable-plugin
        --enable-shared
        --enable-threads=posix
-@@ -146,7 +153,7 @@ build() {
+@@ -146,7 +155,7 @@ build() {
    CXXFLAGS=${CXXFLAGS/-Werror=format-security/}
  
    "$srcdir/gcc/configure" \
@@ -32,7 +36,7 @@
      --enable-bootstrap \
      "${_confflags[@]:?_confflags unset}"
  
-@@ -223,25 +230,20 @@ package_gcc() {
+@@ -223,25 +232,20 @@ package_gcc() {
    install -m755 -t "$pkgdir/$_libdir/" gcc/{cc1,cc1plus,collect2,lto1}
  
    make -C $CHOST/libgcc DESTDIR="$pkgdir" install
@@ -61,7 +65,7 @@
  
    make DESTDIR="$pkgdir" install-fixincludes
    make -C gcc DESTDIR="$pkgdir" install-mkheaders
-@@ -258,15 +260,11 @@ package_gcc() {
+@@ -258,15 +262,11 @@ package_gcc() {
    make -C $CHOST/libsanitizer/asan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
    make -C $CHOST/libsanitizer/tsan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
    make -C $CHOST/libsanitizer/lsan DESTDIR="$pkgdir" install-nodist_toolexeclibHEADERS
@@ -80,7 +84,7 @@
  
    make -C libcpp DESTDIR="$pkgdir" install
    make -C gcc DESTDIR="$pkgdir" install-po
-@@ -277,7 +275,7 @@ package_gcc() {
+@@ -277,7 +277,7 @@ package_gcc() {
    # create cc-rs compatible symlinks
    # https://github.com/rust-lang/cc-rs/blob/1.0.73/src/lib.rs#L2578-L2581
    for binary in {c++,g++,gcc,gcc-ar,gcc-nm,gcc-ranlib}; do
@@ -89,7 +93,7 @@
    done
  
    # POSIX conformance launcher scripts for c89 and c99
-@@ -287,9 +285,6 @@ package_gcc() {
+@@ -287,9 +287,6 @@ package_gcc() {
    # install the libstdc++ man pages
    make -C $CHOST/libstdc++-v3/doc DESTDIR="$pkgdir" doc-install-man
  
@@ -99,7 +103,7 @@
    # byte-compile python libraries
    python -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
    python -O -m compileall "$pkgdir/usr/share/gcc-${pkgver%%+*}/"
-@@ -325,10 +320,6 @@ package_gcc-ada() {
+@@ -325,10 +322,6 @@ package_gcc-ada() {
    make DESTDIR="$pkgdir" INSTALL="install" \
      INSTALL_DATA="install -m644" install-libada
  
@@ -110,7 +114,7 @@
    ln -s gcc "$pkgdir/usr/bin/gnatgcc"
  
    # insist on dynamic linking, but keep static libraries because gnatmake complains
-@@ -337,12 +328,6 @@ package_gcc-ada() {
+@@ -337,12 +330,6 @@ package_gcc-ada() {
    ln -s libgnat-${pkgver%%.*}.so "$pkgdir/usr/lib/libgnat.so"
    rm -f "$pkgdir"/$_libdir/adalib/libgna{rl,t}.so
  
@@ -123,7 +127,7 @@
    # Install Runtime Library Exception
    install -d "$pkgdir/usr/share/licenses/$pkgname/"
    ln -s /usr/share/licenses/gcc-libs/RUNTIME.LIBRARY.EXCEPTION \
-@@ -374,7 +359,6 @@ package_gcc-d() {
+@@ -374,7 +361,6 @@ package_gcc-d() {
  
    make -C $CHOST/libphobos DESTDIR="$pkgdir" install
    rm -f "$pkgdir/usr/lib/"lib{gphobos,gdruntime}.so*
@@ -131,7 +135,7 @@
  
    # Install Runtime Library Exception
    install -d "$pkgdir/usr/share/licenses/$pkgname/"
-@@ -399,8 +383,6 @@ package_gcc-fortran() {
+@@ -399,8 +385,6 @@ package_gcc-fortran() {
    cd gcc-build
    make -C $CHOST/libgfortran DESTDIR="$pkgdir" install-cafexeclibLTLIBRARIES \
      install-{toolexeclibDATA,nodist_fincludeHEADERS,gfor_cHEADERS}
@@ -140,7 +144,7 @@
    make -C $CHOST/libgomp DESTDIR="$pkgdir" install-nodist_fincludeHEADERS
    make -C gcc DESTDIR="$pkgdir" fortran.install-{common,man,info}
    install -Dm755 gcc/f951 "$pkgdir/$_libdir/f951"
-@@ -426,8 +408,6 @@ package_gcc-gcobol() {
+@@ -426,8 +410,6 @@ package_gcc-gcobol() {
  
    install -Dm755 gcc/gcobol "$pkgdir"/usr/bin/gcobol
  
@@ -149,7 +153,7 @@
    # Install Runtime Library Exception
    install -d "$pkgdir/usr/share/licenses/$pkgname/"
    ln -s /usr/share/licenses/gcc-libs/RUNTIME.LIBRARY.EXCEPTION \
-@@ -454,11 +434,10 @@ package_gcc-go() {
+@@ -454,11 +436,10 @@ package_gcc-go() {
  
    cd gcc-build
    make -C $CHOST/libgo DESTDIR="$pkgdir" install-exec-am
@@ -162,7 +166,7 @@
    install -Dm755 gcc/go1 "$pkgdir/$_libdir/go1"
  
    # Install Runtime Library Exception
-@@ -580,9 +559,7 @@ package_lib32-gcc-libs() {
+@@ -580,9 +561,7 @@ package_lib32-gcc-libs() {
    rm -f "$pkgdir/$_libdir/32/libgcc_eh.a"
  
    for lib in libatomic \
@@ -172,7 +176,7 @@
               libgomp \
               libitm \
               libquadmath \
-@@ -686,8 +663,8 @@ package_libgcobol() {
+@@ -686,8 +665,8 @@ package_libgcobol() {
      libgcobol.so
    )
  
@@ -183,7 +187,7 @@
  
    # Install Runtime Library Exception
    install -Dm644 "$srcdir/gcc/COPYING.RUNTIME" \
-@@ -765,9 +742,6 @@ package_libgm2() {
+@@ -765,9 +744,6 @@ package_libgm2() {
  
    make -C $CHOST/libgm2 DESTDIR="$pkgdir" install
  
@@ -193,7 +197,7 @@
    # Install Runtime Library Exception
    install -Dm644 "$srcdir/gcc/COPYING.RUNTIME" \
      "$pkgdir/usr/share/licenses/libgm2/RUNTIME.LIBRARY.EXCEPTION"
-@@ -789,9 +763,6 @@ package_libgphobos() {
+@@ -789,9 +765,6 @@ package_libgphobos() {
    rm -rf "$pkgdir"/$_libdir/include/d/
    rm -f "$pkgdir"/usr/lib/libgphobos.spec
  
@@ -203,7 +207,7 @@
    # Install Runtime Library Exception
    install -Dm644 "$srcdir/gcc/COPYING.RUNTIME" \
      "$pkgdir/usr/share/licenses/libgphobos/RUNTIME.LIBRARY.EXCEPTION"
-@@ -846,9 +817,6 @@ package_libobjc() {
+@@ -846,9 +819,6 @@ package_libobjc() {
    cd gcc-build
    make -C $CHOST/libobjc DESTDIR="$pkgdir" install-libs
  
@@ -213,7 +217,7 @@
    # Install Runtime Library Exception
    install -Dm644 "$srcdir/gcc/COPYING.RUNTIME" \
      "$pkgdir/usr/share/licenses/libobjc/RUNTIME.LIBRARY.EXCEPTION"
-@@ -942,3 +910,8 @@ package_lto-dump() {
+@@ -942,3 +912,8 @@ package_lto-dump() {
    ln -s /usr/share/licenses/gcc-libs/RUNTIME.LIBRARY.EXCEPTION \
      "$pkgdir/usr/share/licenses/$pkgname/"
  }


### PR DESCRIPTION
* Backport upstream fix to extend the narrower shift amount before broadcasting it
* See also: https://github.com/loongson-community/discussions/issues/114