### PR TITLE
updpkg: x86_64-linux-gnu-gcc, ver=15.2.0-1.2

### DIFF
--- a/x86_64-linux-gnu-gcc/PKGBUILD
+++ b/x86_64-linux-gnu-gcc/PKGBUILD
@@ -7,7 +7,7 @@
 _target=x86_64-linux-gnu
 pkgname=$_target-gcc
 pkgver=15.2.0
-pkgrel=1.1
+pkgrel=1.2
 #_snapshot=8-20190111
 pkgdesc='The GNU Compiler Collection - cross compiler for x86_64 target'
 arch=(aarch64 loong64 riscv64)


### PR DESCRIPTION
* Rebuild against x86_64-linux-gnu-linux-api-header 6.19, x86_64-linux-gnu-glibc 2.43, and x86_64-linux-gnu-binutils 2.46