### PR TITLE
updpatch: electron42, ver=42.7.1-1

### DIFF
--- a/electron42/loong.patch
+++ b/electron42/loong.patch
@@ -1,8 +1,8 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index 0f322d7..b3f37e1 100644
+index 580b15c..1affad0 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -465,6 +465,9 @@ prepare() {
+@@ -463,6 +463,9 @@ prepare() {
    echo "Putting together electron sources"
    # Generate gclient gn args file and prepare-electron-source-tree.sh
    python makepkg-source-roller.py generate electron/DEPS $pkgname
@@ -12,7 +12,7 @@ index 0f322d7..b3f37e1 100644
    rbash prepare-electron-source-tree.sh "$CARCH"
    mv electron src/electron
  
-@@ -478,12 +481,50 @@ prepare() {
+@@ -476,12 +479,50 @@ prepare() {
      -s src/third_party/skia --header src/skia/ext/skia_commit_hash.h
    src/build/util/lastchange.py \
      -s src/third_party/dawn --revision src/gpu/webgpu/DAWN_VERSION
@@ -65,7 +65,17 @@ index 0f322d7..b3f37e1 100644
    src/electron/script/apply_all_patches.py \
        src/electron/patches/config.json
  
-@@ -546,10 +587,10 @@ prepare() {
+@@ -490,7 +531,8 @@ prepare() {
+ 
+   pushd src
+   pushd electron
+-  yarn install --frozen-lockfile
++  # Skip build scripts for native test addons only needed for the Electron test suite and fail on loong64.
++  yarn install --frozen-lockfile --mode=skip-build
+   popd
+ 
+   echo "Applying local patches..."
+@@ -544,10 +586,10 @@ prepare() {
             third_party/jdk/current/bin \
             third_party/gperf/cipd/bin
  
@@ -80,7 +90,7 @@ index 0f322d7..b3f37e1 100644
  
    # Electron specific fixes
    #  fix: use GTK UI theme for Linux message boxes #52238
-@@ -563,6 +604,19 @@ prepare() {
+@@ -561,6 +603,19 @@ prepare() {
    sed -i 's/OFFICIAL_BUILD/GOOGLE_CHROME_BUILD/' \
      tools/generate_shim_headers/generate_shim_headers.py
  
@@ -100,7 +110,7 @@ index 0f322d7..b3f37e1 100644
    # Remove bundled libraries for which we will use the system copies; this
    # *should* do what the remove_bundled_libraries.py script does, with the
    # added benefit of not having to list all the remaining libraries
-@@ -681,6 +735,14 @@ build() {
+@@ -679,6 +734,14 @@ build() {
      CXXFLAGS="${CXXFLAGS/-march=*([^ ]) }"
    fi
  
@@ -115,7 +125,7 @@ index 0f322d7..b3f37e1 100644
    export CHROMIUM_BUILDTOOLS_PATH="${PWD}/buildtools"
    gn gen out/Release \
        --args="import(\"//electron/build/args/release.gn\") ${_flags[*]}"
-@@ -705,3 +767,11 @@ package() {
+@@ -703,3 +766,11 @@ package() {
    install -Dm644 src/electron/default_app/icon.png \
            "${pkgdir}/usr/share/pixmaps/${pkgname}.png"  # hicolor has no 1024x1024
  }


### PR DESCRIPTION
* Skip build scripts for native test addons only needed for the Electron test suite and fail on loong64.