### PR TITLE
updpatch: qemu, ver=11.1.1-1

### DIFF
--- a/qemu/loong.patch
+++ b/qemu/loong.patch
@@ -1,8 +1,6 @@
-diff --git a/PKGBUILD b/PKGBUILD
-index 1b7295c..a32237b 100644
 --- a/PKGBUILD
 +++ b/PKGBUILD
-@@ -10,7 +10,7 @@ pkgname=(
+@@ -10,7 +10,7 @@
    qemu-chardev-{baum,spice}
    qemu-docs
    qemu-guest-agent
@@ -11,7 +9,7 @@ index 1b7295c..a32237b 100644
    qemu-hw-s390x-virtio-gpu-ccw
    qemu-hw-uefi-vars
    qemu-hw-usb-{host,redirect,smartcard}
-@@ -112,7 +112,6 @@ makedepends=(
+@@ -111,7 +111,6 @@
    python-sphinx
    python-sphinx_rtd_theme
    rdma-core
@@ -19,7 +17,7 @@ index 1b7295c..a32237b 100644
    sdl2
    sdl2_image
    snappy
-@@ -241,13 +240,10 @@ _qemu_base_optdepends=(
+@@ -234,13 +233,10 @@
    'qemu-hw-display-qxl: for the QXL display device'
    'qemu-hw-display-virtio-vga: for the virtio-vga display device'
    'qemu-hw-display-virtio-vga-gl: for the virtio-vga-gl display device'
@@ -33,7 +31,17 @@ index 1b7295c..a32237b 100644
    'qemu-hw-uefi-vars: for UEFI variable support'
    'qemu-hw-usb-host: for host USB support'
    'qemu-hw-usb-redirect: for USB redirect support'
-@@ -317,7 +313,6 @@ build() {
+@@ -275,6 +271,9 @@
+ }
+ 
+ prepare() {
++  # Recognize LSX/LASX stores when handling translated-code write faults.
++  patch -Np1 -d $pkgbase-$pkgver -i ../loongarch-vector-store-signals.patch
++
+   # extract licenses for TCG
+   sed -n '1,23p' $pkgbase-$pkgver/tcg/tcg-internal.h > tcg.LICENSE.MIT.txt
+   sed -n '1,23p' $pkgbase-$pkgver/tcg/tci/tcg-target.h > tci.LICENSE.MIT.txt
+@@ -307,7 +306,6 @@
      --enable-sdl
      --enable-slirp
      --enable-tpm
@@ -41,7 +49,7 @@ index 1b7295c..a32237b 100644
      --smbd=/usr/bin/smbd
      --with-coroutine=ucontext
    )
-@@ -409,10 +404,8 @@ package_qemu-common() {
+@@ -398,10 +396,8 @@
    done
    # modify and rename binfmt.d configs to prevent name conflicts
    for _conf in "$pkgdir/usr/lib/binfmt.d/"*; do
@@ -53,7 +61,7 @@ index 1b7295c..a32237b 100644
    done
  
    # install default binaries
-@@ -478,13 +471,10 @@ package_qemu-common() {
+@@ -466,13 +462,10 @@
      _pick qemu-hw-display-qxl usr/lib/qemu/hw-display-qxl.so
      _pick qemu-hw-display-virtio-gpu usr/lib/qemu/hw-display-virtio-gpu.so
      _pick qemu-hw-display-virtio-gpu-gl usr/lib/qemu/hw-display-virtio-gpu-gl.so
@@ -67,7 +75,7 @@ index 1b7295c..a32237b 100644
  
      _pick qemu-hw-usb-host usr/lib/qemu/hw-usb-host.so
      _pick qemu-hw-usb-redirect usr/lib/qemu/hw-usb-redirect.so
-@@ -899,7 +889,7 @@ package_qemu-system-hppa-firmware() {
+@@ -890,7 +883,7 @@
  
  package_qemu-system-loongarch64() {
    pkgdesc="QEMU system emulator for LoongArch64"
@@ -76,7 +84,7 @@ index 1b7295c..a32237b 100644
    mv -v $pkgname/* "$pkgdir"
    _install_licenses
  }
-@@ -1223,7 +1213,7 @@ package_qemu-base() {
+@@ -1215,7 +1208,7 @@
    depends=(
      qemu-common=$pkgver-$pkgrel
      qemu-img=$pkgver-$pkgrel
@@ -85,7 +93,7 @@ index 1b7295c..a32237b 100644
      virtiofsd
    )
    optdepends=("${_qemu_base_optdepends[@]}")
-@@ -1239,8 +1229,8 @@ package_qemu-desktop() {
+@@ -1231,8 +1224,8 @@
      qemu-audio-{alsa,dbus,jack,oss,pa,pipewire,sdl,spice}=$pkgver-$pkgrel
      qemu-block-{curl,dmg,nfs,ssh}=$pkgver-$pkgrel
      qemu-chardev-spice=$pkgver-$pkgrel
@@ -96,10 +104,14 @@ index 1b7295c..a32237b 100644
      qemu-hw-uefi-vars=$pkgver-$pkgrel
      qemu-hw-usb-{host,redirect,smartcard}=$pkgver-$pkgrel
      qemu-ui-{curses,dbus,egl-headless,gtk,opengl,sdl,spice-{app,core}}=$pkgver-$pkgrel
-@@ -1282,4 +1272,6 @@ package_qemu-full() {
+@@ -1274,4 +1267,10 @@
    _install_licenses
  }
  
 +_qemu_desktop_optdepends+=("qemu-system-x86: for x86 system emulator")
 +pkgname=(${pkgname[@]/qemu-vmsr-helper})
  # vim:set ts=2 sw=2 et:
++
++source+=(loongarch-vector-store-signals.patch)
++sha512sums+=('85eadcbc57c54b23b78a115483ee956ee928d04c2e0ce802e48ea6420ed39188493612cf3264c0029bd8ed9dbcc8c9d6e5cb057273ebf2dec2917d21b3b80a36')
++b2sums+=('b62a6cf7b83926ef63f32c56d5bb65977f0e69da51999bd5d642369bbe9e3929e5f2dacc1d8d9b874ec1ab27b972e91238f4b953f0cf45b8893ce9e57494b750')

--- a/qemu/loongarch-vector-store-signals.patch
+++ b/qemu/loongarch-vector-store-signals.patch
@@ -1,0 +1,22 @@
+--- a/linux-user/include/host/loongarch64/host-signal.h
++++ b/linux-user/include/host/loongarch64/host-signal.h
+@@ -61,6 +61,10 @@
+             return true;
+         }
+         break;
++    case 0b001011: /* v{ld,st}, xv{ld,st} */
++        return (insn >> 22) & 1;
++    case 0b001100: /* v{ldrepl,stelm}, xv{ldrepl,stelm} */
++        return (insn >> 24) & 1;
+     case 0b001110: /* indexed, atomic, bounds-checking memory operations */
+         switch ((insn >> 15) & 0b11111111111) {
+         case 0b00000100000: /* stx.b */
+@@ -69,6 +73,8 @@
+         case 0b00000111000: /* stx.d */
+         case 0b00001110000: /* fstx.s */
+         case 0b00001111000: /* fstx.d */
++        case 0b00010001000: /* vstx */
++        case 0b00010011000: /* xvstx */
+         case 0b00011101100: /* fstgt.s */
+         case 0b00011101101: /* fstgt.d */
+         case 0b00011101110: /* fstle.s */


### PR DESCRIPTION
* Recognize LSX/LASX stores in the LoongArch host signal handler to fix internal QEMU crashes when RISC-V vector stores hit write-protected code pages through host memcpy.