### PR TITLE
addpatch: dagger, ver=0.21.7-1

### DIFF
--- a/dagger/loong.patch
+++ b/dagger/loong.patch
@@ -1,0 +1,13 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 7a218b0..6e73cee 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -44,7 +44,7 @@ build() {
+     -X github.com/dagger/dagger/engine.Version=v$pkgver \
+     -X github.com/dagger/dagger/engine.Tag=v$pkgver" \
+     -o build \
+-    ./cmd/...
++    ./cmd/dagger
+ }
+ 
+ # TODO tests now require docker *kicks docker*


### PR DESCRIPTION
* At upstream v0.21.7 (054f94b2d86c0ac00bef11ac4550816973c4aeef), cmd/engine imports engine/ebpf/filetracer and engine/ebpf/ovltracer, but the generated bpf2go bindings are only committed for x86 and arm64, leaving loong64 without fileopsObjects or ovlinuseObjects.
* The Arch package installs only build/dagger, so restrict the loong64 build target to ./cmd/dagger instead of the full cmd tree.
* Ref: https://github.com/felixonmars/archriscv-packages/pull/5390