### PR TITLE
updpatch: x86_64-linux-gnu-binutils, ver=2.45-2

### DIFF
--- a/x86_64-linux-gnu-binutils/PKGBUILD
+++ b/x86_64-linux-gnu-binutils/PKGBUILD
@@ -3,7 +3,7 @@
 _target=x86_64-linux-gnu
 pkgname=$_target-binutils
 pkgver=2.45
-pkgrel=1
+pkgrel=2
 pkgdesc='A set of programs to assemble and manipulate binary and object files for 32-bit and 64-bit x86'
 arch=(loong64)
 url='https://www.gnu.org/software/binutils/'
@@ -90,7 +90,10 @@ package() {
 
   # Remove file conflicting with host binutils and manpages for MS Windows tools
   rm "$pkgdir"/usr/share/man/man1/$_target-{dlltool,windres,windmc}*
-  rm -rf "$pkgdir"/usr/lib
+  find "$pkgdir"/usr/lib -mindepth 1 \
+                         ! -name 'libsframe.so.2' \
+                         ! -name 'libsframe.so.2.0.0' \
+                         -delete
 
   rm -rf "$pkgdir"/usr/include
 


### PR DESCRIPTION
* keep libsframe.so.2.0.0 and its symlink libsframe.so.2

The [upstream version of binutils](https://archlinux.org/packages/core/x86_64/binutils/) ships libsframe.so=3-64 starting from 2.46-1. If we keep removing libsframe.so.2.0.0 from x86_64-linux-gnu-binutils, the users of this library would fail:

```console
$ x86_64-linux-gnu-as --version
x86_64-linux-gnu-as: error while loading shared libraries: libsframe.so.2: cannot open shared object file: No such file or directory
$ ldd "$(which x86_64-linux-gnu-as)"
        linux-vdso.so.1 (0x00007ffffe91c000)
        libbfd-2.45.so => /usr/loongarch64-unknown-linux-gnu/x86_64-linux-gnu/lib/libbfd-2.45.so (0x00007ffff1d30000)
        libz.so.1 => /usr/lib/libz.so.1 (0x00007ffff1cc0000)
        libzstd.so.1 => /usr/lib/libzstd.so.1 (0x00007ffff1bb0000)
        libc.so.6 => /usr/lib/libc.so.6 (0x00007ffff19d0000)
        /lib64/ld-linux-loongarch-lp64d.so.1 => /usr/lib64/ld-linux-loongarch-lp64d.so.1 (0x00007ffff1fe0000)
        libsframe.so.2 => not found
```

This PR keeps libsframe.so.2.0.0 and libsframe.so.2 from being removed.