### PR TITLE
addpatch: openbao, ver=2.5.3-1

### DIFF
--- a/openbao/loong.patch
+++ b/openbao/loong.patch
@@ -1,0 +1,41 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index eb984b0..f660e9c 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -41,6 +41,7 @@ prepare() {
+   sed -i 's|/etc/openbao/openbao.env|/etc/default/openbao|g' .release/linux/package/usr/lib/systemd/system/openbao.service
+ 
+   pushd ui
++  node .yarn/releases/yarn-3.5.0.cjs set version 4.9.2
+   yarn install
+   popd
+ 
+@@ -56,7 +57,12 @@ build() {
+   yarn run build
+   popd
+ 
+-  export CGO_ENABLED=0
++  # Go requires external linking for PIE on linux/loong64.
++  export CGO_ENABLED=1
++  export CGO_CPPFLAGS="${CPPFLAGS}"
++  export CGO_CFLAGS="${CFLAGS}"
++  export CGO_CXXFLAGS="${CXXFLAGS}"
++  export CGO_LDFLAGS="${LDFLAGS}"
+   export GOPATH="${srcdir}"
+ 
+   # https://openbao.org/docs/contributing/packaging/
+@@ -71,7 +77,7 @@ build() {
+     -buildmode=pie \
+     -mod=readonly \
+     -modcacherw \
+-    -ldflags "-X github.com/openbao/openbao/version.fullVersion=${pkgver} -X github.com/openbao/openbao/version.GitCommit=${_commit} -X github.com/openbao/openbao/version.BuildDate=${_build_date}" \
++    -ldflags "-linkmode=external -X github.com/openbao/openbao/version.fullVersion=${pkgver} -X github.com/openbao/openbao/version.GitCommit=${_commit} -X github.com/openbao/openbao/version.BuildDate=${_build_date}" \
+     -tags 'openbao ui' \
+     -o dist/bao \
+     .
+@@ -95,3 +101,5 @@ package() {
+     install -Dm644 "${file}" "${pkgdir}/usr/share/doc/${pkgname}/${file}"
+   done
+ }
++
++depends+=(glibc)


### PR DESCRIPTION
Use the vendored Yarn 3 release to set Yarn 4.9.2 in prepare(), avoiding the riscv64 Yarn libzip read error.

Enable cgo because Go requires external linking for -buildmode=pie on linux/riscv64. This fixes:

  -buildmode=pie requires external (cgo) linking, but cgo is not enabled

Pass Arch CGO flags, add glibc for the cgo-linked binary, and add openbao to the sv39 blacklist for the UI wasm out-of-memory failure. Upstream reference: golang/go#64875.

From archriscv: https://github.com/felixonmars/archriscv-packages/commit/91a647a59a6cd41b03dd1e09b4749f4299255246