### PR TITLE
updpatch: apko, ver=1.2.31-1

### DIFF
--- a/apko/loong.patch
+++ b/apko/loong.patch
@@ -1,5 +1,5 @@
 diff --git a/PKGBUILD b/PKGBUILD
-index b068004..3542e9a 100644
+index 70563b6..49ac340 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
 @@ -41,7 +41,7 @@ build() {
@@ -7,7 +7,7 @@ index b068004..3542e9a 100644
    cd "${pkgname}-${pkgver}"
    # skip TestPublish: https://github.com/chainguard-dev/apko/issues/881
 -  go test ./... -skip 'TestPublish|TestBuild'
-+  go test ./... -skip 'TestPublish|TestBuild|TestTarFS|TestAuth_good' # No loong64 depnedency
++  go test ./... -skip 'TestPublish|TestBuild|TestTarFS|TestAuth_good|TestLdsoCache' # No loong64 depnedency
  }
  
  package() {


### PR DESCRIPTION
* Skip unsupported test on loong64