### PR TITLE
addpatch: highway, ver=1.4.0-1.1

### DIFF
--- a/highway/loong.patch
+++ b/highway/loong.patch
@@ -1,0 +1,22 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index dd5aa65..63d079e 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -17,6 +17,10 @@ makedepends=(
+ source=("https://github.com/google/highway/archive/${pkgver}/${pkgname}-${pkgver}.tar.gz")
+ sha256sums=('e72241ac9524bb653ae52ced768b508045d4438726a303f10181a38f764a453c')
+ 
++prepare() {
++    patch -d "${pkgname}-${pkgver}" -p1 -i "${srcdir}/loongarch_lsx-shuffletwo-fix.patch"
++}
++
+ build() {
+     cmake -B build -S "${pkgname}-${pkgver}" \
+         -G 'Unix Makefiles' \
+@@ -36,3 +40,6 @@ package() {
+     DESTDIR="$pkgdir" cmake --install build
+     install -D -m644 "${pkgname}-${pkgver}/LICENSE" -t "${pkgdir}/usr/share/licenses/${pkgname}"
+ }
++
++source+=('loongarch_lsx-shuffletwo-fix.patch')
++sha256sums+=('30aab6409c8481deb0edc7e5815af667e943369bbdcfd8f42674e667118ea368')

--- a/highway/loongarch_lsx-shuffletwo-fix.patch
+++ b/highway/loongarch_lsx-shuffletwo-fix.patch
@@ -1,0 +1,20 @@
+--- highway-1.4.0.orig/hwy/ops/loongarch_lsx-inl.h	2026-06-24 05:24:33.321000000 +0000
++++ highway-1.4.0/hwy/ops/loongarch_lsx-inl.h	2026-06-24 05:24:33.393331050 +0000
+@@ -990,7 +990,7 @@
+ }
+ template <typename T, HWY_IF_T_SIZE(T, 2)>
+ HWY_API Vec64<T> ShuffleTwo1230(const Vec64<T> a, const Vec64<T> b) {
+-  const int16_t _data_idx[] = {10, 11, 2, 1};
++  const int16_t _data_idx[] = {8, 11, 2, 1};
+   __m128i shuffle_idx = __lsx_vld(_data_idx, 0);
+   auto t0 = __lsx_vshuf_h(shuffle_idx, a.raw, b.raw);
+   return Vec64<T>{t0};
+@@ -1011,7 +1011,7 @@
+ }
+ template <typename T, HWY_IF_T_SIZE(T, 2)>
+ HWY_API Vec64<T> ShuffleTwo3012(const Vec64<T> a, const Vec64<T> b) {
+-  const int16_t _data_idx[] = {8, 9, 0, 3};
++  const int16_t _data_idx[] = {10, 9, 0, 3};
+   __m128i shuffle_idx = __lsx_vld(_data_idx, 0);
+   return Vec64<T>{__lsx_vshuf_h(shuffle_idx, a.raw, b.raw)};
+ }


### PR DESCRIPTION
* Backport https://github.com/google/highway/pull/3153
* Fix LoadInterleaved3 for Vec64<uint16_t> on LoongArch LSX