### PR TITLE
addpatch: python-pillow, ver=12.2.0-1

### DIFF
--- a/python-pillow/loong.patch
+++ b/python-pillow/loong.patch
@@ -1,0 +1,17 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 65aeca1..2a5003e 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -55,6 +55,12 @@ b2sums=('8205207450bf0e5a50e82411bdbd4827e0706893ea2999092e689731ed8506bbb1007e9
+ build() {
+   cd "$pkgname"
+ 
++  # Loong64: relax AVIF write test epsilon until upstream fix is released
++  sed -i '/assert_image_similar_tofile/{N;s/"Tests\/images\/avif\/hopper_avif_write.png", 6\.88/"Tests\/images\/avif\/hopper_avif_write.png", 7.0/}' \
++    Tests/test_file_avif.py
++  sed -i 's/assert_image_similar(reloaded, im, 9\.28)/assert_image_similar(reloaded, im, 9.5)/' \
++    Tests/test_file_avif.py
++
+   python -m build --wheel --no-isolation
+ }
+ 


### PR DESCRIPTION
* Increase AVIF test epsilon for loong64
* See also: https://github.com/python-pillow/Pillow/pull/9714