### PR TITLE
updpatch: highway, ver=1.4.0-1.2

### DIFF
--- a/highway/loong.patch
+++ b/highway/loong.patch
@@ -1,8 +1,8 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index dd5aa65..63d079e 100644
+index dd5aa65..32678f6 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -17,6 +17,10 @@ makedepends=(
+@@ -17,7 +17,12 @@ makedepends=(
  source=("https://github.com/google/highway/archive/${pkgver}/${pkgname}-${pkgver}.tar.gz")
  sha256sums=('e72241ac9524bb653ae52ced768b508045d4438726a303f10181a38f764a453c')
  
@@ -11,12 +11,15 @@ index dd5aa65..63d079e 100644
 +}
 +
  build() {
++    export CC=clang CXX=clang++ LDFLAGS="${LDFLAGS} -fuse-ld=lld"
      cmake -B build -S "${pkgname}-${pkgver}" \
          -G 'Unix Makefiles' \
-@@ -36,3 +40,6 @@ package() {
+         -DCMAKE_BUILD_TYPE:STRING='None' \
+@@ -36,3 +41,7 @@ package() {
      DESTDIR="$pkgdir" cmake --install build
      install -D -m644 "${pkgname}-${pkgver}/LICENSE" -t "${pkgdir}/usr/share/licenses/${pkgname}"
  }
 +
 +source+=('loongarch_lsx-shuffletwo-fix.patch')
 +sha256sums+=('30aab6409c8481deb0edc7e5815af667e943369bbdcfd8f42674e667118ea368')
++makedepends+=(clang lld)


### PR DESCRIPTION
* Switch to clang to truly enable dynamic function runtime dispatch on loongarch64