### PR TITLE
updpkg: archlinux-lcpu-keyring, ver=20260906-1

### DIFF
--- a/archlinux-lcpu-keyring/PKGBUILD
+++ b/archlinux-lcpu-keyring/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Zhou Qiankang <wszqkzqk@qq.com>
 
 pkgname='archlinux-lcpu-keyring'
-pkgver=20241126
+pkgver=20260906
 pkgrel=1
 pkgdesc="Arch Linux group of LCPU's PGP keyring"
 arch=('any')


### PR DESCRIPTION
* Fetch new keyring from kry servers