### PR TITLE
addpatch: jupyter-nbconvert, ver=7.17.0-1

### DIFF
--- a/jupyter-nbconvert/loong.patch
+++ b/jupyter-nbconvert/loong.patch
@@ -1,0 +1,10 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 38edc49..0ed04fd 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -70,3 +70,5 @@ package() {
+ 
+   install -Dm644 LICENSE -t "$pkgdir"/usr/share/licenses/$pkgname
+ }
++
++checkdepends=($(printf "%s\n" "${checkdepends[@]}" | grep -Ev '^(python-playwright)$'))


### PR DESCRIPTION
* Remove python-playwright from checkdepends
  * It's unavaliable on loong64