### PR TITLE
updpatch: python-ansible-compat, ver=26.3.0-1

### DIFF
--- a/python-ansible-compat/loong.patch
+++ b/python-ansible-compat/loong.patch
@@ -1,10 +1,13 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index dfa9195..b7bf3c5 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -26,6 +26,7 @@ makedepends=(
-   python-wheel
- )
- checkdepends=(
-+  rust
-   python-pytest
-   python-pytest-mock
- )
+@@ -58,6 +58,8 @@ check() {
+     --deselect test/test_runtime.py::test_require_collection_not_isolated
+     --deselect test/test_runtime.py::test_load_plugins[modules]
+     --deselect test/test_runtime_example.py::test_runtime_example
++    # disable test that downloads rpds-py/maturin from PyPI and builds them from source
++    --deselect test/test_runtime_scan_path.py::test_ro_venv
+   )
+   local _site_packages=$(python -c "import site; print(site.getsitepackages()[0])")
+ 


### PR DESCRIPTION
* disable test that downloads rpds-py/maturin from PyPI and builds them from source