### PR TITLE
updpatch: chromium, ver=148.0.7778.167-1

### DIFF
--- a/chromium/loong.patch
+++ b/chromium/loong.patch
@@ -1,5 +1,5 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index b8f1cdc..d14ed58 100644
+index 9ae703f..ecbf8a0 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
 @@ -54,6 +54,7 @@ optdepends=('pipewire: WebRTC desktop sharing under Wayland'
@@ -19,7 +19,15 @@ index b8f1cdc..d14ed58 100644
  fi
  
  # Possible replacements are listed in build/linux/unbundle/replace_gn_files.py
-@@ -231,6 +234,49 @@ prepare() {
+@@ -199,6 +202,7 @@ prepare() {
+            third_party/jdk/current/bin
+ 
+   ln -s /usr/bin/node third_party/node/linux/node-linux-x64/bin/
++  ln -s /usr/bin/rustc third_party/rust-toolchain/bin/
+   ln -s /usr/bin/java third_party/jdk/current/bin/
+ 
+   # remove x86_64 binary and use our own
+@@ -234,6 +238,46 @@ prepare() {
    python3 build/util/lastchange.py -m DAWN_COMMIT_HASH \
      -s third_party/dawn --revision gpu/webgpu/DAWN_VERSION \
      --header gpu/webgpu/dawn_commit_hash.h
@@ -63,13 +71,10 @@ index b8f1cdc..d14ed58 100644
 +  mv node_modules/@esbuild/linux-loong64/bin/esbuild third_party/devtools-frontend/src/third_party/esbuild/esbuild
 +  rm -r node_modules # Cleaning
 +  python3 third_party/devtools-frontend/src/scripts/deps/manage_node_deps.py
-+
-+  mkdir -p third_party/gperf/cipd/bin
-+  ln -sf /usr/bin/gperf third_party/gperf/cipd/bin/gperf
  }
  
  build() {
-@@ -338,6 +384,13 @@ build() {
+@@ -341,6 +385,12 @@ build() {
      CXXFLAGS="${CXXFLAGS/-march=*([^ ]) }"
    fi
  
@@ -77,13 +82,12 @@ index b8f1cdc..d14ed58 100644
 +  _flags+=(
 +    build_litert_with_xnnpack=false
 +    build_tflite_with_xnnpack=false
-+    build_webnn_with_xnnpack=false
 +  )
 +
    gn gen out/Release --args="${_flags[*]}"
    ninja -C out/Release chrome chrome_sandbox chromedriver.unstripped
  }
-@@ -415,4 +468,10 @@ package() {
+@@ -418,4 +468,10 @@ package() {
    install -Dvm644 LICENSE "$pkgdir/usr/share/licenses/chromium/LICENSE"
  }
  


### PR DESCRIPTION
* Symlink to use system's rustc
* Upstream uses system's gperf now and we don't need to handel it