### PR TITLE
updpatch: gn, ver=0.2385.9ece3f52-1

### DIFF
--- a/gn/loong.patch
+++ b/gn/loong.patch
@@ -1,14 +1,14 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 77077a7..adf19d1 100644
+index 795072f..f506bdd 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -20,6 +20,9 @@ pkgver() {
+@@ -21,6 +21,9 @@ pkgver() {
  
  build() {
    cd $pkgname
 +  # clang does not support it
-+  CXXFLAGS="${CXXFLAGS//-fstack-clash-protection/}"
-+  CFLAGS="${CFLAGS//-fstack-clash-protection/}"
++  CXXFLAGS=($(printf "%s\n" "${CXXFLAGS[@]}" | grep -Ev '^(-fstack-clash-protection|-fno-plt)$'))
++  CFLAGS=($(printf "%s\n" "${CFLAGS[@]}" | grep -Ev '^(-fstack-clash-protection|-fno-plt)$'))
    ./build/gen.py
    ninja -C out
  }


### PR DESCRIPTION
* Remove unsupported `-fno-plt` from CXXFLAGS/CFLAGS for clang