### PR TITLE
addpatch: uv, ver=0.12.5-1

### DIFF
--- a/uv/loong.patch
+++ b/uv/loong.patch
@@ -1,0 +1,20 @@
+diff --git a/PKGBUILD b/PKGBUILD
+index 442b221..1aeb4ca 100644
+--- a/PKGBUILD
++++ b/PKGBUILD
+@@ -42,6 +42,7 @@ _srcenv() {
+ 
+ prepare() {
+   _srcenv
++  patch -Np1 -i "$srcdir/loongarch64-fiemap.patch"
+   cargo fetch --locked --target host-tuple
+   mkdir -p completions
+ }
+@@ -127,4 +128,7 @@ package_python-uv-build() {
+   python -m installer -d "$pkgdir" target/wheels/uv_build-$pkgver-*.whl
+ }
+ 
++source+=('loongarch64-fiemap.patch')
++sha256sums+=('a3045ff89b47ff818ab14141d94c0a0af5e12d4649def23665ecb0873e2d81b1')
++
+ # vim: ts=2 sw=2 et:

--- a/uv/loongarch64-fiemap.patch
+++ b/uv/loongarch64-fiemap.patch
@@ -1,0 +1,33 @@
+--- a/crates/uv-fs/src/space.rs
++++ b/crates/uv-fs/src/space.rs
+@@ -9,10 +9,29 @@
+ use std::os::unix::fs::MetadataExt;
+ 
+ #[cfg(target_os = "linux")]
++use linux_raw_sys::ioctl::FS_IOC_FIEMAP;
++#[cfg(all(target_os = "linux", not(target_arch = "loongarch64")))]
+ use linux_raw_sys::ioctl::{
+     FIEMAP_EXTENT_DATA_INLINE, FIEMAP_EXTENT_DELALLOC, FIEMAP_EXTENT_ENCODED, FIEMAP_EXTENT_LAST,
+-    FIEMAP_EXTENT_NOT_ALIGNED, FIEMAP_EXTENT_SHARED, FIEMAP_EXTENT_UNKNOWN, FS_IOC_FIEMAP,
++    FIEMAP_EXTENT_NOT_ALIGNED, FIEMAP_EXTENT_SHARED, FIEMAP_EXTENT_UNKNOWN,
+ };
++// linux-raw-sys 0.12.1 does not generate the FIEMAP extent flags in its
++// loongarch64 bindings; they are arch-independent UAPI constants
++// (linux/uapi/linux/fiemap.h), so define them locally.
++#[cfg(all(target_os = "linux", target_arch = "loongarch64"))]
++const FIEMAP_EXTENT_LAST: u32 = 0x1;
++#[cfg(all(target_os = "linux", target_arch = "loongarch64"))]
++const FIEMAP_EXTENT_UNKNOWN: u32 = 0x2;
++#[cfg(all(target_os = "linux", target_arch = "loongarch64"))]
++const FIEMAP_EXTENT_DELALLOC: u32 = 0x4;
++#[cfg(all(target_os = "linux", target_arch = "loongarch64"))]
++const FIEMAP_EXTENT_ENCODED: u32 = 0x8;
++#[cfg(all(target_os = "linux", target_arch = "loongarch64"))]
++const FIEMAP_EXTENT_NOT_ALIGNED: u32 = 0x100;
++#[cfg(all(target_os = "linux", target_arch = "loongarch64"))]
++const FIEMAP_EXTENT_DATA_INLINE: u32 = 0x200;
++#[cfg(all(target_os = "linux", target_arch = "loongarch64"))]
++const FIEMAP_EXTENT_SHARED: u32 = 0x2000;
+ #[cfg(any(target_os = "linux", target_os = "macos", target_os = "ios"))]
+ use rustix::io::Errno;
+ use thiserror::Error;


### PR DESCRIPTION
* linux-raw-sys 0.12.1 does not generate the FIEMAP extent flags in its loongarch64 bindings
* define them locally
* see also: https://github.com/sunfishcode/linux-raw-sys/pull/195