### PR TITLE
updpkg: x86_64-linux-gnu-linux-api-headers, ver=6.19-1

### DIFF
--- a/x86_64-linux-gnu-linux-api-headers/PKGBUILD
+++ b/x86_64-linux-gnu-linux-api-headers/PKGBUILD
@@ -3,7 +3,7 @@
 _target_arch=x86
 _target=x86_64-linux-gnu
 pkgname=$_target-linux-api-headers
-pkgver=6.10
+pkgver=6.19
 pkgrel=1
 pkgdesc="Kernel headers sanitized for use in userspace ($_target)"
 arch=(any)
@@ -11,7 +11,7 @@ url='https://www.kernel.org'
 license=(GPL2)
 makedepends=(rsync)
 source=(https://www.kernel.org/pub/linux/kernel/v6.x/linux-$pkgver.tar.{xz,sign})
-sha256sums=('774698422ee54c5f1e704456f37c65c06b51b4e9a8b0866f34580d86fef8e226'
+sha256sums=('303079a8250b8f381f82b03f90463d12ac98d4f6b149b761ea75af1323521357'
             'SKIP')
 validpgpkeys=(
   'ABAF11C65A2970B130ABE3C479BE3E4300411886'  # Linus Torvalds


### PR DESCRIPTION
* Follow up on the upstream version